### PR TITLE
don't use mangled symbol names in startup log

### DIFF
--- a/src/datadog/collector.h
+++ b/src/datadog/collector.h
@@ -37,8 +37,8 @@ class Collector {
   // object's configuration. The JSON representation is an object with
   // the following properties:
   //
-  // - "type" is the unmangled, unqualified name of the most-derived class, e.g.
-  //   "DatadogAgent".
+  // - "type" is the unmangled, qualified name of the most-derived class, e.g.
+  //   "datadog::tracing::DatadogAgent".
   // - "config" is an object containing this object's configuration. "config"
   //   may be omitted if the derived class has no configuration.
   virtual void config_json(nlohmann::json& destination) const = 0;

--- a/src/datadog/collector.h
+++ b/src/datadog/collector.h
@@ -33,15 +33,14 @@ class Collector {
       std::vector<std::unique_ptr<SpanData>>&& spans,
       const std::shared_ptr<TraceSampler>& response_handler) = 0;
 
-  // Assign to the specified `destination` a JSON representation of this
-  // object's configuration. The JSON representation is an object with
-  // the following properties:
+  // Return a JSON representation of this object's configuration. The JSON
+  // representation is an object with the following properties:
   //
   // - "type" is the unmangled, qualified name of the most-derived class, e.g.
   //   "datadog::tracing::DatadogAgent".
   // - "config" is an object containing this object's configuration. "config"
   //   may be omitted if the derived class has no configuration.
-  virtual void config_json(nlohmann::json& destination) const = 0;
+  virtual nlohmann::json config_json() const = 0;
 
   virtual ~Collector() {}
 };

--- a/src/datadog/curl.cpp
+++ b/src/datadog/curl.cpp
@@ -19,6 +19,7 @@
 #include "dict_reader.h"
 #include "dict_writer.h"
 #include "http_client.h"
+#include "json.hpp"
 #include "logger.h"
 #include "parse_util.h"
 
@@ -123,6 +124,10 @@ Expected<void> Curl::post(const URL &url, HeadersSetter set_headers,
 
 void Curl::drain(std::chrono::steady_clock::time_point deadline) {
   impl_->drain(deadline);
+}
+
+void Curl::config_json(nlohmann::json &destination) const {
+  destination = nlohmann::json::object({{"type", "datadog::tracing::Curl"}});
 }
 
 CurlImpl::CurlImpl(const std::shared_ptr<Logger> &logger)

--- a/src/datadog/curl.cpp
+++ b/src/datadog/curl.cpp
@@ -126,8 +126,8 @@ void Curl::drain(std::chrono::steady_clock::time_point deadline) {
   impl_->drain(deadline);
 }
 
-void Curl::config_json(nlohmann::json &destination) const {
-  destination = nlohmann::json::object({{"type", "datadog::tracing::Curl"}});
+nlohmann::json Curl::config_json() const {
+  return nlohmann::json::object({{"type", "datadog::tracing::Curl"}});
 }
 
 CurlImpl::CurlImpl(const std::shared_ptr<Logger> &logger)

--- a/src/datadog/curl.h
+++ b/src/datadog/curl.h
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "http_client.h"
+#include "json_fwd.hpp"
 
 namespace datadog {
 namespace tracing {
@@ -35,6 +36,8 @@ class Curl : public HTTPClient {
                       ErrorHandler on_error) override;
 
   void drain(std::chrono::steady_clock::time_point deadline) override;
+
+  void config_json(nlohmann::json& destination) const override;
 };
 
 }  // namespace tracing

--- a/src/datadog/curl.h
+++ b/src/datadog/curl.h
@@ -37,7 +37,7 @@ class Curl : public HTTPClient {
 
   void drain(std::chrono::steady_clock::time_point deadline) override;
 
-  void config_json(nlohmann::json& destination) const override;
+  nlohmann::json config_json() const override;
 };
 
 }  // namespace tracing

--- a/src/datadog/datadog_agent.cpp
+++ b/src/datadog/datadog_agent.cpp
@@ -164,23 +164,20 @@ Expected<void> DatadogAgent::send(
   return std::nullopt;
 }
 
-void DatadogAgent::config_json(nlohmann::json& destination) const {
+nlohmann::json DatadogAgent::config_json() const {
   const auto& url = traces_endpoint_;  // brevity
   const auto flush_interval_milliseconds =
       std::chrono::duration_cast<std::chrono::milliseconds>(flush_interval_)
           .count();
-  nlohmann::json http_client_json, event_scheduler_json;
-  http_client_->config_json(http_client_json);
-  event_scheduler_->config_json(event_scheduler_json);
 
   // clang-format off
-  destination = nlohmann::json::object({
+  return nlohmann::json::object({
     {"type", "datadog::tracing::DatadogAgent"},
     {"config", nlohmann::json::object({
       {"url", (url.scheme + "://" + url.authority + url.path)},
       {"flush_interval_milliseconds", flush_interval_milliseconds},
-      {"http_client", http_client_json},
-      {"event_scheduler", event_scheduler_json},
+      {"http_client", http_client_->config_json()},
+      {"event_scheduler", event_scheduler_->config_json()},
     })},
   });
   // clang-format on

--- a/src/datadog/datadog_agent.cpp
+++ b/src/datadog/datadog_agent.cpp
@@ -169,15 +169,18 @@ void DatadogAgent::config_json(nlohmann::json& destination) const {
   const auto flush_interval_milliseconds =
       std::chrono::duration_cast<std::chrono::milliseconds>(flush_interval_)
           .count();
+  nlohmann::json http_client_json, event_scheduler_json;
+  http_client_->config_json(http_client_json);
+  event_scheduler_->config_json(event_scheduler_json);
 
   // clang-format off
   destination = nlohmann::json::object({
-    {"type", "DatadogAgent"},
+    {"type", "datadog::tracing::DatadogAgent"},
     {"config", nlohmann::json::object({
       {"url", (url.scheme + "://" + url.authority + url.path)},
       {"flush_interval_milliseconds", flush_interval_milliseconds},
-      {"http_client_typeid", typeid(*http_client_).name()},
-      {"event_scheduler_typeid", typeid(*event_scheduler_).name()},
+      {"http_client", http_client_json},
+      {"event_scheduler", event_scheduler_json},
     })},
   });
   // clang-format on

--- a/src/datadog/datadog_agent.h
+++ b/src/datadog/datadog_agent.h
@@ -55,7 +55,7 @@ class DatadogAgent : public Collector {
       std::vector<std::unique_ptr<SpanData>>&& spans,
       const std::shared_ptr<TraceSampler>& response_handler) override;
 
-  void config_json(nlohmann::json& destination) const override;
+  nlohmann::json config_json() const override;
 };
 
 }  // namespace tracing

--- a/src/datadog/environment.cpp
+++ b/src/datadog/environment.cpp
@@ -19,13 +19,16 @@ std::optional<std::string_view> lookup(Variable variable) {
   return std::string_view{value};
 }
 
-void to_json(nlohmann::json &destination) {
-  destination = nlohmann::json::object({});
+nlohmann::json to_json() {
+  auto result = nlohmann::json::object({});
+
   for (const char *name : variable_names) {
     if (const char *value = std::getenv(name)) {
-      destination[name] = value;
+      result[name] = value;
     }
   }
+
+  return result;
 }
 
 }  // namespace environment

--- a/src/datadog/environment.h
+++ b/src/datadog/environment.h
@@ -72,7 +72,7 @@ std::string_view name(Variable variable);
 // `std::nullptr` if that variable is not set in the environment.
 std::optional<std::string_view> lookup(Variable variable);
 
-void to_json(nlohmann::json& destination);
+nlohmann::json to_json();
 
 }  // namespace environment
 }  // namespace tracing

--- a/src/datadog/event_scheduler.h
+++ b/src/datadog/event_scheduler.h
@@ -30,15 +30,14 @@ class EventScheduler {
       std::chrono::steady_clock::duration interval,
       std::function<void()> callback) = 0;
 
-  // Assign to the specified `destination` a JSON representation of this
-  // object's configuration. The JSON representation is an object with
-  // the following properties:
+  // Return a JSON representation of this object's configuration. The JSON
+  // representation is an object with the following properties:
   //
   // - "type" is the unmangled, qualified name of the most-derived class, e.g.
   //   "datadog::tracing::ThreadedEventScheduler".
   // - "config" is an object containing this object's configuration. "config"
   //   may be omitted if the derived class has no configuration.
-  virtual void config_json(nlohmann::json& destination) const = 0;
+  virtual nlohmann::json config_json() const = 0;
 
   virtual ~EventScheduler() = default;
 };

--- a/src/datadog/event_scheduler.h
+++ b/src/datadog/event_scheduler.h
@@ -13,6 +13,7 @@
 #include <functional>
 
 #include "error.h"
+#include "json_fwd.hpp"
 
 namespace datadog {
 namespace tracing {
@@ -28,6 +29,16 @@ class EventScheduler {
   virtual Cancel schedule_recurring_event(
       std::chrono::steady_clock::duration interval,
       std::function<void()> callback) = 0;
+
+  // Assign to the specified `destination` a JSON representation of this
+  // object's configuration. The JSON representation is an object with
+  // the following properties:
+  //
+  // - "type" is the unmangled, qualified name of the most-derived class, e.g.
+  //   "datadog::tracing::ThreadedEventScheduler".
+  // - "config" is an object containing this object's configuration. "config"
+  //   may be omitted if the derived class has no configuration.
+  virtual void config_json(nlohmann::json& destination) const = 0;
 
   virtual ~EventScheduler() = default;
 };

--- a/src/datadog/http_client.h
+++ b/src/datadog/http_client.h
@@ -52,15 +52,14 @@ class HTTPClient {
   // `deadline`.
   virtual void drain(std::chrono::steady_clock::time_point deadline) = 0;
 
-  // Assign to the specified `destination` a JSON representation of this
-  // object's configuration. The JSON representation is an object with
-  // the following properties:
+  // Return a JSON representation of this object's configuration. The JSON
+  // representation is an object with the following properties:
   //
   // - "type" is the unmangled, qualified name of the most-derived class, e.g.
   //   "datadog::tracing::Curl".
   // - "config" is an object containing this object's configuration. "config"
   //   may be omitted if the derived class has no configuration.
-  virtual void config_json(nlohmann::json& destination) const = 0;
+  virtual nlohmann::json config_json() const = 0;
 
   virtual ~HTTPClient() = default;
 };

--- a/src/datadog/http_client.h
+++ b/src/datadog/http_client.h
@@ -14,6 +14,7 @@
 
 #include "error.h"
 #include "expected.h"
+#include "json_fwd.hpp"
 
 namespace datadog {
 namespace tracing {
@@ -50,6 +51,16 @@ class HTTPClient {
   // Wait until there are no more outstanding requests, or until the specified
   // `deadline`.
   virtual void drain(std::chrono::steady_clock::time_point deadline) = 0;
+
+  // Assign to the specified `destination` a JSON representation of this
+  // object's configuration. The JSON representation is an object with
+  // the following properties:
+  //
+  // - "type" is the unmangled, qualified name of the most-derived class, e.g.
+  //   "datadog::tracing::Curl".
+  // - "config" is an object containing this object's configuration. "config"
+  //   may be omitted if the derived class has no configuration.
+  virtual void config_json(nlohmann::json& destination) const = 0;
 
   virtual ~HTTPClient() = default;
 };

--- a/src/datadog/null_collector.cpp
+++ b/src/datadog/null_collector.cpp
@@ -8,7 +8,7 @@ namespace tracing {
 void NullCollector::config_json(nlohmann::json& destination) const {
   // clang-format off
     destination = nlohmann::json::object({
-        {"type", "NullCollector"},
+        {"type", "datadog::tracing::NullCollector"},
         {"config", nlohmann::json::object({})},
     });
   // clang-format on

--- a/src/datadog/null_collector.cpp
+++ b/src/datadog/null_collector.cpp
@@ -5,9 +5,9 @@
 namespace datadog {
 namespace tracing {
 
-void NullCollector::config_json(nlohmann::json& destination) const {
+nlohmann::json NullCollector::config_json() const {
   // clang-format off
-    destination = nlohmann::json::object({
+    return nlohmann::json::object({
         {"type", "datadog::tracing::NullCollector"},
         {"config", nlohmann::json::object({})},
     });

--- a/src/datadog/null_collector.h
+++ b/src/datadog/null_collector.h
@@ -16,7 +16,7 @@ class NullCollector : public Collector {
     return {};
   }
 
-  void config_json(nlohmann::json& destination) const override;
+  nlohmann::json config_json() const override;
 };
 
 }  // namespace tracing

--- a/src/datadog/propagation_styles.cpp
+++ b/src/datadog/propagation_styles.cpp
@@ -8,7 +8,7 @@
 namespace datadog {
 namespace tracing {
 
-void to_json(nlohmann::json& destination, const PropagationStyles& styles) {
+nlohmann::json to_json(const PropagationStyles& styles) {
   std::vector<std::string> selected_names;
   if (styles.datadog) {
     selected_names.emplace_back("datadog");
@@ -16,7 +16,7 @@ void to_json(nlohmann::json& destination, const PropagationStyles& styles) {
   if (styles.b3) {
     selected_names.emplace_back("B3");
   }
-  destination = selected_names;
+  return selected_names;
 }
 
 }  // namespace tracing

--- a/src/datadog/propagation_styles.h
+++ b/src/datadog/propagation_styles.h
@@ -15,7 +15,7 @@ struct PropagationStyles {
   bool b3 = false;
 };
 
-void to_json(nlohmann::json& destination, const PropagationStyles&);
+nlohmann::json to_json(const PropagationStyles&);
 
 }  // namespace tracing
 }  // namespace datadog

--- a/src/datadog/span_defaults.cpp
+++ b/src/datadog/span_defaults.cpp
@@ -12,10 +12,10 @@ bool operator==(const SpanDefaults& left, const SpanDefaults& right) {
 #undef EQ
 }
 
-void to_json(nlohmann::json& destination, const SpanDefaults& defaults) {
-  destination = nlohmann::json::object({});
+nlohmann::json to_json(const SpanDefaults& defaults) {
+  auto result = nlohmann::json::object({});
 #define TO_JSON(FIELD) \
-  if (!defaults.FIELD.empty()) destination[#FIELD] = defaults.FIELD
+  if (!defaults.FIELD.empty()) result[#FIELD] = defaults.FIELD
   TO_JSON(service);
   TO_JSON(service_type);
   TO_JSON(environment);
@@ -23,6 +23,7 @@ void to_json(nlohmann::json& destination, const SpanDefaults& defaults) {
   TO_JSON(name);
   TO_JSON(tags);
 #undef TO_JSON
+  return result;
 }
 
 }  // namespace tracing

--- a/src/datadog/span_defaults.h
+++ b/src/datadog/span_defaults.h
@@ -21,7 +21,7 @@ struct SpanDefaults {
   std::unordered_map<std::string, std::string> tags;
 };
 
-void to_json(nlohmann::json& destination, const SpanDefaults&);
+nlohmann::json to_json(const SpanDefaults&);
 
 bool operator==(const SpanDefaults&, const SpanDefaults&);
 

--- a/src/datadog/span_matcher.cpp
+++ b/src/datadog/span_matcher.cpp
@@ -19,13 +19,13 @@ bool is_match(std::string_view pattern, std::string_view subject) {
 
 }  // namespace
 
-std::string SpanMatcher::to_json() const {
-  nlohmann::json object;
-  object["service"] = service;
-  object["name"] = name;
-  object["resource"] = resource;
-  object["tags"] = tags;
-  return object.dump();
+nlohmann::json SpanMatcher::to_json() const {
+  return nlohmann::json::object({
+      {"service", service},
+      {"name", name},
+      {"resource", resource},
+      {"tags", tags},
+  });
 }
 
 bool SpanMatcher::match(const SpanData& span) const {

--- a/src/datadog/span_matcher.h
+++ b/src/datadog/span_matcher.h
@@ -29,7 +29,7 @@ struct SpanMatcher {
   std::unordered_map<std::string, std::string> tags;
 
   bool match(const SpanData&) const;
-  std::string to_json() const;
+  nlohmann::json to_json() const;
 
   static Expected<SpanMatcher> from_json(const nlohmann::json&);
 };

--- a/src/datadog/span_sampler.cpp
+++ b/src/datadog/span_sampler.cpp
@@ -66,14 +66,13 @@ SpanSampler::Rule* SpanSampler::match(const SpanData& span) {
   return nullptr;
 }
 
-void SpanSampler::config_json(nlohmann::json& destination) const {
+nlohmann::json SpanSampler::config_json() const {
   std::vector<nlohmann::json> rules;
   for (const auto& rule : rules_) {
-    rules.emplace_back();
-    to_json(rules.back(), rule);
+    rules.push_back(to_json(rule));
   }
 
-  destination = nlohmann::json::object({
+  return nlohmann::json::object({
       {"rules", rules},
   });
 }

--- a/src/datadog/span_sampler.h
+++ b/src/datadog/span_sampler.h
@@ -60,7 +60,7 @@ class SpanSampler {
   // return null if there is no match.
   Rule* match(const SpanData&);
 
-  void config_json(nlohmann::json& destination) const;
+  nlohmann::json config_json() const;
 };
 
 }  // namespace tracing

--- a/src/datadog/span_sampler_config.cpp
+++ b/src/datadog/span_sampler_config.cpp
@@ -213,7 +213,7 @@ Expected<FinalizedSpanSamplerConfig> finalize_config(
       prefix +=
           "Unable to parse sample_rate in span sampling rule with span "
           "pattern ";
-      prefix += rule.to_json();
+      prefix += rule.to_json().dump();
       prefix += ": ";
       return error->with_prefix(prefix);
     }
@@ -226,7 +226,7 @@ Expected<FinalizedSpanSamplerConfig> finalize_config(
              std::end(allowed_types))) {
       std::string message;
       message += "Span sampling rule with pattern ";
-      message += rule.to_json();
+      message += rule.to_json().dump();
       message +=
           " should have a max_per_second value greater than zero, but the "
           "following value was given: ";
@@ -244,9 +244,8 @@ Expected<FinalizedSpanSamplerConfig> finalize_config(
   return result;
 }
 
-void to_json(nlohmann::json &destination,
-             const FinalizedSpanSamplerConfig::Rule &rule) {
-  destination = nlohmann::json::object({
+nlohmann::json to_json(const FinalizedSpanSamplerConfig::Rule &rule) {
+  auto result = nlohmann::json::object({
       {"service", rule.service},
       {"name", rule.name},
       {"resource", rule.resource},
@@ -254,8 +253,10 @@ void to_json(nlohmann::json &destination,
   });
 
   if (rule.max_per_second) {
-    destination["max_per_second"] = *rule.max_per_second;
+    result["max_per_second"] = *rule.max_per_second;
   }
+
+  return result;
 }
 
 }  // namespace tracing

--- a/src/datadog/span_sampler_config.h
+++ b/src/datadog/span_sampler_config.h
@@ -54,8 +54,7 @@ class FinalizedSpanSamplerConfig {
 Expected<FinalizedSpanSamplerConfig> finalize_config(const SpanSamplerConfig&,
                                                      Logger&);
 
-void to_json(nlohmann::json& destination,
-             const FinalizedSpanSamplerConfig::Rule&);
+nlohmann::json to_json(const FinalizedSpanSamplerConfig::Rule&);
 
 }  // namespace tracing
 }  // namespace datadog

--- a/src/datadog/threaded_event_scheduler.cpp
+++ b/src/datadog/threaded_event_scheduler.cpp
@@ -58,8 +58,8 @@ EventScheduler::Cancel ThreadedEventScheduler::schedule_recurring_event(
   };
 }
 
-void ThreadedEventScheduler::config_json(nlohmann::json& destination) const {
-  destination = nlohmann::json::object(
+nlohmann::json ThreadedEventScheduler::config_json() const {
+  return nlohmann::json::object(
       {{"type", "datadog::tracing::ThreadedEventScheduler"}});
 }
 

--- a/src/datadog/threaded_event_scheduler.cpp
+++ b/src/datadog/threaded_event_scheduler.cpp
@@ -2,6 +2,8 @@
 
 #include <thread>
 
+#include "json.hpp"
+
 namespace datadog {
 namespace tracing {
 
@@ -54,6 +56,11 @@ EventScheduler::Cancel ThreadedEventScheduler::schedule_recurring_event(
     });
     config.reset();
   };
+}
+
+void ThreadedEventScheduler::config_json(nlohmann::json& destination) const {
+  destination = nlohmann::json::object(
+      {{"type", "datadog::tracing::ThreadedEventScheduler"}});
 }
 
 void ThreadedEventScheduler::run() {

--- a/src/datadog/threaded_event_scheduler.h
+++ b/src/datadog/threaded_event_scheduler.h
@@ -57,7 +57,7 @@ class ThreadedEventScheduler : public EventScheduler {
   Cancel schedule_recurring_event(std::chrono::steady_clock::duration interval,
                                   std::function<void()> callback) override;
 
-  void config_json(nlohmann::json& destination) const override;
+  nlohmann::json config_json() const override;
 };
 
 }  // namespace tracing

--- a/src/datadog/threaded_event_scheduler.h
+++ b/src/datadog/threaded_event_scheduler.h
@@ -54,9 +54,10 @@ class ThreadedEventScheduler : public EventScheduler {
   ThreadedEventScheduler();
   ~ThreadedEventScheduler();
 
-  virtual Cancel schedule_recurring_event(
-      std::chrono::steady_clock::duration interval,
-      std::function<void()> callback) override;
+  Cancel schedule_recurring_event(std::chrono::steady_clock::duration interval,
+                                  std::function<void()> callback) override;
+
+  void config_json(nlohmann::json& destination) const override;
 };
 
 }  // namespace tracing

--- a/src/datadog/trace_sampler.cpp
+++ b/src/datadog/trace_sampler.cpp
@@ -97,14 +97,13 @@ void TraceSampler::handle_collector_response(
   collector_sample_rates_ = response.sample_rate_by_key;
 }
 
-void TraceSampler::config_json(nlohmann::json& destination) const {
+nlohmann::json TraceSampler::config_json() const {
   std::vector<nlohmann::json> rules;
   for (const auto& rule : rules_) {
-    rules.emplace_back();
-    to_json(rules.back(), rule);
+    rules.push_back(to_json(rule));
   }
 
-  destination = nlohmann::json::object({
+  return nlohmann::json::object({
       {"rules", rules},
       {"max_per_second", limiter_max_per_second_},
   });

--- a/src/datadog/trace_sampler.h
+++ b/src/datadog/trace_sampler.h
@@ -121,7 +121,7 @@ class TraceSampler {
   // collector response.
   void handle_collector_response(const CollectorResponse&);
 
-  void config_json(nlohmann::json& destination) const;
+  nlohmann::json config_json() const;
 };
 
 }  // namespace tracing

--- a/src/datadog/trace_sampler_config.cpp
+++ b/src/datadog/trace_sampler_config.cpp
@@ -1,7 +1,6 @@
 #include "trace_sampler_config.h"
 
 #include <cmath>
-#include <ostream>
 #include <unordered_set>
 
 #include "environment.h"
@@ -116,7 +115,7 @@ Expected<FinalizedTraceSamplerConfig> finalize_config(
       prefix +=
           "Unable to parse sample_rate in trace sampling rule with root span "
           "pattern ";
-      prefix += rule.to_json();
+      prefix += rule.to_json().dump();
       prefix += ": ";
       return error->with_prefix(prefix);
     }
@@ -184,21 +183,13 @@ Expected<FinalizedTraceSamplerConfig> finalize_config(
   return result;
 }
 
-void to_json(nlohmann::json &destination,
-             const FinalizedTraceSamplerConfig::Rule &rule) {
-  destination = nlohmann::json::object({
+nlohmann::json to_json(const FinalizedTraceSamplerConfig::Rule &rule) {
+  return nlohmann::json::object({
       {"service", rule.service},
       {"name", rule.name},
       {"resource", rule.resource},
       {"sample_rate", double(rule.sample_rate)},
   });
-}
-
-std::ostream &operator<<(std::ostream &stream,
-                         const FinalizedTraceSamplerConfig::Rule &rule) {
-  nlohmann::json object;
-  to_json(object, rule);
-  return stream << object.dump();
 }
 
 }  // namespace tracing

--- a/src/datadog/trace_sampler_config.h
+++ b/src/datadog/trace_sampler_config.h
@@ -7,7 +7,6 @@
 // `TraceSamplerConfig` is specified as the `trace_sampler` property of
 // `TracerConfig`.
 
-#include <iosfwd>
 #include <optional>
 #include <vector>
 
@@ -51,11 +50,7 @@ class FinalizedTraceSamplerConfig {
 Expected<FinalizedTraceSamplerConfig> finalize_config(
     const TraceSamplerConfig& config);
 
-std::ostream& operator<<(std::ostream&,
-                         const FinalizedTraceSamplerConfig::Rule&);
-
-void to_json(nlohmann::json& destination,
-             const FinalizedTraceSamplerConfig::Rule&);
+nlohmann::json to_json(const FinalizedTraceSamplerConfig::Rule&);
 
 }  // namespace tracing
 }  // namespace datadog

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -217,28 +217,17 @@ void log_startup_message(Logger& logger, std::string_view tracer_version,
                          const PropagationStyles& extraction_styles,
                          const std::optional<std::string>& hostname,
                          std::size_t tags_header_max_size) {
-  nlohmann::json collector_json, defaults_json, trace_sampler_json,
-      span_sampler_json, injection_json, extraction_json, environment_variables;
-
-  collector.config_json(collector_json);
-  to_json(defaults_json, defaults);
-  trace_sampler.config_json(trace_sampler_json);
-  span_sampler.config_json(span_sampler_json);
-  to_json(injection_json, injection_styles);
-  to_json(extraction_json, extraction_styles);
-  environment::to_json(environment_variables);
-
   // clang-format off
   auto config = nlohmann::json::object({
     {"version", tracer_version},
-    {"defaults", defaults_json},
-    {"collector", collector_json},
-    {"trace_sampler", trace_sampler_json},
-    {"span_sampler", span_sampler_json},
-    {"injection_styles", injection_json},
-    {"extraction_styles", extraction_json},
+    {"defaults", to_json(defaults)},
+    {"collector", collector.config_json()},
+    {"trace_sampler", trace_sampler.config_json()},
+    {"span_sampler", span_sampler.config_json()},
+    {"injection_styles", to_json(injection_styles)},
+    {"extraction_styles", to_json(extraction_styles)},
     {"tags_header_size", tags_header_max_size},
-    {"environment_variables", environment_variables},
+    {"environment_variables", environment::to_json()},
   });
   // clang-format on
 

--- a/test/mocks/collectors.cpp
+++ b/test/mocks/collectors.cpp
@@ -2,9 +2,9 @@
 
 #include <datadog/json.hpp>
 
-#define DEFINE_CONFIG_JSON_METHOD(TYPE)                       \
-  void TYPE::config_json(nlohmann::json& destination) const { \
-    destination = nlohmann::json::object({{"type", #TYPE}});  \
+#define DEFINE_CONFIG_JSON_METHOD(TYPE)               \
+  nlohmann::json TYPE::config_json() const {          \
+    return nlohmann::json::object({{"type", #TYPE}}); \
   }
 
 DEFINE_CONFIG_JSON_METHOD(MockCollector)

--- a/test/mocks/collectors.h
+++ b/test/mocks/collectors.h
@@ -27,7 +27,7 @@ struct MockCollector : public Collector {
     return {};
   }
 
-  void config_json(nlohmann::json& destination) const override;
+  nlohmann::json config_json() const override;
 
   SpanData& first_span() const {
     REQUIRE(chunks.size() >= 1);
@@ -57,7 +57,7 @@ struct MockCollectorWithResponse : public MockCollector {
     return {};
   }
 
-  void config_json(nlohmann::json& destination) const override;
+  nlohmann::json config_json() const override;
 };
 
 struct PriorityCountingCollector : public Collector {
@@ -72,7 +72,7 @@ struct PriorityCountingCollector : public Collector {
     return {};
   }
 
-  void config_json(nlohmann::json& destination) const override;
+  nlohmann::json config_json() const override;
 
   const SpanData& root_span(
       const std::vector<std::unique_ptr<SpanData>>& spans) {
@@ -134,7 +134,7 @@ struct PriorityCountingCollectorWithResponse
     return {};
   }
 
-  void config_json(nlohmann::json& destination) const override;
+  nlohmann::json config_json() const override;
 };
 
 struct FailureCollector : public Collector {
@@ -145,5 +145,5 @@ struct FailureCollector : public Collector {
     return failure;
   }
 
-  void config_json(nlohmann::json& destination) const override;
+  nlohmann::json config_json() const override;
 };

--- a/test/mocks/event_schedulers.h
+++ b/test/mocks/event_schedulers.h
@@ -21,7 +21,7 @@ struct MockEventScheduler : public EventScheduler {
     return [this]() { cancelled = true; };
   }
 
-  void config_json(nlohmann::json& destination) const override {
-    destination = nlohmann::json::object({{"type", "MockEventScheduler"}});
+  nlohmann::json config_json() const override {
+    return nlohmann::json::object({{"type", "MockEventScheduler"}});
   }
 };

--- a/test/mocks/event_schedulers.h
+++ b/test/mocks/event_schedulers.h
@@ -3,6 +3,7 @@
 #include <datadog/event_scheduler.h>
 
 #include <chrono>
+#include <datadog/json.hpp>
 #include <functional>
 #include <optional>
 
@@ -18,5 +19,9 @@ struct MockEventScheduler : public EventScheduler {
     event_callback = callback;
     recurrence_interval = interval;
     return [this]() { cancelled = true; };
+  }
+
+  void config_json(nlohmann::json& destination) const override {
+    destination = nlohmann::json::object({{"type", "MockEventScheduler"}});
   }
 };

--- a/test/mocks/http_clients.h
+++ b/test/mocks/http_clients.h
@@ -3,6 +3,7 @@
 #include <datadog/error.h>
 #include <datadog/http_client.h>
 
+#include <datadog/json.hpp>
 #include <mutex>
 #include <optional>
 #include <sstream>
@@ -58,5 +59,9 @@ struct MockHTTPClient : public HTTPClient {
       MockDictReader reader{response_headers};
       on_response_(response_status, reader, response_body.str());
     }
+  }
+
+  void config_json(nlohmann::json& destination) const override {
+    destination = nlohmann::json::object({{"type", "MockHTTPClient"}});
   }
 };

--- a/test/mocks/http_clients.h
+++ b/test/mocks/http_clients.h
@@ -61,7 +61,7 @@ struct MockHTTPClient : public HTTPClient {
     }
   }
 
-  void config_json(nlohmann::json& destination) const override {
-    destination = nlohmann::json::object({{"type", "MockHTTPClient"}});
+  nlohmann::json config_json() const override {
+    return nlohmann::json::object({{"type", "MockHTTPClient"}});
   }
 };


### PR DESCRIPTION
Add more `config_json` virtual methods to interfaces that will have two or more implementations.