### PR TITLE
Support conditional use of Abseil's string_view and optional, for Envoy.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,6 +24,7 @@ cc_library(
     "src/datadog/msgpack.cpp",
     "src/datadog/net_util.cpp",
     "src/datadog/null_collector.cpp",
+    "src/datadog/optional.cpp",
     "src/datadog/parse_util.cpp",
     "src/datadog/propagation_styles.cpp",
     "src/datadog/rate.cpp",
@@ -74,6 +75,7 @@ cc_library(
     "src/datadog/msgpack.h",
     "src/datadog/net_util.h",
     "src/datadog/null_collector.h",
+    "src/datadog/optional.h",
     "src/datadog/parse_util.h",
     "src/datadog/propagation_styles.h",
     "src/datadog/rate.h",
@@ -111,5 +113,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:optional",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -38,6 +38,7 @@ cc_library(
     "src/datadog/span_matcher.cpp",
     "src/datadog/span_sampler_config.cpp",
     "src/datadog/span_sampler.cpp",
+    "src/datadog/string_view.cpp",
     "src/datadog/tag_propagation.cpp",
     "src/datadog/tags.cpp",
     "src/datadog/threaded_event_scheduler.cpp",
@@ -87,6 +88,7 @@ cc_library(
     "src/datadog/span_matcher.h",
     "src/datadog/span_sampler_config.h",
     "src/datadog/span_sampler.h",
+    "src/datadog/string_view.h",
     "src/datadog/tag_propagation.h",
     "src/datadog/tags.h",
     "src/datadog/threaded_event_scheduler.h",
@@ -103,7 +105,11 @@ cc_library(
         "-Werror",
         "-pedantic",
         "-std=c++17",
+        "-DDD_USE_ABSEIL_FOR_ENVOY",
     ],
     strip_include_prefix = "src/",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_absl//absl/strings",
+    ],
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ target_sources(dd_trace_cpp PRIVATE
     src/datadog/span_matcher.cpp
     src/datadog/span_sampler_config.cpp
     src/datadog/span_sampler.cpp
+    src/datadog/string_view.cpp
     src/datadog/tag_propagation.cpp
     src/datadog/tags.cpp
     src/datadog/threaded_event_scheduler.cpp
@@ -145,6 +146,7 @@ target_sources(dd_trace_cpp PUBLIC
   src/datadog/span_matcher.h
   src/datadog/span_sampler_config.h
   src/datadog/span_sampler.h
+  src/datadog/string_view.h
   src/datadog/tag_propagation.h
   src/datadog/tags.h
   src/datadog/threaded_event_scheduler.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ target_sources(dd_trace_cpp PRIVATE
     src/datadog/msgpack.cpp
     src/datadog/net_util.cpp
     src/datadog/null_collector.cpp
+    src/datadog/optional.cpp
     src/datadog/parse_util.cpp
     src/datadog/propagation_styles.cpp
     src/datadog/rate.cpp
@@ -132,6 +133,7 @@ target_sources(dd_trace_cpp PUBLIC
   src/datadog/msgpack.h
   src/datadog/net_util.h
   src/datadog/null_collector.h
+  src/datadog/optional.h
   src/datadog/parse_util.h
   src/datadog/propagation_styles.h
   src/datadog/rate.h

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,27 @@
+# The Bazel build is primarily for use by Envoy.
+#
+# Envoy forbids use of std::string_view and std::optional, preferring use of
+# Abseil's absl::string_view and absl::optional instead.
+#
+# In the context of an Envoy build, the Abseil libraries point to whatever
+# versions Envoy uses.
+#
+# To test this library's Bazel build independent of Envoy, we need to specify
+# versions of the Abseil libraries. That is what this file is for.
+
+# These rules are based on <https://abseil.io/docs/cpp/quickstart>,
+# accessed December 6, 2022.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+  name = "com_google_absl",
+  urls = ["https://github.com/abseil/abseil-cpp/archive/98eb410c93ad059f9bba1bf43f5bb916fc92a5ea.zip"],
+  sha256 = "aabf6c57e3834f8dc3873a927f37eaf69975d4b28117fc7427dfb1c661542a87",
+  strip_prefix = "abseil-cpp-98eb410c93ad059f9bba1bf43f5bb916fc92a5ea",
+)
+
+http_archive(
+  name = "bazel_skylib",
+  urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
+  sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+)

--- a/src/datadog/collector.h
+++ b/src/datadog/collector.h
@@ -11,11 +11,11 @@
 // `response_handler` parameter to `Collector::send`.
 
 #include <memory>
-#include "optional.h"
 #include <vector>
 
 #include "expected.h"
 #include "json_fwd.hpp"
+#include "optional.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/collector.h
+++ b/src/datadog/collector.h
@@ -11,7 +11,7 @@
 // `response_handler` parameter to `Collector::send`.
 
 #include <memory>
-#include <optional>
+#include "optional.h"
 #include <vector>
 
 #include "expected.h"

--- a/src/datadog/collector_response.cpp
+++ b/src/datadog/collector_response.cpp
@@ -3,8 +3,7 @@
 namespace datadog {
 namespace tracing {
 
-std::string CollectorResponse::key(StringView service,
-                                   StringView environment) {
+std::string CollectorResponse::key(StringView service, StringView environment) {
   std::string result;
   result += "service:";
   result += service;

--- a/src/datadog/collector_response.cpp
+++ b/src/datadog/collector_response.cpp
@@ -3,8 +3,8 @@
 namespace datadog {
 namespace tracing {
 
-std::string CollectorResponse::key(std::string_view service,
-                                   std::string_view environment) {
+std::string CollectorResponse::key(StringView service,
+                                   StringView environment) {
   std::string result;
   result += "service:";
   result += service;

--- a/src/datadog/collector_response.h
+++ b/src/datadog/collector_response.h
@@ -14,7 +14,7 @@
 // information.
 
 #include <string>
-#include <string_view>
+#include "string_view.h"
 #include <unordered_map>
 
 #include "rate.h"
@@ -23,8 +23,8 @@ namespace datadog {
 namespace tracing {
 
 struct CollectorResponse {
-  static std::string key(std::string_view service,
-                         std::string_view environment);
+  static std::string key(StringView service,
+                         StringView environment);
   static const std::string key_of_default_rate;
   std::unordered_map<std::string, Rate> sample_rate_by_key;
 };

--- a/src/datadog/collector_response.h
+++ b/src/datadog/collector_response.h
@@ -14,17 +14,16 @@
 // information.
 
 #include <string>
-#include "string_view.h"
 #include <unordered_map>
 
 #include "rate.h"
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {
 
 struct CollectorResponse {
-  static std::string key(StringView service,
-                         StringView environment);
+  static std::string key(StringView service, StringView environment);
   static const std::string key_of_default_rate;
   std::unordered_map<std::string, Rate> sample_rate_by_key;
 };

--- a/src/datadog/curl.cpp
+++ b/src/datadog/curl.cpp
@@ -71,7 +71,7 @@ class CurlImpl {
    public:
     explicit HeaderReader(
         std::unordered_map<std::string, std::string> *response_headers_lower);
-    std::optional<StringView> lookup(StringView key) const override;
+    Optional<StringView> lookup(StringView key) const override;
     void visit(const std::function<void(StringView key, StringView value)>
                    &visitor) const override;
   };
@@ -438,7 +438,7 @@ CurlImpl::HeaderReader::HeaderReader(
     std::unordered_map<std::string, std::string> *response_headers_lower)
     : response_headers_lower_(response_headers_lower) {}
 
-std::optional<StringView> CurlImpl::HeaderReader::lookup(StringView key) const {
+Optional<StringView> CurlImpl::HeaderReader::lookup(StringView key) const {
   buffer_.clear();
   std::transform(key.begin(), key.end(), std::back_inserter(buffer_),
                  &to_lower);

--- a/src/datadog/curl.cpp
+++ b/src/datadog/curl.cpp
@@ -11,7 +11,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
-#include <string_view>
+#include "string_view.h"
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -61,7 +61,7 @@ class CurlImpl {
    public:
     ~HeaderWriter();
     curl_slist *release();
-    void set(std::string_view key, std::string_view value) override;
+    void set(StringView key, StringView value) override;
   };
 
   class HeaderReader : public DictReader {
@@ -71,9 +71,9 @@ class CurlImpl {
    public:
     explicit HeaderReader(
         std::unordered_map<std::string, std::string> *response_headers_lower);
-    std::optional<std::string_view> lookup(std::string_view key) const override;
+    std::optional<StringView> lookup(StringView key) const override;
     void visit(
-        const std::function<void(std::string_view key, std::string_view value)>
+        const std::function<void(StringView key, StringView value)>
             &visitor) const override;
   };
 
@@ -88,7 +88,7 @@ class CurlImpl {
                                   void *user_data);
   static bool is_non_whitespace(unsigned char);
   static char to_lower(unsigned char);
-  static std::string_view trim(std::string_view);
+  static StringView trim(StringView);
 
  public:
   explicit CurlImpl(const std::shared_ptr<Logger> &logger);
@@ -426,7 +426,7 @@ curl_slist *CurlImpl::HeaderWriter::release() {
   return list;
 }
 
-void CurlImpl::HeaderWriter::set(std::string_view key, std::string_view value) {
+void CurlImpl::HeaderWriter::set(StringView key, StringView value) {
   buffer_.clear();
   buffer_ += key;
   buffer_ += ": ";
@@ -439,8 +439,8 @@ CurlImpl::HeaderReader::HeaderReader(
     std::unordered_map<std::string, std::string> *response_headers_lower)
     : response_headers_lower_(response_headers_lower) {}
 
-std::optional<std::string_view> CurlImpl::HeaderReader::lookup(
-    std::string_view key) const {
+std::optional<StringView> CurlImpl::HeaderReader::lookup(
+    StringView key) const {
   buffer_.clear();
   std::transform(key.begin(), key.end(), std::back_inserter(buffer_),
                  &to_lower);
@@ -453,7 +453,7 @@ std::optional<std::string_view> CurlImpl::HeaderReader::lookup(
 }
 
 void CurlImpl::HeaderReader::visit(
-    const std::function<void(std::string_view key, std::string_view value)>
+    const std::function<void(StringView key, StringView value)>
         &visitor) const {
   for (const auto &[key, value] : *response_headers_lower_) {
     visitor(key, value);

--- a/src/datadog/curl.cpp
+++ b/src/datadog/curl.cpp
@@ -11,7 +11,6 @@
 #include <list>
 #include <memory>
 #include <mutex>
-#include "string_view.h"
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -22,6 +21,7 @@
 #include "json.hpp"
 #include "logger.h"
 #include "parse_util.h"
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {
@@ -72,9 +72,8 @@ class CurlImpl {
     explicit HeaderReader(
         std::unordered_map<std::string, std::string> *response_headers_lower);
     std::optional<StringView> lookup(StringView key) const override;
-    void visit(
-        const std::function<void(StringView key, StringView value)>
-            &visitor) const override;
+    void visit(const std::function<void(StringView key, StringView value)>
+                   &visitor) const override;
   };
 
   void run();
@@ -439,8 +438,7 @@ CurlImpl::HeaderReader::HeaderReader(
     std::unordered_map<std::string, std::string> *response_headers_lower)
     : response_headers_lower_(response_headers_lower) {}
 
-std::optional<StringView> CurlImpl::HeaderReader::lookup(
-    StringView key) const {
+std::optional<StringView> CurlImpl::HeaderReader::lookup(StringView key) const {
   buffer_.clear();
   std::transform(key.begin(), key.end(), std::back_inserter(buffer_),
                  &to_lower);
@@ -453,8 +451,8 @@ std::optional<StringView> CurlImpl::HeaderReader::lookup(
 }
 
 void CurlImpl::HeaderReader::visit(
-    const std::function<void(StringView key, StringView value)>
-        &visitor) const {
+    const std::function<void(StringView key, StringView value)> &visitor)
+    const {
   for (const auto &[key, value] : *response_headers_lower_) {
     visitor(key, value);
   }

--- a/src/datadog/datadog_agent.cpp
+++ b/src/datadog/datadog_agent.cpp
@@ -21,7 +21,7 @@ namespace datadog {
 namespace tracing {
 namespace {
 
-const std::string_view traces_api_path = "/v0.4/traces";
+const StringView traces_api_path = "/v0.4/traces";
 
 HTTPClient::URL traces_endpoint(const HTTPClient::URL& agent_url) {
   auto traces_url = agent_url;
@@ -49,10 +49,10 @@ Expected<void> msgpack_encode(
 }
 
 std::variant<CollectorResponse, std::string> parse_agent_traces_response(
-    std::string_view body) try {
+    StringView body) try {
   nlohmann::json response = nlohmann::json::parse(body);
 
-  std::string_view type = response.type_name();
+  StringView type = response.type_name();
   if (type != "object") {
     std::string message;
     message +=
@@ -66,7 +66,7 @@ std::variant<CollectorResponse, std::string> parse_agent_traces_response(
     return message;
   }
 
-  const std::string_view sample_rates_property = "rate_by_service";
+  const StringView sample_rates_property = "rate_by_service";
   const auto found = response.find(sample_rates_property);
   if (found == response.end()) {
     return CollectorResponse{};

--- a/src/datadog/datadog_agent_config.cpp
+++ b/src/datadog/datadog_agent_config.cpp
@@ -25,7 +25,7 @@ Expected<HTTPClient::URL> DatadogAgentConfig::parse(StringView input) {
 
   const StringView scheme = range(input.begin(), after_scheme);
   const StringView supported[] = {"http", "https", "unix", "http+unix",
-                                        "https+unix"};
+                                  "https+unix"};
   const auto found =
       std::find(std::begin(supported), std::end(supported), scheme);
   if (found == std::end(supported)) {

--- a/src/datadog/datadog_agent_config.cpp
+++ b/src/datadog/datadog_agent_config.cpp
@@ -11,8 +11,8 @@
 namespace datadog {
 namespace tracing {
 
-Expected<HTTPClient::URL> DatadogAgentConfig::parse(std::string_view input) {
-  const std::string_view separator = "://";
+Expected<HTTPClient::URL> DatadogAgentConfig::parse(StringView input) {
+  const StringView separator = "://";
   const auto after_scheme = std::search(input.begin(), input.end(),
                                         separator.begin(), separator.end());
   if (after_scheme == input.end()) {
@@ -23,8 +23,8 @@ Expected<HTTPClient::URL> DatadogAgentConfig::parse(std::string_view input) {
     return Error{Error::URL_MISSING_SEPARATOR, std::move(message)};
   }
 
-  const std::string_view scheme = range(input.begin(), after_scheme);
-  const std::string_view supported[] = {"http", "https", "unix", "http+unix",
+  const StringView scheme = range(input.begin(), after_scheme);
+  const StringView supported[] = {"http", "https", "unix", "http+unix",
                                         "https+unix"};
   const auto found =
       std::find(std::begin(supported), std::end(supported), scheme);
@@ -42,7 +42,7 @@ Expected<HTTPClient::URL> DatadogAgentConfig::parse(std::string_view input) {
     return Error{Error::URL_UNSUPPORTED_SCHEME, std::move(message)};
   }
 
-  const std::string_view authority_and_path =
+  const StringView authority_and_path =
       range(after_scheme + separator.size(), input.end());
   // If the scheme is for unix domain sockets, then there's no way to
   // distinguish the path-to-socket from the path-to-resource.  Some

--- a/src/datadog/datadog_agent_config.h
+++ b/src/datadog/datadog_agent_config.h
@@ -14,11 +14,11 @@
 #include <chrono>
 #include <memory>
 #include <string>
-#include "string_view.h"
 #include <variant>
 
 #include "expected.h"
 #include "http_client.h"
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/datadog_agent_config.h
+++ b/src/datadog/datadog_agent_config.h
@@ -14,7 +14,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
-#include <string_view>
+#include "string_view.h"
 #include <variant>
 
 #include "expected.h"
@@ -50,7 +50,7 @@ struct DatadogAgentConfig {
   // How often, in milliseconds, to send batches of traces to the Datadog Agent.
   int flush_interval_milliseconds = 2000;
 
-  static Expected<HTTPClient::URL> parse(std::string_view);
+  static Expected<HTTPClient::URL> parse(StringView);
 };
 
 class FinalizedDatadogAgentConfig {

--- a/src/datadog/dict_reader.h
+++ b/src/datadog/dict_reader.h
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <optional>
+
 #include "string_view.h"
 
 namespace datadog {
@@ -17,13 +18,12 @@ class DictReader {
 
   // Return the value at the specified `key`, or return `std::nullopt` if there
   // is no value at `key`.
-  virtual std::optional<StringView> lookup(
-      StringView key) const = 0;
+  virtual std::optional<StringView> lookup(StringView key) const = 0;
 
   // Invoke the specified `visitor` once for each key/value pair in this object.
   virtual void visit(
-      const std::function<void(StringView key, StringView value)>&
-          visitor) const = 0;
+      const std::function<void(StringView key, StringView value)>& visitor)
+      const = 0;
 };
 
 }  // namespace tracing

--- a/src/datadog/dict_reader.h
+++ b/src/datadog/dict_reader.h
@@ -5,7 +5,7 @@
 // context from externalized formats: HTTP headers, gRPC metadata, etc.
 
 #include <functional>
-#include <optional>
+#include "optional.h"
 
 #include "string_view.h"
 
@@ -18,7 +18,7 @@ class DictReader {
 
   // Return the value at the specified `key`, or return `std::nullopt` if there
   // is no value at `key`.
-  virtual std::optional<StringView> lookup(StringView key) const = 0;
+  virtual Optional<StringView> lookup(StringView key) const = 0;
 
   // Invoke the specified `visitor` once for each key/value pair in this object.
   virtual void visit(

--- a/src/datadog/dict_reader.h
+++ b/src/datadog/dict_reader.h
@@ -6,7 +6,7 @@
 
 #include <functional>
 #include <optional>
-#include <string_view>
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {
@@ -17,12 +17,12 @@ class DictReader {
 
   // Return the value at the specified `key`, or return `std::nullopt` if there
   // is no value at `key`.
-  virtual std::optional<std::string_view> lookup(
-      std::string_view key) const = 0;
+  virtual std::optional<StringView> lookup(
+      StringView key) const = 0;
 
   // Invoke the specified `visitor` once for each key/value pair in this object.
   virtual void visit(
-      const std::function<void(std::string_view key, std::string_view value)>&
+      const std::function<void(StringView key, StringView value)>&
           visitor) const = 0;
 };
 

--- a/src/datadog/dict_reader.h
+++ b/src/datadog/dict_reader.h
@@ -5,8 +5,8 @@
 // context from externalized formats: HTTP headers, gRPC metadata, etc.
 
 #include <functional>
-#include "optional.h"
 
+#include "optional.h"
 #include "string_view.h"
 
 namespace datadog {

--- a/src/datadog/dict_writer.h
+++ b/src/datadog/dict_writer.h
@@ -8,7 +8,7 @@
 // permitted to result from repeated invocations of `DictWriter::set` with the
 // same key.
 
-#include <string_view>
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {
@@ -20,7 +20,7 @@ class DictWriter {
   // Associate the specified `value` with the specified `key`.  An
   // implementation may, but is not required to, overwrite any previous value at
   // `key`.
-  virtual void set(std::string_view key, std::string_view value) = 0;
+  virtual void set(StringView key, StringView value) = 0;
 };
 
 }  // namespace tracing

--- a/src/datadog/environment.cpp
+++ b/src/datadog/environment.cpp
@@ -10,7 +10,7 @@ namespace environment {
 
 StringView name(Variable variable) { return variable_names[variable]; }
 
-std::optional<StringView> lookup(Variable variable) {
+Optional<StringView> lookup(Variable variable) {
   const char *name = variable_names[variable];
   const char *value = std::getenv(name);
   if (!value) {

--- a/src/datadog/environment.cpp
+++ b/src/datadog/environment.cpp
@@ -8,15 +8,15 @@ namespace datadog {
 namespace tracing {
 namespace environment {
 
-std::string_view name(Variable variable) { return variable_names[variable]; }
+StringView name(Variable variable) { return variable_names[variable]; }
 
-std::optional<std::string_view> lookup(Variable variable) {
+std::optional<StringView> lookup(Variable variable) {
   const char *name = variable_names[variable];
   const char *value = std::getenv(name);
   if (!value) {
     return std::nullopt;
   }
-  return std::string_view{value};
+  return StringView{value};
 }
 
 nlohmann::json to_json() {

--- a/src/datadog/environment.h
+++ b/src/datadog/environment.h
@@ -14,9 +14,8 @@
 //
 // `lookup` retrieves the value of `Variable` in the environment.
 
-#include "optional.h"
-
 #include "json_fwd.hpp"
+#include "optional.h"
 #include "string_view.h"
 
 namespace datadog {

--- a/src/datadog/environment.h
+++ b/src/datadog/environment.h
@@ -15,9 +15,9 @@
 // `lookup` retrieves the value of `Variable` in the environment.
 
 #include <optional>
-#include "string_view.h"
 
 #include "json_fwd.hpp"
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/environment.h
+++ b/src/datadog/environment.h
@@ -15,7 +15,7 @@
 // `lookup` retrieves the value of `Variable` in the environment.
 
 #include <optional>
-#include <string_view>
+#include "string_view.h"
 
 #include "json_fwd.hpp"
 
@@ -66,11 +66,11 @@ inline const char* const variable_names[] = {
 #undef LIST_ENVIRONMENT_VARIABLES
 
 // Return the name of the specified environment `variable`.
-std::string_view name(Variable variable);
+StringView name(Variable variable);
 
 // Return the value of the specified environment `variable`, or return
 // `std::nullptr` if that variable is not set in the environment.
-std::optional<std::string_view> lookup(Variable variable);
+std::optional<StringView> lookup(Variable variable);
 
 nlohmann::json to_json();
 

--- a/src/datadog/environment.h
+++ b/src/datadog/environment.h
@@ -14,7 +14,7 @@
 //
 // `lookup` retrieves the value of `Variable` in the environment.
 
-#include <optional>
+#include "optional.h"
 
 #include "json_fwd.hpp"
 #include "string_view.h"
@@ -70,7 +70,7 @@ StringView name(Variable variable);
 
 // Return the value of the specified environment `variable`, or return
 // `std::nullptr` if that variable is not set in the environment.
-std::optional<StringView> lookup(Variable variable);
+Optional<StringView> lookup(Variable variable);
 
 nlohmann::json to_json();
 

--- a/src/datadog/error.cpp
+++ b/src/datadog/error.cpp
@@ -10,7 +10,7 @@ std::ostream& operator<<(std::ostream& stream, const Error& error) {
   return stream << "[error code " << int(error.code) << "] " << error.message;
 }
 
-Error Error::with_prefix(std::string_view prefix) const {
+Error Error::with_prefix(StringView prefix) const {
   std::string new_message{prefix.begin(), prefix.end()};
   new_message += message;
   return Error{code, std::move(new_message)};

--- a/src/datadog/error.h
+++ b/src/datadog/error.h
@@ -12,6 +12,7 @@
 
 #include <iosfwd>
 #include <string>
+
 #include "string_view.h"
 
 namespace datadog {

--- a/src/datadog/error.h
+++ b/src/datadog/error.h
@@ -12,7 +12,7 @@
 
 #include <iosfwd>
 #include <string>
-#include <string_view>
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {
@@ -71,7 +71,7 @@ struct Error {
   Code code;
   std::string message;
 
-  Error with_prefix(std::string_view) const;
+  Error with_prefix(StringView) const;
 };
 
 std::ostream& operator<<(std::ostream&, const Error&);

--- a/src/datadog/expected.h
+++ b/src/datadog/expected.h
@@ -35,9 +35,9 @@
 //
 // `Expected<void>` is like `Expected<T>`, except that if the value is not an
 // error then it cannot be "dereferenced" with `operator*`, i.e. it is analogous
-// to `std::optional<Error>` (and is implemented as such).
+// to `Optional<Error>` (and is implemented as such).
 
-#include <optional>
+#include "optional.h"
 #include <variant>
 
 #include "error.h"
@@ -189,7 +189,7 @@ const Error* Expected<Value>::if_error() const& {
 
 template <>
 class Expected<void> {
-  std::optional<Error> data_;
+  Optional<Error> data_;
 
  public:
   Expected() = default;

--- a/src/datadog/expected.h
+++ b/src/datadog/expected.h
@@ -37,10 +37,10 @@
 // error then it cannot be "dereferenced" with `operator*`, i.e. it is analogous
 // to `Optional<Error>` (and is implemented as such).
 
-#include "optional.h"
 #include <variant>
 
 #include "error.h"
+#include "optional.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/expected.h
+++ b/src/datadog/expected.h
@@ -10,7 +10,7 @@
 // -------------
 // The following excerpt demonstrates the intended usage of `Expected<T>`:
 //
-//     Expected<int> parse_integer(std::string_view name);
+//     Expected<int> parse_integer(StringView name);
 //
 //
 //     int main() {

--- a/src/datadog/glob.cpp
+++ b/src/datadog/glob.cpp
@@ -5,7 +5,7 @@
 namespace datadog {
 namespace tracing {
 
-bool glob_match(std::string_view pattern, std::string_view subject) {
+bool glob_match(StringView pattern, StringView subject) {
   // This is a backtracking implementation of the glob matching algorithm.
   // The glob pattern language supports `*` and `?`, but no escape sequences.
   //

--- a/src/datadog/glob.h
+++ b/src/datadog/glob.h
@@ -11,7 +11,7 @@
 // The patterns are here called "glob patterns," though they are different from
 // the patterns used in Unix shells.
 
-#include <string_view>
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {
@@ -19,7 +19,7 @@ namespace tracing {
 // Return whether the specified `subject` matches the specified glob `pattern`,
 // i.e.  whether `subject` is a member of the set of strings represented by the
 // glob `pattern`.
-bool glob_match(std::string_view pattern, std::string_view subject);
+bool glob_match(StringView pattern, StringView subject);
 
 }  // namespace tracing
 }  // namespace datadog

--- a/src/datadog/http_client.h
+++ b/src/datadog/http_client.h
@@ -10,11 +10,11 @@
 
 #include <chrono>
 #include <functional>
-#include "optional.h"
 
 #include "error.h"
 #include "expected.h"
 #include "json_fwd.hpp"
+#include "optional.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/http_client.h
+++ b/src/datadog/http_client.h
@@ -10,7 +10,7 @@
 
 #include <chrono>
 #include <functional>
-#include <optional>
+#include "optional.h"
 
 #include "error.h"
 #include "expected.h"

--- a/src/datadog/logger.cpp
+++ b/src/datadog/logger.cpp
@@ -9,7 +9,7 @@ void Logger::log_error(const Error& error) {
   log_error([&](auto& stream) { stream << error; });
 }
 
-void Logger::log_error(std::string_view message) {
+void Logger::log_error(StringView message) {
   log_error([&](auto& stream) { stream << message; });
 }
 

--- a/src/datadog/logger.h
+++ b/src/datadog/logger.h
@@ -32,7 +32,7 @@
 //       return;
 //     }
 //
-// The other overload accepts a `std::string_view`:
+// The other overload accepts a `StringView`:
 //
 //     if (!success) {
 //       logger.log_error("Something went wrong with the frobnication.");
@@ -41,7 +41,7 @@
 
 #include <functional>
 #include <ostream>
-#include <string_view>
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {
@@ -58,7 +58,7 @@ class Logger {
   virtual void log_startup(const LogFunc&) = 0;
 
   virtual void log_error(const Error&);
-  virtual void log_error(std::string_view);
+  virtual void log_error(StringView);
 };
 
 }  // namespace tracing

--- a/src/datadog/logger.h
+++ b/src/datadog/logger.h
@@ -41,6 +41,7 @@
 
 #include <functional>
 #include <ostream>
+
 #include "string_view.h"
 
 namespace datadog {

--- a/src/datadog/msgpack.cpp
+++ b/src/datadog/msgpack.cpp
@@ -20,7 +20,7 @@ constexpr auto STR32 = std::byte(0xDB);
 constexpr auto UINT64 = std::byte(0xCF);
 }  // namespace types
 
-std::string make_overflow_message(std::string_view type, std::size_t actual,
+std::string make_overflow_message(StringView type, std::size_t actual,
                                   std::size_t max) {
   std::string message;
   message += "Cannot msgpack encode ";
@@ -93,7 +93,7 @@ void pack_double(std::string& buffer, double value) {
   push_number_big_endian(buffer, memory.as_integer);
 }
 
-Expected<void> pack_string(std::string& buffer, std::string_view value) {
+Expected<void> pack_string(std::string& buffer, StringView value) {
   const auto size = value.size();
   const auto max = std::numeric_limits<std::uint32_t>::max();
   if (size > max) {

--- a/src/datadog/msgpack.h
+++ b/src/datadog/msgpack.h
@@ -14,7 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
-#include <string_view>
+#include "string_view.h"
 #include <utility>
 
 #include "expected.h"
@@ -29,7 +29,7 @@ void pack_integer(std::string& buffer, std::int32_t value);
 
 void pack_double(std::string& buffer, double value);
 
-Expected<void> pack_string(std::string& buffer, std::string_view value);
+Expected<void> pack_string(std::string& buffer, StringView value);
 
 Expected<void> pack_array(std::string& buffer, std::size_t size);
 

--- a/src/datadog/msgpack.h
+++ b/src/datadog/msgpack.h
@@ -14,10 +14,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
-#include "string_view.h"
 #include <utility>
 
 #include "expected.h"
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/net_util.cpp
+++ b/src/datadog/net_util.cpp
@@ -9,7 +9,7 @@
 namespace datadog {
 namespace tracing {
 
-std::optional<std::string> get_hostname() {
+Optional<std::string> get_hostname() {
   char buffer[256];
   if (::gethostname(buffer, sizeof buffer)) {
     return std::nullopt;

--- a/src/datadog/net_util.h
+++ b/src/datadog/net_util.h
@@ -2,13 +2,13 @@
 
 // This component provides networking-related miscellanea.
 
-#include <optional>
+#include "optional.h"
 #include <string>
 
 namespace datadog {
 namespace tracing {
 
-std::optional<std::string> get_hostname();
+Optional<std::string> get_hostname();
 
 }  // namespace tracing
 }  // namespace datadog

--- a/src/datadog/net_util.h
+++ b/src/datadog/net_util.h
@@ -2,8 +2,9 @@
 
 // This component provides networking-related miscellanea.
 
-#include "optional.h"
 #include <string>
+
+#include "optional.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/optional.cpp
+++ b/src/datadog/optional.cpp
@@ -1,0 +1,1 @@
+#include "optional.h"

--- a/src/datadog/optional.h
+++ b/src/datadog/optional.h
@@ -1,6 +1,29 @@
 #pragma once
 
-// TODO: explain
+// One of the clients of this library is Envoy, a service (HTTP) proxy.
+//
+// Envoy uses Abseil as its base C++ library, and additionally builds in C++17
+// mode.  Abseil has a build option to forward its `std::string_view` and
+// `std::optional` equivalents to the actual standard types when C++17 is
+// available.
+//
+// Envoy does not use this Abseil build option, due to incomplete support for
+// the C++17 standard library on iOS 11.
+//
+// As a result, Envoy forbids use of `std::string_view` and `std::optional`,
+// instead preferring Abseil's `absl::string_view` and `absl::optional`.
+//
+// This presents a problem for this library, since we use `std::string_view`
+// and `std::optional` in the exported interface, i.e. in header files.
+//
+// As a workaround, Bazel (the build tool used by Envoy) builds of this library
+// will define the `DD_USE_ABSEIL_FOR_ENVOY` preprocessor macro.  When this
+// macro is defined, the library-specific `StringView` and `Optional` aliases
+// will refer to the Abseil types.  When the macro is not defined, the
+// library-specific aliases will refer to the standard types.
+//
+// This file defines `datadog::tracing::Optional`, a type template that is an
+// alias for either `std::optional` or `absl::optional`.
 
 #ifdef DD_USE_ABSEIL_FOR_ENVOY
 // Abseil examples, including usage in Envoy, include Abseil headers in quoted

--- a/src/datadog/optional.h
+++ b/src/datadog/optional.h
@@ -1,0 +1,25 @@
+#pragma once
+
+// TODO: explain
+
+#ifdef DD_USE_ABSEIL_FOR_ENVOY
+// Abseil examples, including usage in Envoy, include Abseil headers in quoted
+// style instead of angle bracket style, per Bazel's default build behavior.
+#include "absl/types/optional.h"
+#else
+#include <optional>
+#endif  // defined DD_USE_ABSEIL_FOR_ENVOY
+
+namespace datadog {
+namespace tracing {
+
+#ifdef DD_USE_ABSEIL_FOR_ENVOY
+template <typename Value>
+using Optional = absl::optional<Value>;
+#else
+template <typename Value>
+using Optional = std::optional<Value>;
+#endif  // defined DD_USE_ABSEIL_FOR_ENVOY
+
+}  // namespace tracing
+}  // namespace datadog

--- a/src/datadog/parse_util.cpp
+++ b/src/datadog/parse_util.cpp
@@ -15,8 +15,8 @@ namespace tracing {
 namespace {
 
 template <typename Integer>
-Expected<Integer> parse_integer(std::string_view input, int base,
-                                std::string_view kind) {
+Expected<Integer> parse_integer(StringView input, int base,
+                                StringView kind) {
   Integer value;
   input = strip(input);
   const auto status = std::from_chars(input.begin(), input.end(), value, base);
@@ -45,7 +45,7 @@ Expected<Integer> parse_integer(std::string_view input, int base,
 
 }  // namespace
 
-std::string_view strip(std::string_view input) {
+StringView strip(StringView input) {
   const auto not_whitespace = [](unsigned char ch) {
     return !std::isspace(ch);
   };
@@ -58,18 +58,18 @@ std::string_view strip(std::string_view input) {
 
   assert(begin <= end);
 
-  return std::string_view{begin, std::size_t(end - begin)};
+  return StringView{begin, std::size_t(end - begin)};
 }
 
-Expected<std::uint64_t> parse_uint64(std::string_view input, int base) {
+Expected<std::uint64_t> parse_uint64(StringView input, int base) {
   return parse_integer<std::uint64_t>(input, base, "64-bit unsigned");
 }
 
-Expected<int> parse_int(std::string_view input, int base) {
+Expected<int> parse_int(StringView input, int base) {
   return parse_integer<int>(input, base, "int");
 }
 
-Expected<double> parse_double(std::string_view input) {
+Expected<double> parse_double(StringView input) {
   // This function uses a different technique from `parse_integer`, because
   // some compilers with _partial_ support for C++17 do not implement the
   // floating point portions of `std::from_chars`:
@@ -100,7 +100,7 @@ Expected<double> parse_double(std::string_view input) {
   return value;
 }
 
-bool starts_with(std::string_view subject, std::string_view prefix) {
+bool starts_with(StringView subject, StringView prefix) {
   if (prefix.size() > subject.size()) {
     return false;
   }

--- a/src/datadog/parse_util.cpp
+++ b/src/datadog/parse_util.cpp
@@ -15,8 +15,7 @@ namespace tracing {
 namespace {
 
 template <typename Integer>
-Expected<Integer> parse_integer(StringView input, int base,
-                                StringView kind) {
+Expected<Integer> parse_integer(StringView input, int base, StringView kind) {
   Integer value;
   input = strip(input);
   const auto status = std::from_chars(input.begin(), input.end(), value, base);

--- a/src/datadog/parse_util.h
+++ b/src/datadog/parse_util.h
@@ -4,7 +4,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string_view>
+#include "string_view.h"
 
 #include "expected.h"
 
@@ -12,29 +12,29 @@ namespace datadog {
 namespace tracing {
 
 // Return a `string_view` over the specified range of characters `[begin, end)`.
-inline std::string_view range(const char* begin, const char* end) {
-  return std::string_view{begin, std::size_t(end - begin)};
+inline StringView range(const char* begin, const char* end) {
+  return StringView{begin, std::size_t(end - begin)};
 }
 
 // Remove leading and trailing whitespace (as determined by `std::isspace`) from
 // the specified `input`.
-std::string_view strip(std::string_view input);
+StringView strip(StringView input);
 
 // Return a non-negative integer parsed from the specified `input` with respect
 // to the specified `base`, or return an `Error` if no such integer can be
 // parsed. It is an error unless all of `input` is consumed by the parse.
 // Leading and trailing whitespace are not ignored.
-Expected<std::uint64_t> parse_uint64(std::string_view input, int base);
-Expected<int> parse_int(std::string_view input, int base);
+Expected<std::uint64_t> parse_uint64(StringView input, int base);
+Expected<int> parse_int(StringView input, int base);
 
 // Return a floating point number parsed from the specified `input`, or return
 // an `Error` if not such number can be parsed. It is an error unless all of
 // `input` is consumed by the parse. Leading and trailing whitespace are not
 // ignored.
-Expected<double> parse_double(std::string_view input);
+Expected<double> parse_double(StringView input);
 
 // Return whether the specified `prefix` is a prefix of the specified `subject`.
-bool starts_with(std::string_view subject, std::string_view prefix);
+bool starts_with(StringView subject, StringView prefix);
 
 }  // namespace tracing
 }  // namespace datadog

--- a/src/datadog/parse_util.h
+++ b/src/datadog/parse_util.h
@@ -4,9 +4,9 @@
 
 #include <cstddef>
 #include <cstdint>
-#include "string_view.h"
 
 #include "expected.h"
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/sampling_decision.h
+++ b/src/datadog/sampling_decision.h
@@ -4,7 +4,7 @@
 // keep/drop sampling decision (for either trace sampling or span sampling) and
 // contains supporting information about the reason for the decision.
 
-#include <optional>
+#include "optional.h"
 
 #include "rate.h"
 #include "sampling_mechanism.h"
@@ -33,15 +33,15 @@ struct SamplingDecision {
   // "drop."
   int priority;
   // See `sampling_mechanism.h`.
-  std::optional<int> mechanism;
+  Optional<int> mechanism;
   // The sample rate associated with this decision, if any.
-  std::optional<Rate> configured_rate;
+  Optional<Rate> configured_rate;
   // The effective rate of the limiter consulted in this decision, if any. A
   // limiter's effective rate is `num_allowed / num_asked`.
-  std::optional<Rate> limiter_effective_rate;
+  Optional<Rate> limiter_effective_rate;
   // The per-second maximum allowed number of "keeps" configured for the limiter
   // consulted in this decision, if any.
-  std::optional<double> limiter_max_per_second;
+  Optional<double> limiter_max_per_second;
   // The provenance of this decision.
   Origin origin;
 };

--- a/src/datadog/sampling_decision.h
+++ b/src/datadog/sampling_decision.h
@@ -5,7 +5,6 @@
 // contains supporting information about the reason for the decision.
 
 #include "optional.h"
-
 #include "rate.h"
 #include "sampling_mechanism.h"
 

--- a/src/datadog/span.cpp
+++ b/src/datadog/span.cpp
@@ -3,11 +3,11 @@
 #include <cassert>
 #include <optional>
 #include <string>
-#include "string_view.h"
 
 #include "dict_writer.h"
 #include "span_config.h"
 #include "span_data.h"
+#include "string_view.h"
 #include "tags.h"
 #include "trace_segment.h"
 
@@ -99,13 +99,9 @@ void Span::remove_tag(StringView name) {
   }
 }
 
-void Span::set_service_name(StringView service) {
-  data_->service = service;
-}
+void Span::set_service_name(StringView service) { data_->service = service; }
 
-void Span::set_service_type(StringView type) {
-  data_->service_type = type;
-}
+void Span::set_service_type(StringView type) { data_->service_type = type; }
 
 void Span::set_resource_name(StringView resource) {
   data_->resource = resource;

--- a/src/datadog/span.cpp
+++ b/src/datadog/span.cpp
@@ -1,7 +1,7 @@
 #include "span.h"
 
 #include <cassert>
-#include <optional>
+#include "optional.h"
 #include <string>
 
 #include "dict_writer.h"
@@ -64,7 +64,7 @@ std::uint64_t Span::id() const { return data_->span_id; }
 
 std::uint64_t Span::trace_id() const { return data_->trace_id; }
 
-std::optional<std::uint64_t> Span::parent_id() const {
+Optional<std::uint64_t> Span::parent_id() const {
   if (data_->parent_id == 0) {
     return std::nullopt;
   }
@@ -75,7 +75,7 @@ TimePoint Span::start_time() const { return data_->start; }
 
 bool Span::error() const { return data_->error; }
 
-std::optional<StringView> Span::lookup_tag(StringView name) const {
+Optional<StringView> Span::lookup_tag(StringView name) const {
   if (tags::is_internal(name)) {
     return std::nullopt;
   }

--- a/src/datadog/span.cpp
+++ b/src/datadog/span.cpp
@@ -1,10 +1,10 @@
 #include "span.h"
 
 #include <cassert>
-#include "optional.h"
 #include <string>
 
 #include "dict_writer.h"
+#include "optional.h"
 #include "span_config.h"
 #include "span_data.h"
 #include "string_view.h"

--- a/src/datadog/span.cpp
+++ b/src/datadog/span.cpp
@@ -3,7 +3,7 @@
 #include <cassert>
 #include <optional>
 #include <string>
-#include <string_view>
+#include "string_view.h"
 
 #include "dict_writer.h"
 #include "span_config.h"
@@ -75,7 +75,7 @@ TimePoint Span::start_time() const { return data_->start; }
 
 bool Span::error() const { return data_->error; }
 
-std::optional<std::string_view> Span::lookup_tag(std::string_view name) const {
+std::optional<StringView> Span::lookup_tag(StringView name) const {
   if (tags::is_internal(name)) {
     return std::nullopt;
   }
@@ -87,27 +87,27 @@ std::optional<std::string_view> Span::lookup_tag(std::string_view name) const {
   return found->second;
 }
 
-void Span::set_tag(std::string_view name, std::string_view value) {
+void Span::set_tag(StringView name, StringView value) {
   if (!tags::is_internal(name)) {
     data_->tags.insert_or_assign(std::string(name), std::string(value));
   }
 }
 
-void Span::remove_tag(std::string_view name) {
+void Span::remove_tag(StringView name) {
   if (!tags::is_internal(name)) {
     data_->tags.erase(std::string(name));
   }
 }
 
-void Span::set_service_name(std::string_view service) {
+void Span::set_service_name(StringView service) {
   data_->service = service;
 }
 
-void Span::set_service_type(std::string_view type) {
+void Span::set_service_type(StringView type) {
   data_->service_type = type;
 }
 
-void Span::set_resource_name(std::string_view resource) {
+void Span::set_resource_name(StringView resource) {
   data_->resource = resource;
 }
 
@@ -119,22 +119,22 @@ void Span::set_error(bool is_error) {
   }
 }
 
-void Span::set_error_message(std::string_view message) {
+void Span::set_error_message(StringView message) {
   data_->error = true;
   data_->tags.insert_or_assign("error.msg", std::string(message));
 }
 
-void Span::set_error_type(std::string_view type) {
+void Span::set_error_type(StringView type) {
   data_->error = true;
   data_->tags.insert_or_assign("error.type", std::string(type));
 }
 
-void Span::set_error_stack(std::string_view type) {
+void Span::set_error_stack(StringView type) {
   data_->error = true;
   data_->tags.insert_or_assign("error.stack", std::string(type));
 }
 
-void Span::set_name(std::string_view value) { data_->name = value; }
+void Span::set_name(StringView value) { data_->name = value; }
 
 void Span::set_end_time(std::chrono::steady_clock::time_point end_time) {
   end_time_ = end_time;

--- a/src/datadog/span.h
+++ b/src/datadog/span.h
@@ -44,11 +44,11 @@
 #include <functional>
 #include <memory>
 #include <optional>
-#include "string_view.h"
 
 #include "clock.h"
 #include "error.h"
 #include "id_generator.h"
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/span.h
+++ b/src/datadog/span.h
@@ -43,11 +43,11 @@
 #include <chrono>
 #include <functional>
 #include <memory>
-#include "optional.h"
 
 #include "clock.h"
 #include "error.h"
 #include "id_generator.h"
+#include "optional.h"
 #include "string_view.h"
 
 namespace datadog {

--- a/src/datadog/span.h
+++ b/src/datadog/span.h
@@ -44,7 +44,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
-#include <string_view>
+#include "string_view.h"
 
 #include "clock.h"
 #include "error.h"
@@ -107,36 +107,36 @@ class Span {
 
   // Return the value of the tag having the specified `name`, or return null if
   // there is no such tag.
-  std::optional<std::string_view> lookup_tag(std::string_view name) const;
+  std::optional<StringView> lookup_tag(StringView name) const;
   // Overwrite the tag having the specified `name` so that it has the specified
   // `value`, or create a new tag.
-  void set_tag(std::string_view name, std::string_view value);
+  void set_tag(StringView name, StringView value);
   // Delete the tag having the specified `name` if it exists.
-  void remove_tag(std::string_view name);
+  void remove_tag(StringView name);
 
   // Set the name of the service associated with this span, e.g.
   // "ingress-nginx-useast1".
-  void set_service_name(std::string_view);
+  void set_service_name(StringView);
   // Set the type of the service associated with this span, e.g. "web".
-  void set_service_type(std::string_view);
+  void set_service_type(StringView);
   // Set the name of the operation that this span represents, e.g.
   // "handle.request", "execute.query", or "healthcheck".
-  void set_name(std::string_view);
+  void set_name(StringView);
   // Set the name of the resource associated with the operation that this span
   // represents, e.g. "/api/v1/info" or "select count(*) from users".
-  void set_resource_name(std::string_view);
+  void set_resource_name(StringView);
   // Set whether an error occurred during the extent of this span.  If `false`,
   // then error-related tags will be removed from this span as well.
   void set_error(bool);
   // Associate a message with the error that occurred during the extent of this
   // span.  This also has the effect of calling `set_error(true)`.
-  void set_error_message(std::string_view);
+  void set_error_message(StringView);
   // Associate an error type with the error that occurred during the extent of
   // this span.  This also has the effect of calling `set_error(true)`.
-  void set_error_type(std::string_view);
+  void set_error_type(StringView);
   // Associate a call stack with the error that occurred during the extent of
   // this span.  This also has the effect of calling `set_error(true)`.
-  void set_error_stack(std::string_view);
+  void set_error_stack(StringView);
   // Set end time of this span.  Doing so will override the default behavior of
   // using the current time in the destructor.
   void set_end_time(std::chrono::steady_clock::time_point);

--- a/src/datadog/span.h
+++ b/src/datadog/span.h
@@ -43,7 +43,7 @@
 #include <chrono>
 #include <functional>
 #include <memory>
-#include <optional>
+#include "optional.h"
 
 #include "clock.h"
 #include "error.h"
@@ -63,7 +63,7 @@ class Span {
   SpanData* data_;
   IDGenerator generate_span_id_;
   Clock clock_;
-  std::optional<std::chrono::steady_clock::time_point> end_time_;
+  Optional<std::chrono::steady_clock::time_point> end_time_;
 
  public:
   // Create a span whose properties are stored in the specified `data` and that
@@ -98,7 +98,7 @@ class Span {
   std::uint64_t trace_id() const;
   // Return the ID of this span's parent span, or return null if this span has
   // no parent.
-  std::optional<std::uint64_t> parent_id() const;
+  Optional<std::uint64_t> parent_id() const;
   // Return the start time of this span.
   TimePoint start_time() const;
   // Return whether this span has been marked as an error having occurred during
@@ -107,7 +107,7 @@ class Span {
 
   // Return the value of the tag having the specified `name`, or return null if
   // there is no such tag.
-  std::optional<StringView> lookup_tag(StringView name) const;
+  Optional<StringView> lookup_tag(StringView name) const;
   // Overwrite the tag having the specified `name` so that it has the specified
   // `value`, or create a new tag.
   void set_tag(StringView name, StringView value);

--- a/src/datadog/span_config.h
+++ b/src/datadog/span_config.h
@@ -13,12 +13,12 @@
 // when no corresponding property is specified in a `SpanConfig` argument.
 // See `SpanData::apply_config`.
 
-#include "optional.h"
 #include <string>
 #include <unordered_map>
 #include <variant>
 
 #include "clock.h"
+#include "optional.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/span_config.h
+++ b/src/datadog/span_config.h
@@ -13,7 +13,7 @@
 // when no corresponding property is specified in a `SpanConfig` argument.
 // See `SpanData::apply_config`.
 
-#include <optional>
+#include "optional.h"
 #include <string>
 #include <unordered_map>
 #include <variant>
@@ -24,13 +24,13 @@ namespace datadog {
 namespace tracing {
 
 struct SpanConfig {
-  std::optional<std::string> service;
-  std::optional<std::string> service_type;
-  std::optional<std::string> version;
-  std::optional<std::string> environment;
-  std::optional<std::string> name;
-  std::optional<std::string> resource;
-  std::optional<TimePoint> start;
+  Optional<std::string> service;
+  Optional<std::string> service_type;
+  Optional<std::string> version;
+  Optional<std::string> environment;
+  Optional<std::string> name;
+  Optional<std::string> resource;
+  Optional<TimePoint> start;
   std::unordered_map<std::string, std::string> tags;
 };
 

--- a/src/datadog/span_data.cpp
+++ b/src/datadog/span_data.cpp
@@ -1,12 +1,12 @@
 #include "span_data.h"
 
 #include <cstddef>
-#include "string_view.h"
 
 #include "error.h"
 #include "msgpack.h"
 #include "span_config.h"
 #include "span_defaults.h"
+#include "string_view.h"
 #include "tags.h"
 
 namespace datadog {

--- a/src/datadog/span_data.cpp
+++ b/src/datadog/span_data.cpp
@@ -13,7 +13,7 @@ namespace datadog {
 namespace tracing {
 namespace {
 
-std::optional<StringView> lookup(
+Optional<StringView> lookup(
     const std::string& key,
     const std::unordered_map<std::string, std::string>& map) {
   const auto found = map.find(key);
@@ -25,11 +25,11 @@ std::optional<StringView> lookup(
 
 }  // namespace
 
-std::optional<StringView> SpanData::environment() const {
+Optional<StringView> SpanData::environment() const {
   return lookup(tags::environment, tags);
 }
 
-std::optional<StringView> SpanData::version() const {
+Optional<StringView> SpanData::version() const {
   return lookup(tags::version, tags);
 }
 

--- a/src/datadog/span_data.cpp
+++ b/src/datadog/span_data.cpp
@@ -1,7 +1,7 @@
 #include "span_data.h"
 
 #include <cstddef>
-#include <string_view>
+#include "string_view.h"
 
 #include "error.h"
 #include "msgpack.h"
@@ -13,7 +13,7 @@ namespace datadog {
 namespace tracing {
 namespace {
 
-std::optional<std::string_view> lookup(
+std::optional<StringView> lookup(
     const std::string& key,
     const std::unordered_map<std::string, std::string>& map) {
   const auto found = map.find(key);
@@ -25,11 +25,11 @@ std::optional<std::string_view> lookup(
 
 }  // namespace
 
-std::optional<std::string_view> SpanData::environment() const {
+std::optional<StringView> SpanData::environment() const {
   return lookup(tags::environment, tags);
 }
 
-std::optional<std::string_view> SpanData::version() const {
+std::optional<StringView> SpanData::version() const {
   return lookup(tags::version, tags);
 }
 

--- a/src/datadog/span_data.h
+++ b/src/datadog/span_data.h
@@ -5,12 +5,12 @@
 
 #include <cstddef>
 #include <memory>
-#include "optional.h"
 #include <string>
 #include <unordered_map>
 
 #include "clock.h"
 #include "expected.h"
+#include "optional.h"
 #include "string_view.h"
 
 namespace datadog {

--- a/src/datadog/span_data.h
+++ b/src/datadog/span_data.h
@@ -5,7 +5,7 @@
 
 #include <cstddef>
 #include <memory>
-#include <optional>
+#include "optional.h"
 #include <string>
 #include <unordered_map>
 
@@ -33,8 +33,8 @@ struct SpanData {
   std::unordered_map<std::string, std::string> tags;
   std::unordered_map<std::string, double> numeric_tags;
 
-  std::optional<StringView> environment() const;
-  std::optional<StringView> version() const;
+  Optional<StringView> environment() const;
+  Optional<StringView> version() const;
 
   // Modify the properties of this object to honor the specified `config` and
   // `defaults`.  The properties of `config`, if set, override the properties of

--- a/src/datadog/span_data.h
+++ b/src/datadog/span_data.h
@@ -7,11 +7,11 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include "string_view.h"
 #include <unordered_map>
 
 #include "clock.h"
 #include "expected.h"
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/span_data.h
+++ b/src/datadog/span_data.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <string_view>
+#include "string_view.h"
 #include <unordered_map>
 
 #include "clock.h"
@@ -33,8 +33,8 @@ struct SpanData {
   std::unordered_map<std::string, std::string> tags;
   std::unordered_map<std::string, double> numeric_tags;
 
-  std::optional<std::string_view> environment() const;
-  std::optional<std::string_view> version() const;
+  std::optional<StringView> environment() const;
+  std::optional<StringView> version() const;
 
   // Modify the properties of this object to honor the specified `config` and
   // `defaults`.  The properties of `config`, if set, override the properties of

--- a/src/datadog/span_matcher.cpp
+++ b/src/datadog/span_matcher.cpp
@@ -12,7 +12,7 @@ namespace datadog {
 namespace tracing {
 namespace {
 
-bool is_match(std::string_view pattern, std::string_view subject) {
+bool is_match(StringView pattern, StringView subject) {
   // Since "*" is the default pattern, optimize for that case.
   return pattern == "*" || glob_match(pattern, subject);
 }
@@ -52,8 +52,8 @@ Expected<SpanMatcher> SpanMatcher::from_json(const nlohmann::json& json) {
   }
 
   const auto check_property_type =
-      [&](std::string_view property, const nlohmann::json& value,
-          std::string_view expected_type) -> std::optional<Error> {
+      [&](StringView property, const nlohmann::json& value,
+          StringView expected_type) -> std::optional<Error> {
     type = value.type_name();
     if (type == expected_type) {
       return std::nullopt;

--- a/src/datadog/span_matcher.cpp
+++ b/src/datadog/span_matcher.cpp
@@ -1,7 +1,7 @@
 #include "span_matcher.h"
 
 #include <algorithm>
-#include <optional>
+#include "optional.h"
 
 #include "error.h"
 #include "glob.h"
@@ -53,7 +53,7 @@ Expected<SpanMatcher> SpanMatcher::from_json(const nlohmann::json& json) {
 
   const auto check_property_type =
       [&](StringView property, const nlohmann::json& value,
-          StringView expected_type) -> std::optional<Error> {
+          StringView expected_type) -> Optional<Error> {
     type = value.type_name();
     if (type == expected_type) {
       return std::nullopt;

--- a/src/datadog/span_matcher.cpp
+++ b/src/datadog/span_matcher.cpp
@@ -1,11 +1,11 @@
 #include "span_matcher.h"
 
 #include <algorithm>
-#include "optional.h"
 
 #include "error.h"
 #include "glob.h"
 #include "json.hpp"
+#include "optional.h"
 #include "span_data.h"
 
 namespace datadog {

--- a/src/datadog/span_sampler_config.cpp
+++ b/src/datadog/span_sampler_config.cpp
@@ -16,8 +16,8 @@ namespace {
 
 // `env_var` is the name of the environment variable from which `rules_raw` was
 // obtained.  It's used for error messages.
-Expected<std::vector<SpanSamplerConfig::Rule>> parse_rules(
-    StringView rules_raw, StringView env_var) {
+Expected<std::vector<SpanSamplerConfig::Rule>> parse_rules(StringView rules_raw,
+                                                           StringView env_var) {
   std::vector<SpanSamplerConfig::Rule> rules;
   nlohmann::json json_rules;
 

--- a/src/datadog/span_sampler_config.cpp
+++ b/src/datadog/span_sampler_config.cpp
@@ -17,7 +17,7 @@ namespace {
 // `env_var` is the name of the environment variable from which `rules_raw` was
 // obtained.  It's used for error messages.
 Expected<std::vector<SpanSamplerConfig::Rule>> parse_rules(
-    std::string_view rules_raw, std::string_view env_var) {
+    StringView rules_raw, StringView env_var) {
   std::vector<SpanSamplerConfig::Rule> rules;
   nlohmann::json json_rules;
 
@@ -46,7 +46,7 @@ Expected<std::vector<SpanSamplerConfig::Rule>> parse_rules(
     return Error{Error::SPAN_SAMPLING_RULES_WRONG_TYPE, std::move(message)};
   }
 
-  const std::unordered_set<std::string_view> allowed_properties{
+  const std::unordered_set<StringView> allowed_properties{
       "service", "name", "resource", "tags", "sample_rate", "max_per_second"};
 
   for (const auto &json_rule : json_rules) {

--- a/src/datadog/span_sampler_config.h
+++ b/src/datadog/span_sampler_config.h
@@ -7,11 +7,11 @@
 // `SpanSamplerConfig` is specified as the `span_sampler` property of
 // `TracerConfig`.
 
-#include "optional.h"
 #include <vector>
 
 #include "expected.h"
 #include "json_fwd.hpp"
+#include "optional.h"
 #include "rate.h"
 #include "span_matcher.h"
 

--- a/src/datadog/span_sampler_config.h
+++ b/src/datadog/span_sampler_config.h
@@ -7,7 +7,7 @@
 // `SpanSamplerConfig` is specified as the `span_sampler` property of
 // `TracerConfig`.
 
-#include <optional>
+#include "optional.h"
 #include <vector>
 
 #include "expected.h"
@@ -23,7 +23,7 @@ class Logger;
 struct SpanSamplerConfig {
   struct Rule : public SpanMatcher {
     double sample_rate = 1.0;
-    std::optional<double> max_per_second;
+    Optional<double> max_per_second;
 
     Rule(const SpanMatcher&);
     Rule() = default;
@@ -45,7 +45,7 @@ class FinalizedSpanSamplerConfig {
  public:
   struct Rule : public SpanMatcher {
     Rate sample_rate;
-    std::optional<double> max_per_second;
+    Optional<double> max_per_second;
   };
 
   std::vector<Rule> rules;

--- a/src/datadog/string_view.cpp
+++ b/src/datadog/string_view.cpp
@@ -1,0 +1,1 @@
+#include "string_view.h"

--- a/src/datadog/string_view.h
+++ b/src/datadog/string_view.h
@@ -1,6 +1,29 @@
 #pragma once
 
-// TODO: explain
+// One of the clients of this library is Envoy, a service (HTTP) proxy.
+//
+// Envoy uses Abseil as its base C++ library, and additionally builds in C++17
+// mode.  Abseil has a build option to forward its `std::string_view` and
+// `std::optional` equivalents to the actual standard types when C++17 is
+// available.
+//
+// Envoy does not use this Abseil build option, due to incomplete support for
+// the C++17 standard library on iOS 11.
+//
+// As a result, Envoy forbids use of `std::string_view` and `std::optional`,
+// instead preferring Abseil's `absl::string_view` and `absl::optional`.
+//
+// This presents a problem for this library, since we use `std::string_view`
+// and `std::optional` in the exported interface, i.e. in header files.
+//
+// As a workaround, Bazel (the build tool used by Envoy) builds of this library
+// will define the `DD_USE_ABSEIL_FOR_ENVOY` preprocessor macro.  When this
+// macro is defined, the library-specific `StringView` and `Optional` aliases
+// will refer to the Abseil types.  When the macro is not defined, the
+// library-specific aliases will refer to the standard types.
+//
+// This file defines `datadog::tracing::StringView`, a type that is an alias
+// for either `std::string_view` or `absl::string_view`.
 
 #ifdef DD_USE_ABSEIL_FOR_ENVOY
 // Abseil examples, including usage in Envoy, include Abseil headers in quoted

--- a/src/datadog/string_view.h
+++ b/src/datadog/string_view.h
@@ -8,7 +8,7 @@
 #include "absl/strings/string_view.h"
 #else
 #include <string_view>
-#endif // defined DD_USE_ABSEIL_FOR_ENVOY
+#endif  // defined DD_USE_ABSEIL_FOR_ENVOY
 
 namespace datadog {
 namespace tracing {
@@ -17,7 +17,7 @@ namespace tracing {
 using StringView = absl::string_view;
 #else
 using StringView = std::string_view;
-#endif // defined DD_USE_ABSEIL_FOR_ENVOY
+#endif  // defined DD_USE_ABSEIL_FOR_ENVOY
 
-} // namespace tracing
-} // namespace datadog
+}  // namespace tracing
+}  // namespace datadog

--- a/src/datadog/string_view.h
+++ b/src/datadog/string_view.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// TODO: explain
+
+#ifdef DD_USE_ABSEIL_FOR_ENVOY
+// Abseil examples, including usage in Envoy, include Abseil headers in quoted
+// style instead of angle bracket style, per Bazel's default build behavior.
+#include "absl/strings/string_view.h"
+#else
+#include <string_view>
+#endif // defined DD_USE_ABSEIL_FOR_ENVOY
+
+namespace datadog {
+namespace tracing {
+
+#ifdef DD_USE_ABSEIL_FOR_ENVOY
+using StringView = absl::string_view;
+#else
+using StringView = std::string_view;
+#endif // defined DD_USE_ABSEIL_FOR_ENVOY
+
+} // namespace tracing
+} // namespace datadog

--- a/src/datadog/tag_propagation.cpp
+++ b/src/datadog/tag_propagation.cpp
@@ -33,7 +33,7 @@ namespace {
 // `entry`.  Return an `Error` if an error occurs.
 Expected<void> decode_tag(
     std::unordered_map<std::string, std::string>& destination,
-    std::string_view entry) {
+    StringView entry) {
   const auto separator = std::find(entry.begin(), entry.end(), '=');
   if (separator == entry.end()) {
     std::string message;
@@ -42,16 +42,16 @@ Expected<void> decode_tag(
     return Error{Error::MALFORMED_TRACE_TAGS, std::move(message)};
   }
 
-  const std::string_view key = range(entry.begin(), separator);
-  const std::string_view value = range(separator + 1, entry.end());
+  const StringView key = range(entry.begin(), separator);
+  const StringView value = range(separator + 1, entry.end());
   // Among duplicate keys, most recent value wins.
   destination.insert_or_assign(std::string(key), std::string(value));
 
   return std::nullopt;
 }
 
-void append_tag(std::string& serialized_tags, std::string_view tag_key,
-                std::string_view tag_value) {
+void append_tag(std::string& serialized_tags, StringView tag_key,
+                StringView tag_value) {
   serialized_tags.append(tag_key.begin(), tag_key.end());
   serialized_tags += '=';
   serialized_tags.append(tag_value.begin(), tag_value.end());
@@ -60,7 +60,7 @@ void append_tag(std::string& serialized_tags, std::string_view tag_key,
 }  // namespace
 
 Expected<std::unordered_map<std::string, std::string>> decode_tags(
-    std::string_view header_value) {
+    StringView header_value) {
   std::unordered_map<std::string, std::string> tags;
 
   auto iter = header_value.begin();

--- a/src/datadog/tag_propagation.h
+++ b/src/datadog/tag_propagation.h
@@ -12,10 +12,10 @@
 // "x-datadog-tags" header format.
 
 #include <string>
-#include "string_view.h"
 #include <unordered_map>
 
 #include "expected.h"
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/tag_propagation.h
+++ b/src/datadog/tag_propagation.h
@@ -12,7 +12,7 @@
 // "x-datadog-tags" header format.
 
 #include <string>
-#include <string_view>
+#include "string_view.h"
 #include <unordered_map>
 
 #include "expected.h"
@@ -23,7 +23,7 @@ namespace tracing {
 // Return a name->value mapping of tags parsed from the specified
 // `header_value`, or return an `Error` if an error occurs.
 Expected<std::unordered_map<std::string, std::string>> decode_tags(
-    std::string_view header_value);
+    StringView header_value);
 
 // Serialize the specified `trace_tags` into the propagation format and return
 // the resulting string.

--- a/src/datadog/tags.cpp
+++ b/src/datadog/tags.cpp
@@ -31,7 +31,7 @@ const std::string span_sampling_limit = "_dd.span_sampling.max_per_second";
 
 }  // namespace internal
 
-bool is_internal(std::string_view tag_name) {
+bool is_internal(StringView tag_name) {
   return starts_with(tag_name, "_dd.");
 }
 

--- a/src/datadog/tags.cpp
+++ b/src/datadog/tags.cpp
@@ -31,9 +31,7 @@ const std::string span_sampling_limit = "_dd.span_sampling.max_per_second";
 
 }  // namespace internal
 
-bool is_internal(StringView tag_name) {
-  return starts_with(tag_name, "_dd.");
-}
+bool is_internal(StringView tag_name) { return starts_with(tag_name, "_dd."); }
 
 }  // namespace tags
 }  // namespace tracing

--- a/src/datadog/tags.h
+++ b/src/datadog/tags.h
@@ -4,7 +4,7 @@
 // meaning.
 
 #include <string>
-#include <string_view>
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {
@@ -35,7 +35,7 @@ extern const std::string span_sampling_limit;
 
 // Return whether the specified `tag_name` is reserved for use internal to this
 // library.
-bool is_internal(std::string_view tag_name);
+bool is_internal(StringView tag_name);
 
 }  // namespace tags
 }  // namespace tracing

--- a/src/datadog/tags.h
+++ b/src/datadog/tags.h
@@ -4,6 +4,7 @@
 // meaning.
 
 #include <string>
+
 #include "string_view.h"
 
 namespace datadog {

--- a/src/datadog/trace_sampler.h
+++ b/src/datadog/trace_sampler.h
@@ -84,13 +84,13 @@
 // `DD_TRACE_RATE_LIMIT` environment variable.
 
 #include <mutex>
-#include "optional.h"
 #include <string>
 #include <unordered_map>
 
 #include "clock.h"
 #include "json_fwd.hpp"
 #include "limiter.h"
+#include "optional.h"
 #include "rate.h"
 #include "trace_sampler_config.h"
 

--- a/src/datadog/trace_sampler.h
+++ b/src/datadog/trace_sampler.h
@@ -84,7 +84,7 @@
 // `DD_TRACE_RATE_LIMIT` environment variable.
 
 #include <mutex>
-#include <optional>
+#include "optional.h"
 #include <string>
 #include <unordered_map>
 
@@ -104,7 +104,7 @@ struct SpanData;
 class TraceSampler {
   std::mutex mutex_;
 
-  std::optional<Rate> collector_default_sample_rate_;
+  Optional<Rate> collector_default_sample_rate_;
   std::unordered_map<std::string, Rate> collector_sample_rates_;
 
   std::vector<FinalizedTraceSamplerConfig::Rule> rules_;

--- a/src/datadog/trace_sampler_config.cpp
+++ b/src/datadog/trace_sampler_config.cpp
@@ -47,7 +47,7 @@ Expected<FinalizedTraceSamplerConfig> finalize_config(
       return Error{Error::TRACE_SAMPLING_RULES_WRONG_TYPE, std::move(message)};
     }
 
-    const std::unordered_set<std::string_view> allowed_properties{
+    const std::unordered_set<StringView> allowed_properties{
         "service", "name", "resource", "tags", "sample_rate"};
 
     for (const auto &json_rule : json_rules) {

--- a/src/datadog/trace_sampler_config.h
+++ b/src/datadog/trace_sampler_config.h
@@ -7,11 +7,11 @@
 // `TraceSamplerConfig` is specified as the `trace_sampler` property of
 // `TracerConfig`.
 
-#include "optional.h"
 #include <vector>
 
 #include "expected.h"
 #include "json_fwd.hpp"
+#include "optional.h"
 #include "rate.h"
 #include "span_matcher.h"
 

--- a/src/datadog/trace_sampler_config.h
+++ b/src/datadog/trace_sampler_config.h
@@ -7,7 +7,7 @@
 // `TraceSamplerConfig` is specified as the `trace_sampler` property of
 // `TracerConfig`.
 
-#include <optional>
+#include "optional.h"
 #include <vector>
 
 #include "expected.h"
@@ -26,7 +26,7 @@ struct TraceSamplerConfig {
     Rule() = default;
   };
 
-  std::optional<double> sample_rate;
+  Optional<double> sample_rate;
   std::vector<Rule> rules;
   double max_per_second = 200;
 };

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <charconv>
 #include <limits>
-#include "optional.h"
 #include <string>
 #include <system_error>
 #include <unordered_map>
@@ -14,6 +13,7 @@
 #include "dict_writer.h"
 #include "error.h"
 #include "logger.h"
+#include "optional.h"
 #include "span_data.h"
 #include "span_sampler.h"
 #include "tag_propagation.h"
@@ -46,8 +46,8 @@ TraceSegment::TraceSegment(
     const std::shared_ptr<SpanSampler>& span_sampler,
     const std::shared_ptr<const SpanDefaults>& defaults,
     const PropagationStyles& injection_styles,
-    const Optional<std::string>& hostname,
-    Optional<std::string> origin, std::size_t tags_header_max_size,
+    const Optional<std::string>& hostname, Optional<std::string> origin,
+    std::size_t tags_header_max_size,
     std::unordered_map<std::string, std::string> trace_tags,
     Optional<SamplingDecision> sampling_decision,
     std::unique_ptr<SpanData> local_root)
@@ -78,9 +78,7 @@ const Optional<std::string>& TraceSegment::hostname() const {
   return hostname_;
 }
 
-const Optional<std::string>& TraceSegment::origin() const {
-  return origin_;
-}
+const Optional<std::string>& TraceSegment::origin() const { return origin_; }
 
 Optional<SamplingDecision> TraceSegment::sampling_decision() const {
   // `sampling_decision_` can change, so we need a lock.

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -3,7 +3,7 @@
 #include <cassert>
 #include <charconv>
 #include <limits>
-#include <optional>
+#include "optional.h"
 #include <string>
 #include <system_error>
 #include <unordered_map>
@@ -46,10 +46,10 @@ TraceSegment::TraceSegment(
     const std::shared_ptr<SpanSampler>& span_sampler,
     const std::shared_ptr<const SpanDefaults>& defaults,
     const PropagationStyles& injection_styles,
-    const std::optional<std::string>& hostname,
-    std::optional<std::string> origin, std::size_t tags_header_max_size,
+    const Optional<std::string>& hostname,
+    Optional<std::string> origin, std::size_t tags_header_max_size,
     std::unordered_map<std::string, std::string> trace_tags,
-    std::optional<SamplingDecision> sampling_decision,
+    Optional<SamplingDecision> sampling_decision,
     std::unique_ptr<SpanData> local_root)
     : logger_(logger),
       collector_(collector),
@@ -74,15 +74,15 @@ TraceSegment::TraceSegment(
 
 const SpanDefaults& TraceSegment::defaults() const { return *defaults_; }
 
-const std::optional<std::string>& TraceSegment::hostname() const {
+const Optional<std::string>& TraceSegment::hostname() const {
   return hostname_;
 }
 
-const std::optional<std::string>& TraceSegment::origin() const {
+const Optional<std::string>& TraceSegment::origin() const {
   return origin_;
 }
 
-std::optional<SamplingDecision> TraceSegment::sampling_decision() const {
+Optional<SamplingDecision> TraceSegment::sampling_decision() const {
   // `sampling_decision_` can change, so we need a lock.
   std::lock_guard<std::mutex> lock(mutex_);
   return sampling_decision_;

--- a/src/datadog/trace_segment.h
+++ b/src/datadog/trace_segment.h
@@ -29,7 +29,7 @@
 #include <cstddef>
 #include <memory>
 #include <mutex>
-#include <optional>
+#include "optional.h"
 #include <unordered_map>
 #include <vector>
 
@@ -59,14 +59,14 @@ class TraceSegment {
 
   std::shared_ptr<const SpanDefaults> defaults_;
   const PropagationStyles injection_styles_;
-  const std::optional<std::string> hostname_;
-  const std::optional<std::string> origin_;
+  const Optional<std::string> hostname_;
+  const Optional<std::string> origin_;
   const std::size_t tags_header_max_size_;
   std::unordered_map<std::string, std::string> trace_tags_;
 
   std::vector<std::unique_ptr<SpanData>> spans_;
   std::size_t num_finished_spans_;
-  std::optional<SamplingDecision> sampling_decision_;
+  Optional<SamplingDecision> sampling_decision_;
   bool awaiting_delegated_sampling_decision_ = false;
 
  public:
@@ -76,17 +76,17 @@ class TraceSegment {
                const std::shared_ptr<SpanSampler>& span_sampler,
                const std::shared_ptr<const SpanDefaults>& defaults,
                const PropagationStyles& injection_styles,
-               const std::optional<std::string>& hostname,
-               std::optional<std::string> origin,
+               const Optional<std::string>& hostname,
+               Optional<std::string> origin,
                std::size_t tags_header_max_size,
                std::unordered_map<std::string, std::string> trace_tags,
-               std::optional<SamplingDecision> sampling_decision,
+               Optional<SamplingDecision> sampling_decision,
                std::unique_ptr<SpanData> local_root);
 
   const SpanDefaults& defaults() const;
-  const std::optional<std::string>& hostname() const;
-  const std::optional<std::string>& origin() const;
-  std::optional<SamplingDecision> sampling_decision() const;
+  const Optional<std::string>& hostname() const;
+  const Optional<std::string>& origin() const;
+  Optional<SamplingDecision> sampling_decision() const;
 
   Logger& logger() const;
 

--- a/src/datadog/trace_segment.h
+++ b/src/datadog/trace_segment.h
@@ -29,11 +29,11 @@
 #include <cstddef>
 #include <memory>
 #include <mutex>
-#include "optional.h"
 #include <unordered_map>
 #include <vector>
 
 #include "expected.h"
+#include "optional.h"
 #include "propagation_styles.h"
 #include "sampling_decision.h"
 
@@ -77,8 +77,7 @@ class TraceSegment {
                const std::shared_ptr<const SpanDefaults>& defaults,
                const PropagationStyles& injection_styles,
                const Optional<std::string>& hostname,
-               Optional<std::string> origin,
-               std::size_t tags_header_max_size,
+               Optional<std::string> origin, std::size_t tags_header_max_size,
                std::unordered_map<std::string, std::string> trace_tags,
                Optional<SamplingDecision> sampling_decision,
                std::unique_ptr<SpanData> local_root);

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -38,8 +38,8 @@ class ExtractionPolicy {
 
 class DatadogExtractionPolicy : public ExtractionPolicy {
   Expected<std::optional<std::uint64_t>> id(const DictReader& headers,
-                                            std::string_view header,
-                                            std::string_view kind) {
+                                            StringView header,
+                                            StringView kind) {
     auto found = headers.lookup(header);
     if (!found) {
       return std::nullopt;
@@ -72,7 +72,7 @@ class DatadogExtractionPolicy : public ExtractionPolicy {
 
   Expected<std::optional<int>> sampling_priority(
       const DictReader& headers) override {
-    const std::string_view header = "x-datadog-sampling-priority";
+    const StringView header = "x-datadog-sampling-priority";
     auto found = headers.lookup(header);
     if (!found) {
       return std::nullopt;
@@ -109,8 +109,8 @@ class DatadogExtractionPolicy : public ExtractionPolicy {
 
 class B3ExtractionPolicy : public DatadogExtractionPolicy {
   Expected<std::optional<std::uint64_t>> id(const DictReader& headers,
-                                            std::string_view header,
-                                            std::string_view kind) {
+                                            StringView header,
+                                            StringView kind) {
     auto found = headers.lookup(header);
     if (!found) {
       return std::nullopt;
@@ -143,7 +143,7 @@ class B3ExtractionPolicy : public DatadogExtractionPolicy {
 
   Expected<std::optional<int>> sampling_priority(
       const DictReader& headers) override {
-    const std::string_view header = "x-b3-sampled";
+    const StringView header = "x-b3-sampled";
     auto found = headers.lookup(header);
     if (!found) {
       return std::nullopt;
@@ -208,7 +208,7 @@ Expected<ExtractedData> extract_data(ExtractionPolicy& extract,
   return extracted_data;
 }
 
-void log_startup_message(Logger& logger, std::string_view tracer_version_string,
+void log_startup_message(Logger& logger, StringView tracer_version_string,
                          const Collector& collector,
                          const SpanDefaults& defaults,
                          const TraceSampler& trace_sampler,

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -26,18 +26,18 @@ namespace {
 
 class ExtractionPolicy {
  public:
-  virtual Expected<std::optional<std::uint64_t>> trace_id(
+  virtual Expected<Optional<std::uint64_t>> trace_id(
       const DictReader& headers) = 0;
-  virtual Expected<std::optional<std::uint64_t>> parent_id(
+  virtual Expected<Optional<std::uint64_t>> parent_id(
       const DictReader& headers) = 0;
-  virtual Expected<std::optional<int>> sampling_priority(
+  virtual Expected<Optional<int>> sampling_priority(
       const DictReader& headers) = 0;
-  virtual std::optional<std::string> origin(const DictReader& headers) = 0;
-  virtual std::optional<std::string> trace_tags(const DictReader&) = 0;
+  virtual Optional<std::string> origin(const DictReader& headers) = 0;
+  virtual Optional<std::string> trace_tags(const DictReader&) = 0;
 };
 
 class DatadogExtractionPolicy : public ExtractionPolicy {
-  Expected<std::optional<std::uint64_t>> id(const DictReader& headers,
+  Expected<Optional<std::uint64_t>> id(const DictReader& headers,
                                             StringView header,
                                             StringView kind) {
     auto found = headers.lookup(header);
@@ -60,17 +60,17 @@ class DatadogExtractionPolicy : public ExtractionPolicy {
   }
 
  public:
-  Expected<std::optional<std::uint64_t>> trace_id(
+  Expected<Optional<std::uint64_t>> trace_id(
       const DictReader& headers) override {
     return id(headers, "x-datadog-trace-id", "trace");
   }
 
-  Expected<std::optional<std::uint64_t>> parent_id(
+  Expected<Optional<std::uint64_t>> parent_id(
       const DictReader& headers) override {
     return id(headers, "x-datadog-parent-id", "parent span");
   }
 
-  Expected<std::optional<int>> sampling_priority(
+  Expected<Optional<int>> sampling_priority(
       const DictReader& headers) override {
     const StringView header = "x-datadog-sampling-priority";
     auto found = headers.lookup(header);
@@ -90,7 +90,7 @@ class DatadogExtractionPolicy : public ExtractionPolicy {
     return *result;
   }
 
-  std::optional<std::string> origin(const DictReader& headers) override {
+  Optional<std::string> origin(const DictReader& headers) override {
     auto found = headers.lookup("x-datadog-origin");
     if (found) {
       return std::string(*found);
@@ -98,7 +98,7 @@ class DatadogExtractionPolicy : public ExtractionPolicy {
     return std::nullopt;
   }
 
-  std::optional<std::string> trace_tags(const DictReader& headers) override {
+  Optional<std::string> trace_tags(const DictReader& headers) override {
     auto found = headers.lookup("x-datadog-tags");
     if (found) {
       return std::string(*found);
@@ -108,7 +108,7 @@ class DatadogExtractionPolicy : public ExtractionPolicy {
 };
 
 class B3ExtractionPolicy : public DatadogExtractionPolicy {
-  Expected<std::optional<std::uint64_t>> id(const DictReader& headers,
+  Expected<Optional<std::uint64_t>> id(const DictReader& headers,
                                             StringView header,
                                             StringView kind) {
     auto found = headers.lookup(header);
@@ -131,17 +131,17 @@ class B3ExtractionPolicy : public DatadogExtractionPolicy {
   }
 
  public:
-  Expected<std::optional<std::uint64_t>> trace_id(
+  Expected<Optional<std::uint64_t>> trace_id(
       const DictReader& headers) override {
     return id(headers, "x-b3-traceid", "trace");
   }
 
-  Expected<std::optional<std::uint64_t>> parent_id(
+  Expected<Optional<std::uint64_t>> parent_id(
       const DictReader& headers) override {
     return id(headers, "x-b3-spanid", "parent span");
   }
 
-  Expected<std::optional<int>> sampling_priority(
+  Expected<Optional<int>> sampling_priority(
       const DictReader& headers) override {
     const StringView header = "x-b3-sampled";
     auto found = headers.lookup(header);
@@ -163,11 +163,11 @@ class B3ExtractionPolicy : public DatadogExtractionPolicy {
 };
 
 struct ExtractedData {
-  std::optional<std::uint64_t> trace_id;
-  std::optional<std::uint64_t> parent_id;
-  std::optional<std::string> origin;
-  std::optional<std::string> trace_tags;
-  std::optional<int> sampling_priority;
+  Optional<std::uint64_t> trace_id;
+  Optional<std::uint64_t> parent_id;
+  Optional<std::string> origin;
+  Optional<std::string> trace_tags;
+  Optional<int> sampling_priority;
 };
 
 bool operator!=(const ExtractedData& left, const ExtractedData& right) {
@@ -215,7 +215,7 @@ void log_startup_message(Logger& logger, StringView tracer_version_string,
                          const SpanSampler& span_sampler,
                          const PropagationStyles& injection_styles,
                          const PropagationStyles& extraction_styles,
-                         const std::optional<std::string>& hostname,
+                         const Optional<std::string>& hostname,
                          std::size_t tags_header_max_size) {
   // clang-format off
   auto config = nlohmann::json::object({
@@ -305,7 +305,7 @@ Expected<Span> Tracer::extract_span(const DictReader& reader,
                                     const SpanConfig& config) {
   assert(extraction_styles_.datadog || extraction_styles_.b3);
 
-  std::optional<ExtractedData> extracted_data;
+  Optional<ExtractedData> extracted_data;
   const char* extracted_by;
 
   if (extraction_styles_.datadog) {
@@ -391,7 +391,7 @@ Expected<Span> Tracer::extract_span(const DictReader& reader,
   span_data->trace_id = *trace_id;
   span_data->parent_id = *parent_id;
 
-  std::optional<SamplingDecision> sampling_decision;
+  Optional<SamplingDecision> sampling_decision;
   if (sampling_priority) {
     SamplingDecision decision;
     decision.priority = *sampling_priority;

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -38,8 +38,7 @@ class ExtractionPolicy {
 
 class DatadogExtractionPolicy : public ExtractionPolicy {
   Expected<Optional<std::uint64_t>> id(const DictReader& headers,
-                                            StringView header,
-                                            StringView kind) {
+                                       StringView header, StringView kind) {
     auto found = headers.lookup(header);
     if (!found) {
       return std::nullopt;
@@ -109,8 +108,7 @@ class DatadogExtractionPolicy : public ExtractionPolicy {
 
 class B3ExtractionPolicy : public DatadogExtractionPolicy {
   Expected<Optional<std::uint64_t>> id(const DictReader& headers,
-                                            StringView header,
-                                            StringView kind) {
+                                       StringView header, StringView kind) {
     auto found = headers.lookup(header);
     if (!found) {
       return std::nullopt;

--- a/src/datadog/tracer.h
+++ b/src/datadog/tracer.h
@@ -10,7 +10,7 @@
 // obtained from a `TracerConfig` via the `finalize_config` function.  See
 // `tracer_config.h`.
 
-#include <optional>
+#include "optional.h"
 
 #include "clock.h"
 #include "error.h"
@@ -37,7 +37,7 @@ class Tracer {
   std::shared_ptr<const SpanDefaults> defaults_;
   PropagationStyles injection_styles_;
   PropagationStyles extraction_styles_;
-  std::optional<std::string> hostname_;
+  Optional<std::string> hostname_;
   std::size_t tags_header_max_size_;
 
  public:

--- a/src/datadog/tracer.h
+++ b/src/datadog/tracer.h
@@ -10,12 +10,11 @@
 // obtained from a `TracerConfig` via the `finalize_config` function.  See
 // `tracer_config.h`.
 
-#include "optional.h"
-
 #include "clock.h"
 #include "error.h"
 #include "expected.h"
 #include "id_generator.h"
+#include "optional.h"
 #include "span.h"
 #include "tracer_config.h"
 

--- a/src/datadog/tracer_config.cpp
+++ b/src/datadog/tracer_config.cpp
@@ -4,7 +4,7 @@
 #include <cctype>
 #include <cstddef>
 #include <string>
-#include <string_view>
+#include "string_view.h"
 #include <unordered_map>
 #include <vector>
 
@@ -23,7 +23,7 @@ void to_lower(std::string &text) {
                  [](unsigned char ch) { return std::tolower(ch); });
 }
 
-bool falsy(std::string_view text) {
+bool falsy(StringView text) {
   auto lower = std::string{text};
   to_lower(lower);
   return lower == "0" || lower == "false" || lower == "no";
@@ -32,11 +32,11 @@ bool falsy(std::string_view text) {
 // List items are separated by an optional comma (",") and any amount of
 // whitespace.
 // Leading and trailing whitespace is ignored.
-std::vector<std::string_view> parse_list(std::string_view input) {
+std::vector<StringView> parse_list(StringView input) {
   using uchar = unsigned char;
 
   input = strip(input);
-  std::vector<std::string_view> items;
+  std::vector<StringView> items;
   if (input.empty()) {
     return items;
   }
@@ -67,11 +67,11 @@ std::vector<std::string_view> parse_list(std::string_view input) {
   return items;
 }
 
-Expected<PropagationStyles> parse_propagation_styles(std::string_view input) {
+Expected<PropagationStyles> parse_propagation_styles(StringView input) {
   PropagationStyles styles{false, false};
 
   // Style names are separated by spaces, or a comma, or some combination.
-  for (const std::string_view &item : parse_list(input)) {
+  for (const StringView &item : parse_list(input)) {
     auto token = std::string(item);
     to_lower(token);
     if (token == "datadog") {
@@ -93,11 +93,11 @@ Expected<PropagationStyles> parse_propagation_styles(std::string_view input) {
 }
 
 Expected<std::unordered_map<std::string, std::string>> parse_tags(
-    std::string_view input) {
+    StringView input) {
   std::unordered_map<std::string, std::string> tags;
 
   // Within a tag, the key and value are separated by a colon (":").
-  for (const std::string_view &token : parse_list(input)) {
+  for (const StringView &token : parse_list(input)) {
     const auto separator = std::find(token.begin(), token.end(), ':');
     if (separator == token.end()) {
       std::string message;

--- a/src/datadog/tracer_config.cpp
+++ b/src/datadog/tracer_config.cpp
@@ -4,7 +4,6 @@
 #include <cctype>
 #include <cstddef>
 #include <string>
-#include "string_view.h"
 #include <unordered_map>
 #include <vector>
 
@@ -13,6 +12,7 @@
 #include "environment.h"
 #include "null_collector.h"
 #include "parse_util.h"
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {

--- a/src/datadog/version.h
+++ b/src/datadog/version.h
@@ -2,7 +2,7 @@
 
 // This component provides the release version of this library.
 
-#include <string_view>
+#include "string_view.h"
 
 namespace datadog {
 namespace tracing {

--- a/test/glob.cpp
+++ b/test/glob.cpp
@@ -3,7 +3,7 @@
 
 #include <datadog/glob.h>
 
-#include <string_view>
+#include <datadog/string_view.h>
 
 #include "test.h"
 
@@ -11,8 +11,8 @@ using namespace datadog::tracing;
 
 TEST_CASE("glob") {
   struct TestCase {
-    std::string_view pattern;
-    std::string_view subject;
+    StringView pattern;
+    StringView subject;
     bool expected;
   };
 

--- a/test/glob.cpp
+++ b/test/glob.cpp
@@ -2,7 +2,6 @@
 // `glob_match`, defined in `glob.h`.
 
 #include <datadog/glob.h>
-
 #include <datadog/string_view.h>
 
 #include "test.h"

--- a/test/mocks/dict_readers.h
+++ b/test/mocks/dict_readers.h
@@ -23,9 +23,8 @@ class MockDictReader : public DictReader {
     return found->second;
   }
 
-  void visit(
-      const std::function<void(StringView key, StringView value)>&
-          visitor) const override {
+  void visit(const std::function<void(StringView key, StringView value)>&
+                 visitor) const override {
     for (const auto& [key, value] : *map_) {
       visitor(key, value);
     }

--- a/test/mocks/dict_readers.h
+++ b/test/mocks/dict_readers.h
@@ -15,7 +15,7 @@ class MockDictReader : public DictReader {
       const std::unordered_map<std::string, std::string>& map)
       : map_(&map) {}
 
-  std::optional<std::string_view> lookup(std::string_view key) const override {
+  std::optional<StringView> lookup(StringView key) const override {
     auto found = map_->find(std::string(key));
     if (found == map_->end()) {
       return std::nullopt;
@@ -24,7 +24,7 @@ class MockDictReader : public DictReader {
   }
 
   void visit(
-      const std::function<void(std::string_view key, std::string_view value)>&
+      const std::function<void(StringView key, StringView value)>&
           visitor) const override {
     for (const auto& [key, value] : *map_) {
       visitor(key, value);

--- a/test/mocks/dict_readers.h
+++ b/test/mocks/dict_readers.h
@@ -15,7 +15,7 @@ class MockDictReader : public DictReader {
       const std::unordered_map<std::string, std::string>& map)
       : map_(&map) {}
 
-  std::optional<StringView> lookup(StringView key) const override {
+  Optional<StringView> lookup(StringView key) const override {
     auto found = map_->find(std::string(key));
     if (found == map_->end()) {
       return std::nullopt;

--- a/test/mocks/dict_writers.h
+++ b/test/mocks/dict_writers.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <datadog/dict_writer.h>
+#include <datadog/string_view.h>
 
 #include <string>
-#include <string_view>
 #include <unordered_map>
 
 using namespace datadog::tracing;
@@ -11,7 +11,7 @@ using namespace datadog::tracing;
 struct MockDictWriter : public DictWriter {
   std::unordered_map<std::string, std::string> items;
 
-  void set(std::string_view key, std::string_view value) override {
+  void set(StringView key, StringView value) override {
     items.insert_or_assign(std::string(key), std::string(value));
   }
 };

--- a/test/mocks/event_schedulers.h
+++ b/test/mocks/event_schedulers.h
@@ -1,17 +1,17 @@
 #pragma once
 
 #include <datadog/event_scheduler.h>
+#include <datadog/optional.h>
 
 #include <chrono>
 #include <datadog/json.hpp>
 #include <functional>
-#include <optional>
 
 using namespace datadog::tracing;
 
 struct MockEventScheduler : public EventScheduler {
   std::function<void()> event_callback;
-  std::optional<std::chrono::steady_clock::duration> recurrence_interval;
+  Optional<std::chrono::steady_clock::duration> recurrence_interval;
   bool cancelled = false;
 
   Cancel schedule_recurring_event(std::chrono::steady_clock::duration interval,

--- a/test/mocks/http_clients.h
+++ b/test/mocks/http_clients.h
@@ -2,10 +2,10 @@
 
 #include <datadog/error.h>
 #include <datadog/http_client.h>
+#include <datadog/optional.h>
 
 #include <datadog/json.hpp>
 #include <mutex>
-#include <optional>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -29,11 +29,11 @@ using namespace datadog::tracing;
 // If `response_error` is not null, then it will be delivered instead of the
 // `response_body`.
 struct MockHTTPClient : public HTTPClient {
-  std::optional<Error> post_error;
+  Optional<Error> post_error;
   std::ostringstream response_body;
   int response_status = -1;
   std::unordered_map<std::string, std::string> response_headers;
-  std::optional<Error> response_error;
+  Optional<Error> response_error;
   MockDictWriter request_headers;
   std::mutex mutex_;
   ResponseHandler on_response_;

--- a/test/mocks/loggers.h
+++ b/test/mocks/loggers.h
@@ -18,7 +18,7 @@ struct NullLogger : public Logger {
   void log_error(const LogFunc&) override {}
   void log_startup(const LogFunc&) override {}
   void log_error(const Error&) override {}
-  void log_error(std::string_view) override {}
+  void log_error(StringView) override {}
 };
 
 struct MockLogger : public Logger {
@@ -64,7 +64,7 @@ struct MockLogger : public Logger {
     entries.push_back(Entry{Entry::ERROR, error});
   }
 
-  void log_error(std::string_view message) override {
+  void log_error(StringView message) override {
     if (echo) {
       *echo << message << '\n';
     }

--- a/test/span.cpp
+++ b/test/span.cpp
@@ -3,6 +3,7 @@
 // for propagation.
 
 #include <datadog/clock.h>
+#include <datadog/optional.h>
 #include <datadog/span.h>
 #include <datadog/span_config.h>
 #include <datadog/tag_propagation.h>
@@ -14,7 +15,6 @@
 #include <cstdint>
 #include <functional>
 #include <limits>
-#include <optional>
 #include <string>
 
 #include "matchers.h"
@@ -228,9 +228,9 @@ TEST_CASE(".error() and .set_error*()") {
     std::string name;
     std::function<void(Span&)> mutate;
     bool expected_error;
-    std::optional<StringView> expected_error_message;
-    std::optional<StringView> expected_error_type;
-    std::optional<StringView> expected_error_stack;
+    Optional<StringView> expected_error_message;
+    Optional<StringView> expected_error_type;
+    Optional<StringView> expected_error_stack;
   };
 
   auto test_case = GENERATE(values<TestCase>(

--- a/test/span.cpp
+++ b/test/span.cpp
@@ -228,9 +228,9 @@ TEST_CASE(".error() and .set_error*()") {
     std::string name;
     std::function<void(Span&)> mutate;
     bool expected_error;
-    std::optional<std::string_view> expected_error_message;
-    std::optional<std::string_view> expected_error_type;
-    std::optional<std::string_view> expected_error_stack;
+    std::optional<StringView> expected_error_message;
+    std::optional<StringView> expected_error_type;
+    std::optional<StringView> expected_error_stack;
   };
 
   auto test_case = GENERATE(values<TestCase>(

--- a/test/span_sampler.cpp
+++ b/test/span_sampler.cpp
@@ -70,19 +70,19 @@ SpanSamplingTags span_sampling_tags(const SpanData& span) {
   return result;
 }
 
-SpanSamplerConfig::Rule by_service(std::string_view service) {
+SpanSamplerConfig::Rule by_service(StringView service) {
   SpanSamplerConfig::Rule rule;
   rule.service = service;
   return rule;
 }
 
-SpanSamplerConfig::Rule by_name(std::string_view name) {
+SpanSamplerConfig::Rule by_name(StringView name) {
   SpanSamplerConfig::Rule rule;
   rule.name = name;
   return rule;
 }
 
-SpanSamplerConfig::Rule by_resource(std::string_view resource) {
+SpanSamplerConfig::Rule by_resource(StringView resource) {
   SpanSamplerConfig::Rule rule;
   rule.resource = resource;
   return rule;
@@ -96,7 +96,7 @@ SpanSamplerConfig::Rule by_tags(
 }
 
 SpanSamplerConfig::Rule by_name_and_tags(
-    std::string_view name, std::unordered_map<std::string, std::string> tags) {
+    StringView name, std::unordered_map<std::string, std::string> tags) {
   SpanSamplerConfig::Rule rule;
   rule.name = name;
   rule.tags = std::move(tags);

--- a/test/span_sampler.cpp
+++ b/test/span_sampler.cpp
@@ -1,10 +1,10 @@
+#include <datadog/optional.h>
 #include <datadog/span_data.h>
 #include <datadog/span_sampler.h>
 #include <datadog/tags.h>
 #include <datadog/tracer.h>
 
 #include <cstddef>
-#include <optional>
 #include <ostream>
 #include <string>
 #include <unordered_map>
@@ -18,7 +18,7 @@ using namespace datadog::tracing;
 
 namespace std {
 
-std::ostream& operator<<(std::ostream& stream, std::optional<double> value) {
+std::ostream& operator<<(std::ostream& stream, Optional<double> value) {
   if (value) {
     return stream << *value;
   }
@@ -46,9 +46,9 @@ std::ostream& operator<<(
 namespace {
 
 struct SpanSamplingTags {
-  std::optional<double> mechanism;
-  std::optional<double> rule_rate;
-  std::optional<double> max_per_second;
+  Optional<double> mechanism;
+  Optional<double> rule_rate;
+  Optional<double> max_per_second;
 };
 
 SpanSamplingTags span_sampling_tags(const SpanData& span) {
@@ -292,7 +292,7 @@ TEST_CASE("span rule limiter") {
   struct TestCase {
     std::string name;
     std::size_t num_spans;
-    std::optional<double> max_per_second;
+    Optional<double> max_per_second;
     std::size_t expected_count;
   };
 

--- a/test/tracer.cpp
+++ b/test/tracer.cpp
@@ -4,6 +4,7 @@
 #include <datadog/error.h>
 #include <datadog/net_util.h>
 #include <datadog/null_collector.h>
+#include <datadog/optional.h>
 #include <datadog/span.h>
 #include <datadog/span_config.h>
 #include <datadog/span_data.h>
@@ -14,7 +15,6 @@
 #include <datadog/tracer_config.h>
 
 #include <iosfwd>
-#include <optional>
 
 #include "matchers.h"
 #include "mocks/collectors.h"
@@ -26,7 +26,7 @@ namespace datadog {
 namespace tracing {
 
 std::ostream& operator<<(std::ostream& stream,
-                         const std::optional<Error::Code>& code) {
+                         const Optional<Error::Code>& code) {
   if (code) {
     return stream << "Error::Code(" << int(*code) << ")";
   }
@@ -263,7 +263,7 @@ TEST_CASE("span extraction") {
       bool extract_b3;
       std::unordered_map<std::string, std::string> headers;
       // Null means "don't expect an error."
-      std::optional<Error::Code> expected_error;
+      Optional<Error::Code> expected_error;
     };
 
     auto test_case = GENERATE(values<TestCase>({
@@ -453,8 +453,8 @@ TEST_CASE("span extraction") {
       bool extract_b3;
       std::unordered_map<std::string, std::string> headers;
       std::uint64_t expected_trace_id;
-      std::optional<std::uint64_t> expected_parent_id;
-      std::optional<int> expected_sampling_priority;
+      Optional<std::uint64_t> expected_parent_id;
+      Optional<int> expected_sampling_priority;
     };
 
     auto test_case = GENERATE(values<TestCase>({

--- a/test/tracer_config.cpp
+++ b/test/tracer_config.cpp
@@ -1,4 +1,5 @@
 #include <datadog/id_generator.h>
+#include <datadog/optional.h>
 #include <datadog/propagation_styles.h>
 #include <datadog/threaded_event_scheduler.h>
 #include <datadog/tracer.h>
@@ -10,7 +11,6 @@
 #include <fstream>
 #include <iostream>
 #include <limits>
-#include <optional>
 #include <ostream>
 #include <stdexcept>
 #include <string>
@@ -55,7 +55,7 @@ namespace {
 // Restore any previous value (or unset the value if it was unset) afterward.
 class EnvGuard {
   std::string name_;
-  std::optional<std::string> former_value_;
+  Optional<std::string> former_value_;
 
  public:
   EnvGuard(std::string name, std::string value) : name_(std::move(name)) {
@@ -93,7 +93,7 @@ class EnvGuard {
 };
 
 // For brevity when we're tabulating a lot of test cases with parse
-// `std::optional<...>` data members.
+// `Optional<...>` data members.
 const auto x = std::nullopt;
 
 // Here's an attempt at a portable secure temporary file.
@@ -194,7 +194,7 @@ TEST_CASE("TracerConfig::defaults") {
       std::string name;
       std::string dd_tags;
       std::unordered_map<std::string, std::string> expected_tags;
-      std::optional<Error::Code> expected_error;
+      Optional<Error::Code> expected_error;
     };
 
     auto test_case = GENERATE(values<TestCase>({
@@ -416,7 +416,7 @@ TEST_CASE("TracerConfig::agent") {
     SECTION("parsing") {
       struct TestCase {
         std::string url;
-        std::optional<Error::Code> expected_error;
+        Optional<Error::Code> expected_error;
         std::string expected_scheme = "";
         std::string expected_authority = "";
         std::string expected_path = "";
@@ -459,9 +459,9 @@ TEST_CASE("TracerConfig::agent") {
     SECTION("environment variables override") {
       struct TestCase {
         std::string name;
-        std::optional<std::string> env_host;
-        std::optional<std::string> env_port;
-        std::optional<std::string> env_url;
+        Optional<std::string> env_host;
+        Optional<std::string> env_port;
+        Optional<std::string> env_url;
         std::string expected_scheme;
         std::string expected_authority;
       };
@@ -490,15 +490,15 @@ TEST_CASE("TracerConfig::agent") {
       }));
 
       CAPTURE(test_case.name);
-      std::optional<EnvGuard> host_guard;
+      Optional<EnvGuard> host_guard;
       if (test_case.env_host) {
         host_guard.emplace("DD_AGENT_HOST", *test_case.env_host);
       }
-      std::optional<EnvGuard> port_guard;
+      Optional<EnvGuard> port_guard;
       if (test_case.env_port) {
         port_guard.emplace("DD_TRACE_AGENT_PORT", *test_case.env_port);
       }
-      std::optional<EnvGuard> url_guard;
+      Optional<EnvGuard> url_guard;
       if (test_case.env_url) {
         url_guard.emplace("DD_TRACE_AGENT_URL", *test_case.env_url);
       }
@@ -1018,7 +1018,7 @@ TEST_CASE("TracerConfig propagation styles") {
         struct TestCase {
           int line;
           std::string env_value;
-          std::optional<Error::Code> expected_error;
+          Optional<Error::Code> expected_error;
           PropagationStyles expected_styles = PropagationStyles{};
         };
 


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/23958 revealed that Envoy's linter doesn't like `std::string_view` or `std::optional`, preferring the Abseil `absl::*` versions instead.

For `std::string_view`, there is a `NOLINT` exception, but for `std::optional` there is not.

This pull request adds a level of indirection for each of string view and optional, namely `src/datadog/{string_view,optional}.h`, which define the type and type template `datadog::tracing::StringView` and `datadog::tracing::Optional`, respectively.

The default behavior, when the `DD_USE_ABSEIL_FOR_ENVOY` preprocessor macro is not defined, is for the Datadog-specific types to be aliases for the `std` types.

In Bazel builds, such as Envoy's, `DD_USE_ABSEIL_FOR_ENVOY` is defined. This make the Datadog-specific types aliases for the `absl` types.