### PR TITLE
numeric type portability

### DIFF
--- a/src/datadog/clock.h
+++ b/src/datadog/clock.h
@@ -39,11 +39,15 @@ inline Duration operator-(const TimePoint& after, const TimePoint& before) {
 }
 
 inline TimePoint operator-(const TimePoint& origin, Duration offset) {
-  return {origin.wall - offset, origin.tick - offset};
+  return {origin.wall -
+              std::chrono::duration_cast<std::chrono::system_clock::duration>(
+                  offset),
+          origin.tick - offset};
 }
 
 inline TimePoint& operator+=(TimePoint& self, Duration offset) {
-  self.wall += offset;
+  self.wall +=
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(offset);
   self.tick += offset;
   return self;
 }

--- a/src/datadog/span_data.cpp
+++ b/src/datadog/span_data.cpp
@@ -89,16 +89,16 @@ Expected<void> msgpack_encode(std::string& destination, const SpanData& span) {
        },
       "start", [&](auto& destination) {
          msgpack::pack_integer(
-             destination, std::chrono::duration_cast<std::chrono::nanoseconds>(
+             destination, std::uint64_t(std::chrono::duration_cast<std::chrono::nanoseconds>(
                               span.start.wall.time_since_epoch())
-                              .count());
+                              .count()));
          return Expected<void>{};
        },
       "duration", [&](auto& destination) {
          msgpack::pack_integer(
              destination,
-             std::chrono::duration_cast<std::chrono::nanoseconds>(span.duration)
-                 .count());
+             std::uint64_t(std::chrono::duration_cast<std::chrono::nanoseconds>(span.duration)
+                 .count()));
         return Expected<void>{};
        },
       "error", [&](auto& destination) {


### PR DESCRIPTION
Envoy's CI reveals yet more shortcomings in this code.

One of these points was already addressed in the not-yet-merged https://github.com/DataDog/dd-trace-cpp/pull/6.