### PR TITLE
Store coverage reports in a website

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ jobs:
     - image: "datadog/docker-library:dd-trace-cpp-ci"
     resource_class: small
     steps:
+    - add_ssh_keys:
+        fingerprints:
+        - "90:30:2f:b2:d1:88:73:79:4e:2b:ea:45:e2:b7:ea:b3"
     - run: find ~/.ssh
 
   format:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,13 @@
 version: 2.1
 
 jobs:
+  snoop:
+    docker:
+    - image: "datadog/docker-library:dd-trace-cpp-ci"
+    resource_class: small
+    steps:
+    - run: find ~/.ssh
+
   format:
     docker:
     - image: "datadog/docker-library:dd-trace-cpp-ci"
@@ -8,7 +15,7 @@ jobs:
     steps:
     - checkout
     - run: bin/check-format
-  
+
   build-bazel:
     parameters:
       toolchain:
@@ -21,7 +28,7 @@ jobs:
     steps:
     - checkout
     - run: bin/with-toolchain << parameters.toolchain >> bazelisk build --jobs $MAKE_JOB_COUNT dd_trace_cpp
-  
+
   test-cmake:
     parameters:
       toolchain:
@@ -43,6 +50,7 @@ jobs:
 workflows:
   pull-request:
     jobs:
+    - snoop
     - format
     - test-cmake:
         matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - add_ssh_keys:
         fingerprints:
-        - "90:30:2f:b2:d1:88:73:79:4e:2b:ea:45:e2:b7:ea:b3"
+        - "d3:8f:a8:6e:b6:ef:37:65:1a:dc:2b:88:3b:ff:50:f4"
     - run: find ~/.ssh
 
   format:
@@ -50,6 +50,20 @@ jobs:
     - run: cd .build && make -j $MAKE_JOB_COUNT VERBOSE=1
     - run: cd .build && test/tests
 
+  coverage:
+    docker:
+    - image: "datadog/docker-library:dd-trace-cpp-ci"
+    resource_class: xlarge
+    environment:
+      MAKE_JOB_COUNT: 8
+    steps:
+    - checkout
+    - run: bin/test --coverage --verbose
+    - add_ssh_keys:
+        fingerprints:
+        - "d3:8f:a8:6e:b6:ef:37:65:1a:dc:2b:88:3b:ff:50:f4"
+    - run: bin/publish-coverage
+
 workflows:
   pull-request:
     jobs:
@@ -64,3 +78,4 @@ workflows:
         matrix:
           parameters:
             toolchain: ["gnu", "llvm"]
+    - coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,6 @@
 version: 2.1
 
 jobs:
-  snoop:
-    docker:
-    - image: "datadog/docker-library:dd-trace-cpp-ci"
-    resource_class: small
-    steps:
-    - add_ssh_keys:
-        fingerprints:
-        - "d3:8f:a8:6e:b6:ef:37:65:1a:dc:2b:88:3b:ff:50:f4"
-    - run: find ~/.ssh
 
   format:
     docker:
@@ -67,7 +58,6 @@ jobs:
 workflows:
   pull-request:
     jobs:
-    - snoop
     - format
     - test-cmake:
         matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,22 +7,25 @@ from ubuntu:22.04
 # prompts for the current time zone).
 env DEBIAN_FRONTEND=noninteractive
 
-# Update the package lists and upgrade already-installed software.
-run apt-get update && apt-get upgrade --yes
+# - Make available more recent versions of git.
+# - Update the package lists and upgrade already-installed software.
+# - Install build tooling:
+#   - GCC, clang, make, git, debugger, formatter, and miscellanea
+run apt-get update && apt-get install --yes software-properties-common && \
+    add-apt-repository ppa:git-core/ppa --yes && \
+    apt-get update && apt-get upgrade --yes && \
+    apt-get install --yes wget build-essential clang sed gdb clang-format git ssh
 
-# Install build tooling:
-# GCC, clang, make, coverage report generator, debugger, formatter, and miscellanea
-run apt-get install --yes wget build-essential clang sed lcov gdb clang-format
 # bazelisk, a launcher for bazel. `bazelisk --help` will cause the latest
 # version to be downloaded.
 run wget -O/usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64 \
     && chmod +x /usr/local/bin/bazelisk \
     && bazelisk --help
+
 # CMake, by downloading a recent release from their website.
 copy bin/install-cmake /tmp/install-cmake
 run chmod +x /tmp/install-cmake && /tmp/install-cmake && rm /tmp/install-cmake
 
-# Coverage reporting and pushing to Github Pages.
-run apt-get install --yes git ssh
+# Coverage reporting.
 copy bin/install-lcov /tmp/install-lcov
 run chmod +x /tmp/install-lcov && /tmp/install-lcov && rm /tmp/install-lcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,8 @@ run wget -O/usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releas
 # CMake, by downloading a recent release from their website.
 copy bin/install-cmake /tmp/install-cmake
 run chmod +x /tmp/install-cmake && /tmp/install-cmake && rm /tmp/install-cmake
+
+# Coverage reporting and pushing to Github Pages.
+run apt-get install --yes git ssh
+copy bin/install-lcov /tmp/install-lcov
+run chmod +x /tmp/install-lcov && /tmp/install-lcov && rm /tmp/install-lcov

--- a/bin/install-lcov
+++ b/bin/install-lcov
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -x
+set -e
+
+cd /tmp
+wget 'https://github.com/linux-test-project/lcov/releases/download/v1.16/lcov-1.16.tar.gz'
+tar xzf lcov-1.16.tar.gz
+cd lcov-1.16/
+make install
+cd ../
+rm -r lcov-1.16 lcov-1.16.tar.gz

--- a/bin/publish-coverage
+++ b/bin/publish-coverage
@@ -1,22 +1,53 @@
 #!/bin/sh
 
+# Publish an already-generated coverage report from dd-trace-cpp to
+# dd-trace-cpp-coverage.
+#
+# Overall, here's what we're going to do:
+#
+# Clone as little of the dd-trace-cpp-coverage repository as we can manage.
+# Then, move the rendered coverage report from dd-trace-cpp into a specially
+# named location in dd-trace-cpp-coverage.  Commit and push.
+
+set -x
 set -e
 
-cd "$(dirname "$0")"/..
+tracer_dir=$(pwd)
+temp_dir=$(mktemp -d)
 
-# See <https://unix.stackexchange.com/a/155077>
-if output=$(git status --porcelain) && [ -z "$output" ]; then
-  : # Working directory clean
-else 
-  >&2 echo 'Commit or stash changes to the working tree before running this script.'
-  >&2 echo 'See `git status` for more info.'
-  exit 1
-fi
+echo "Using temporary directory: $temp_dir"
+cd "$temp_dir"
 
-bin/test --coverage
-git switch gh-pages
-cp -r .coverage/report/* .
-git add -A
-git commit -m 'update testing code coverage report'
+# Clone directory structure of the most recent commit of one
+# branch (main).  Don't fetch any regular files.
+mkdir dd-trace-cpp-coverage
+cd dd-trace-cpp-coverage
+git init
+git remote add origin 'git@github.com:DataDog/dd-trace-cpp-coverage.git'
+
+branch=gh-pages
+git fetch --depth=1 --filter=blob:none origin "$branch"
+
+# "Sparse checkout" some subdirectory of the repo root.
+# The leaves above and below that directory will be fetched,
+# but its sibling directories will not.
+git sparse-checkout set dummy/
+git checkout "$branch"
+
+# e.g. "2022-12-29 22:09:54 UTC (6c6e440)"
+coverage_report_name() {
+    commit_time_iso=$(git show -s --format=%cI)
+    commit_hash_short=$(git rev-parse HEAD | head -c 7)
+
+    date "--date=$commit_time_iso" --iso-8601=seconds --utc | \
+        sed -e 's/T/ /' -e "s/+.*/ UTC ($commit_hash_short)/"
+}
+
+cd "$tracer_dir"
+report_name=$(coverage_report_name)
+mv .coverage/report "$temp_dir/dd-trace-cpp-coverage/$report_name"
+
+cd "$temp_dir/dd-trace-cpp-coverage"
+git add -A --sparse
+git commit -m "add $report_name"
 git push
-git switch -

--- a/bin/publish-coverage
+++ b/bin/publish-coverage
@@ -22,9 +22,13 @@ cd "$temp_dir"
 # branch (main).  Don't fetch any regular files.
 mkdir dd-trace-cpp-coverage
 cd dd-trace-cpp-coverage
-git init
-git remote add origin 'git@github.com:DataDog/dd-trace-cpp-coverage.git'
 
+git init
+
+git config user.email "david.goffredo@datadoghq.com"
+git config user.name "David Goffredo (via script)"
+
+git remote add origin 'git@github.com:DataDog/dd-trace-cpp-coverage.git'
 branch=gh-pages
 git fetch --depth=1 --filter=blob:none origin "$branch"
 

--- a/bin/test
+++ b/bin/test
@@ -2,6 +2,8 @@
 
 set -e
 
+MAKE_JOB_COUNT=${MAKE_JOB_COUNT:-$(nproc)}
+
 if [ "$1" = '--coverage' ]; then
     coverage_flags=-DBUILD_COVERAGE=1
     shift
@@ -38,7 +40,7 @@ cd .build
 cmake .. $coverage_flags -DBUILD_TESTING=1
 # Clean up any code coverage artifacts.
 find . -type f -name '*.gcda' -print0 | xargs -0 rm -f
-make -j $(nproc) $verbosity_flags
+make -j "$MAKE_JOB_COUNT" $verbosity_flags
 
 if [ "$build_only" -eq 1 ]; then
     exit
@@ -57,7 +59,7 @@ if [ "$coverage_flags" != '' ]; then
     # Filter out system headers and test drivers.
     lcov --quiet --remove .coverage/raw.info -o .coverage/filtered.info '/usr/*' "$(pwd)/test/*" '*json.hpp'
     # Generate an HTML coverage report at ".coverage/report/index.html".
-    genhtml --quiet .coverage/filtered.info --output-directory .coverage/report
+    genhtml --quiet --dark-mode .coverage/filtered.info --output-directory .coverage/report
 
     echo 'Done.'
 fi


### PR DESCRIPTION
Have CircleCI generate a coverage report and push it to (a newly create repository) `dd-trace-cpp-coverage`. `dd-trace-cpp-coverage` hosts the coverage reports via GitHub Pages.