### PR TITLE
Add some unit tests for `class Curl`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ target_sources(dd_trace_cpp PRIVATE
     src/datadog/trace_sampler_config.cpp
     src/datadog/trace_sampler.cpp
     src/datadog/trace_segment.cpp
-    src/datadog/version.cpp    
+    src/datadog/version.cpp
 )
 
 # This library's public headers are just its source headers.
@@ -164,12 +164,12 @@ target_sources(dd_trace_cpp PUBLIC
 
 add_dependencies(dd_trace_cpp curl)
 
-# Make the build libcurl visible to dd_trace_cpp, but not to its dependents.
-target_include_directories(dd_trace_cpp PRIVATE ${CMAKE_BINARY_DIR}/include)
+# Make the build libcurl visible to dd_trace_cpp, and its dependents.
+target_include_directories(dd_trace_cpp PUBLIC ${CMAKE_BINARY_DIR}/include)
 
 # Linking this library requires libcurl and threads.
 find_package(Threads REQUIRED)
-target_link_libraries(dd_trace_cpp PRIVATE ${CMAKE_BINARY_DIR}/lib/libcurl.a PUBLIC Threads::Threads ${COVERAGE_LIBRARIES})
+target_link_libraries(dd_trace_cpp PUBLIC ${CMAKE_BINARY_DIR}/lib/libcurl.a PUBLIC Threads::Threads ${COVERAGE_LIBRARIES})
 
 # When installing, install the library and its public headers.
 

--- a/src/datadog/curl.cpp
+++ b/src/datadog/curl.cpp
@@ -1,7 +1,5 @@
 #include "curl.h"
 
-#include <curl/curl.h>
-
 #include <algorithm>
 #include <cctype>
 #include <chrono>
@@ -11,7 +9,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
-#include <thread>
+#include <system_error>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -25,6 +23,135 @@
 
 namespace datadog {
 namespace tracing {
+namespace {
+
+// `libcurl` is the default implementation: it calls `curl_*` functions under
+// the hood.
+CurlLibrary libcurl;
+
+}  // namespace
+
+CURL *CurlLibrary::easy_init() { return curl_easy_init(); }
+
+void CurlLibrary::easy_cleanup(CURL *handle) { curl_easy_cleanup(handle); }
+
+CURLcode CurlLibrary::easy_getinfo_private(CURL *curl, char **user_data) {
+  return curl_easy_getinfo(curl, CURLINFO_PRIVATE, user_data);
+}
+
+CURLcode CurlLibrary::easy_getinfo_response_code(CURL *curl, long *code) {
+  return curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, code);
+}
+
+CURLcode CurlLibrary::easy_setopt_errorbuffer(CURL *handle, char *buffer) {
+  return curl_easy_setopt(handle, CURLOPT_ERRORBUFFER, buffer);
+}
+
+CURLcode CurlLibrary::easy_setopt_headerdata(CURL *handle, void *data) {
+  return curl_easy_setopt(handle, CURLOPT_HEADERDATA, data);
+}
+
+CURLcode CurlLibrary::easy_setopt_headerfunction(CURL *handle,
+                                                 HeaderCallback on_header) {
+  return curl_easy_setopt(handle, CURLOPT_HEADERFUNCTION, on_header);
+}
+
+CURLcode CurlLibrary::easy_setopt_httpheader(CURL *handle,
+                                             curl_slist *headers) {
+  return curl_easy_setopt(handle, CURLOPT_HTTPHEADER, headers);
+}
+
+CURLcode CurlLibrary::easy_setopt_post(CURL *handle, long post) {
+  return curl_easy_setopt(handle, CURLOPT_POST, post);
+}
+
+CURLcode CurlLibrary::easy_setopt_postfields(CURL *handle, const char *data) {
+  return curl_easy_setopt(handle, CURLOPT_POSTFIELDS, data);
+}
+
+CURLcode CurlLibrary::easy_setopt_postfieldsize(CURL *handle, long size) {
+  return curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE, size);
+}
+
+CURLcode CurlLibrary::easy_setopt_private(CURL *handle, void *pointer) {
+  return curl_easy_setopt(handle, CURLOPT_PRIVATE, pointer);
+}
+
+CURLcode CurlLibrary::easy_setopt_unix_socket_path(CURL *handle,
+                                                   const char *path) {
+  return curl_easy_setopt(handle, CURLOPT_UNIX_SOCKET_PATH, path);
+}
+
+CURLcode CurlLibrary::easy_setopt_url(CURL *handle, const char *url) {
+  return curl_easy_setopt(handle, CURLOPT_URL, url);
+}
+
+CURLcode CurlLibrary::easy_setopt_writedata(CURL *handle, void *data) {
+  return curl_easy_setopt(handle, CURLOPT_WRITEDATA, data);
+}
+
+CURLcode CurlLibrary::easy_setopt_writefunction(CURL *handle,
+                                                WriteCallback on_write) {
+  return curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, on_write);
+}
+
+const char *CurlLibrary::easy_strerror(CURLcode error) {
+  return curl_easy_strerror(error);
+}
+
+void CurlLibrary::global_cleanup() { curl_global_cleanup(); }
+
+CURLcode CurlLibrary::global_init(long flags) {
+  return curl_global_init(flags);
+}
+
+CURLMcode CurlLibrary::multi_add_handle(CURLM *multi_handle,
+                                        CURL *easy_handle) {
+  return curl_multi_add_handle(multi_handle, easy_handle);
+}
+
+CURLMcode CurlLibrary::multi_cleanup(CURLM *multi_handle) {
+  return curl_multi_cleanup(multi_handle);
+}
+
+CURLMsg *CurlLibrary::multi_info_read(CURLM *multi_handle, int *msgs_in_queue) {
+  return curl_multi_info_read(multi_handle, msgs_in_queue);
+}
+
+CURLM *CurlLibrary::multi_init() { return curl_multi_init(); }
+
+CURLMcode CurlLibrary::multi_perform(CURLM *multi_handle,
+                                     int *running_handles) {
+  return curl_multi_perform(multi_handle, running_handles);
+}
+
+CURLMcode CurlLibrary::multi_poll(CURLM *multi_handle, curl_waitfd extra_fds[],
+                                  unsigned extra_nfds, int timeout_ms,
+                                  int *numfds) {
+  return curl_multi_poll(multi_handle, extra_fds, extra_nfds, timeout_ms,
+                         numfds);
+}
+
+CURLMcode CurlLibrary::multi_remove_handle(CURLM *multi_handle,
+                                           CURL *easy_handle) {
+  return curl_multi_remove_handle(multi_handle, easy_handle);
+}
+
+const char *CurlLibrary::multi_strerror(CURLMcode error) {
+  return curl_multi_strerror(error);
+}
+
+CURLMcode CurlLibrary::multi_wakeup(CURLM *multi_handle) {
+  return curl_multi_wakeup(multi_handle);
+}
+
+curl_slist *CurlLibrary::slist_append(curl_slist *list, const char *string) {
+  return curl_slist_append(list, string);
+}
+
+void CurlLibrary::slist_free_all(curl_slist *list) {
+  curl_slist_free_all(list);
+}
 
 using ErrorHandler = HTTPClient::ErrorHandler;
 using HeadersSetter = HTTPClient::HeadersSetter;
@@ -33,7 +160,8 @@ using URL = HTTPClient::URL;
 
 class CurlImpl {
   std::mutex mutex_;
-  std::shared_ptr<Logger> logger_;
+  CurlLibrary &curl_;
+  const std::shared_ptr<Logger> logger_;
   CURLM *multi_handle_;
   std::unordered_set<CURL *> request_handles_;
   std::list<CURL *> new_handles_;
@@ -43,6 +171,7 @@ class CurlImpl {
   std::thread event_loop_;
 
   struct Request {
+    CurlLibrary *curl = nullptr;
     curl_slist *request_headers = nullptr;
     std::string request_body;
     ResponseHandler on_response;
@@ -57,8 +186,10 @@ class CurlImpl {
   class HeaderWriter : public DictWriter {
     curl_slist *list_ = nullptr;
     std::string buffer_;
+    CurlLibrary &curl_;
 
    public:
+    explicit HeaderWriter(CurlLibrary &curl);
     ~HeaderWriter();
     curl_slist *release();
     void set(StringView key, StringView value) override;
@@ -90,7 +221,8 @@ class CurlImpl {
   static StringView trim(StringView);
 
  public:
-  explicit CurlImpl(const std::shared_ptr<Logger> &logger);
+  explicit CurlImpl(const std::shared_ptr<Logger> &, CurlLibrary &,
+                    const Curl::ThreadGenerator &);
   ~CurlImpl();
 
   Expected<void> post(const URL &url, HeadersSetter set_headers,
@@ -110,8 +242,15 @@ void throw_on_error(CURLcode result) {
 
 }  // namespace
 
-Curl::Curl(const std::shared_ptr<Logger> &logger)
-    : impl_(new CurlImpl{logger}) {}
+Curl::Curl(const std::shared_ptr<Logger> &logger) : Curl(logger, libcurl) {}
+
+Curl::Curl(const std::shared_ptr<Logger> &logger, CurlLibrary &curl)
+    : Curl(logger, curl,
+           [](auto &&func) { return std::thread(std::move(func)); }) {}
+
+Curl::Curl(const std::shared_ptr<Logger> &logger, CurlLibrary &curl,
+           const Curl::ThreadGenerator &make_thread)
+    : impl_(new CurlImpl{logger, curl, make_thread}) {}
 
 Curl::~Curl() { delete impl_; }
 
@@ -129,10 +268,14 @@ nlohmann::json Curl::config_json() const {
   return nlohmann::json::object({{"type", "datadog::tracing::Curl"}});
 }
 
-CurlImpl::CurlImpl(const std::shared_ptr<Logger> &logger)
-    : logger_(logger), shutting_down_(false), num_active_handles_(0) {
-  curl_global_init(CURL_GLOBAL_ALL);
-  multi_handle_ = curl_multi_init();
+CurlImpl::CurlImpl(const std::shared_ptr<Logger> &logger, CurlLibrary &curl,
+                   const Curl::ThreadGenerator &make_thread)
+    : curl_(curl),
+      logger_(logger),
+      shutting_down_(false),
+      num_active_handles_(0) {
+  curl_.global_init(CURL_GLOBAL_ALL);
+  multi_handle_ = curl_.multi_init();
   if (multi_handle_ == nullptr) {
     logger_->log_error(Error{
         Error::CURL_HTTP_CLIENT_SETUP_FAILED,
@@ -141,15 +284,15 @@ CurlImpl::CurlImpl(const std::shared_ptr<Logger> &logger)
   }
 
   try {
-    event_loop_ = std::thread([this]() { run(); });
+    event_loop_ = make_thread([this]() { run(); });
   } catch (const std::system_error &error) {
     logger_->log_error(
         Error{Error::CURL_HTTP_CLIENT_SETUP_FAILED, error.what()});
 
     // Usually the worker thread would do this, but since the thread failed to
     // start, do it here.
-    (void)curl_multi_cleanup(multi_handle_);
-    curl_global_cleanup();
+    (void)curl_.multi_cleanup(multi_handle_);
+    curl_.global_cleanup();
 
     // Mark this object as not working.
     multi_handle_ = nullptr;
@@ -166,7 +309,7 @@ CurlImpl::~CurlImpl() {
     std::lock_guard<std::mutex> lock(mutex_);
     shutting_down_ = true;
   }
-  log_on_error(curl_multi_wakeup(multi_handle_));
+  log_on_error(curl_.multi_wakeup(multi_handle_));
   event_loop_.join();
 }
 
@@ -182,58 +325,54 @@ Expected<void> CurlImpl::post(const HTTPClient::URL &url,
 
   auto request = std::make_unique<Request>();
 
+  request->curl = &curl_;
   request->request_body = std::move(body);
   request->on_response = std::move(on_response);
   request->on_error = std::move(on_error);
 
-  std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> handle{
-      curl_easy_init(), &curl_easy_cleanup};
+  auto cleanup_handle = [&](auto handle) { curl_.easy_cleanup(handle); };
+  std::unique_ptr<CURL, decltype(cleanup_handle)> handle{
+      curl_.easy_init(), std::move(cleanup_handle)};
 
   if (!handle) {
     return Error{Error::CURL_REQUEST_SETUP_FAILED,
                  "unable to initialize a curl handle for request sending"};
   }
 
-  // throw_on_error(curl_easy_setopt(handle.get(), CURLOPT_VERBOSE, 1));
-
+  throw_on_error(curl_.easy_setopt_private(handle.get(), request.get()));
   throw_on_error(
-      curl_easy_setopt(handle.get(), CURLOPT_PRIVATE, request.get()));
-  throw_on_error(curl_easy_setopt(handle.get(), CURLOPT_ERRORBUFFER,
-                                  request->error_buffer));
-  throw_on_error(curl_easy_setopt(handle.get(), CURLOPT_POST, 1));
-  throw_on_error(curl_easy_setopt(handle.get(), CURLOPT_POSTFIELDSIZE,
-                                  request->request_body.size()));
-  throw_on_error(curl_easy_setopt(handle.get(), CURLOPT_POSTFIELDS,
-                                  request->request_body.data()));
+      curl_.easy_setopt_errorbuffer(handle.get(), request->error_buffer));
+  throw_on_error(curl_.easy_setopt_post(handle.get(), 1));
+  throw_on_error(curl_.easy_setopt_postfieldsize(handle.get(),
+                                                 request->request_body.size()));
   throw_on_error(
-      curl_easy_setopt(handle.get(), CURLOPT_HEADERFUNCTION, &on_read_header));
+      curl_.easy_setopt_postfields(handle.get(), request->request_body.data()));
   throw_on_error(
-      curl_easy_setopt(handle.get(), CURLOPT_HEADERDATA, request.get()));
-  throw_on_error(
-      curl_easy_setopt(handle.get(), CURLOPT_WRITEFUNCTION, &on_read_body));
-  throw_on_error(
-      curl_easy_setopt(handle.get(), CURLOPT_WRITEDATA, request.get()));
+      curl_.easy_setopt_headerfunction(handle.get(), &on_read_header));
+  throw_on_error(curl_.easy_setopt_headerdata(handle.get(), request.get()));
+  throw_on_error(curl_.easy_setopt_writefunction(handle.get(), &on_read_body));
+  throw_on_error(curl_.easy_setopt_writedata(handle.get(), request.get()));
   if (url.scheme == "unix" || url.scheme == "http+unix" ||
       url.scheme == "https+unix") {
-    throw_on_error(curl_easy_setopt(handle.get(), CURLOPT_UNIX_SOCKET_PATH,
-                                    url.authority.c_str()));
+    throw_on_error(curl_.easy_setopt_unix_socket_path(handle.get(),
+                                                      url.authority.c_str()));
     // The authority section of the URL is ignored when a unix domain socket is
     // to be used.
-    throw_on_error(curl_easy_setopt(handle.get(), CURLOPT_URL,
-                                    ("http://localhost" + url.path).c_str()));
+    throw_on_error(curl_.easy_setopt_url(
+        handle.get(), ("http://localhost" + url.path).c_str()));
   } else {
-    throw_on_error(curl_easy_setopt(
-        handle.get(), CURLOPT_URL,
-        (url.scheme + "://" + url.authority + url.path).c_str()));
+    throw_on_error(curl_.easy_setopt_url(
+        handle.get(), (url.scheme + "://" + url.authority + url.path).c_str()));
   }
 
-  HeaderWriter writer;
+  HeaderWriter writer{curl_};
   set_headers(writer);
-  std::unique_ptr<curl_slist, decltype(&curl_slist_free_all)> headers{
-      writer.release(), &curl_slist_free_all};
+  auto cleanup_list = [&](auto list) { curl_.slist_free_all(list); };
+  std::unique_ptr<curl_slist, decltype(cleanup_list)> headers{
+      writer.release(), std::move(cleanup_list)};
   request->request_headers = headers.get();
-  throw_on_error(curl_easy_setopt(handle.get(), CURLOPT_HTTPHEADER,
-                                  request->request_headers));
+  throw_on_error(
+      curl_.easy_setopt_httpheader(handle.get(), request->request_headers));
 
   std::list<CURL *> node;
   node.push_back(handle.get());
@@ -245,11 +384,11 @@ Expected<void> CurlImpl::post(const HTTPClient::URL &url,
     handle.release();
     request.release();
   }
-  log_on_error(curl_multi_wakeup(multi_handle_));
+  log_on_error(curl_.multi_wakeup(multi_handle_));
 
   return nullopt;
 } catch (CURLcode error) {
-  return Error{Error::CURL_REQUEST_SETUP_FAILED, curl_easy_strerror(error)};
+  return Error{Error::CURL_REQUEST_SETUP_FAILED, curl_.easy_strerror(error)};
 }
 
 void CurlImpl::drain(std::chrono::steady_clock::time_point deadline) {
@@ -309,7 +448,7 @@ std::size_t CurlImpl::on_read_body(char *data, std::size_t, std::size_t length,
 CURLcode CurlImpl::log_on_error(CURLcode result) {
   if (result != CURLE_OK) {
     logger_->log_error(
-        Error{Error::CURL_HTTP_CLIENT_ERROR, curl_easy_strerror(result)});
+        Error{Error::CURL_HTTP_CLIENT_ERROR, curl_.easy_strerror(result)});
   }
   return result;
 }
@@ -317,7 +456,7 @@ CURLcode CurlImpl::log_on_error(CURLcode result) {
 CURLMcode CurlImpl::log_on_error(CURLMcode result) {
   if (result != CURLM_OK) {
     logger_->log_error(
-        Error{Error::CURL_HTTP_CLIENT_ERROR, curl_multi_strerror(result)});
+        Error{Error::CURL_HTTP_CLIENT_ERROR, curl_.multi_strerror(result)});
   }
   return result;
 }
@@ -328,28 +467,28 @@ void CurlImpl::run() {
   std::unique_lock<std::mutex> lock(mutex_);
 
   for (;;) {
-    log_on_error(curl_multi_perform(multi_handle_, &num_active_handles_));
+    log_on_error(curl_.multi_perform(multi_handle_, &num_active_handles_));
     if (num_active_handles_ == 0) {
       no_requests_.notify_all();
     }
 
     // If a request is done or errored out, curl will enqueue a "message" for
     // us to handle.  Handle any pending messages.
-    while ((message =
-                curl_multi_info_read(multi_handle_, &num_messages_remaining))) {
+    while ((message = curl_.multi_info_read(multi_handle_,
+                                            &num_messages_remaining))) {
       handle_message(*message);
     }
 
     const int max_wait_milliseconds = 10 * 1000;
     lock.unlock();
-    log_on_error(curl_multi_poll(multi_handle_, nullptr, 0,
-                                 max_wait_milliseconds, nullptr));
+    log_on_error(curl_.multi_poll(multi_handle_, nullptr, 0,
+                                  max_wait_milliseconds, nullptr));
     lock.lock();
 
     // New requests might have been added while we were sleeping.
     for (; !new_handles_.empty(); new_handles_.pop_front()) {
       CURL *const handle = new_handles_.front();
-      log_on_error(curl_multi_add_handle(multi_handle_, handle));
+      log_on_error(curl_.multi_add_handle(multi_handle_, handle));
       request_handles_.insert(handle);
     }
 
@@ -361,17 +500,17 @@ void CurlImpl::run() {
   // We're shutting down.  Clean up any remaining request handles.
   for (const auto &handle : request_handles_) {
     char *user_data;
-    if (log_on_error(curl_easy_getinfo(handle, CURLINFO_PRIVATE, &user_data)) ==
+    if (log_on_error(curl_.easy_getinfo_private(handle, &user_data)) ==
         CURLE_OK) {
       delete reinterpret_cast<Request *>(user_data);
     }
 
-    log_on_error(curl_multi_remove_handle(multi_handle_, handle));
+    log_on_error(curl_.multi_remove_handle(multi_handle_, handle));
   }
 
   request_handles_.clear();
-  log_on_error(curl_multi_cleanup(multi_handle_));
-  curl_global_cleanup();
+  log_on_error(curl_.multi_cleanup(multi_handle_));
+  curl_.global_cleanup();
 }
 
 void CurlImpl::handle_message(const CURLMsg &message) {
@@ -381,8 +520,8 @@ void CurlImpl::handle_message(const CURLMsg &message) {
 
   auto *const request_handle = message.easy_handle;
   char *user_data;
-  if (log_on_error(curl_easy_getinfo(request_handle, CURLINFO_PRIVATE,
-                                     &user_data)) != CURLE_OK) {
+  if (log_on_error(curl_.easy_getinfo_private(request_handle, &user_data)) !=
+      CURLE_OK) {
     return;
   }
   auto &request = *reinterpret_cast<Request *>(user_data);
@@ -393,15 +532,15 @@ void CurlImpl::handle_message(const CURLMsg &message) {
   if (result != CURLE_OK) {
     std::string error_message;
     error_message += "Error sending request with libcurl (";
-    error_message += curl_easy_strerror(result);
+    error_message += curl_.easy_strerror(result);
     error_message += "): ";
     error_message += request.error_buffer;
     request.on_error(
         Error{Error::CURL_REQUEST_FAILURE, std::move(error_message)});
   } else {
     long status;
-    if (log_on_error(curl_easy_getinfo(request_handle, CURLINFO_RESPONSE_CODE,
-                                       &status)) != CURLE_OK) {
+    if (log_on_error(curl_.easy_getinfo_response_code(request_handle,
+                                                      &status)) != CURLE_OK) {
       status = -1;
     }
     HeaderReader reader(&request.response_headers_lower);
@@ -409,15 +548,17 @@ void CurlImpl::handle_message(const CURLMsg &message) {
                         std::move(request.response_body));
   }
 
-  log_on_error(curl_multi_remove_handle(multi_handle_, request_handle));
-  curl_easy_cleanup(request_handle);
+  log_on_error(curl_.multi_remove_handle(multi_handle_, request_handle));
+  curl_.easy_cleanup(request_handle);
   request_handles_.erase(request_handle);
   delete &request;
 }
 
-CurlImpl::Request::~Request() { curl_slist_free_all(request_headers); }
+CurlImpl::Request::~Request() { curl->slist_free_all(request_headers); }
 
-CurlImpl::HeaderWriter::~HeaderWriter() { curl_slist_free_all(list_); }
+CurlImpl::HeaderWriter::HeaderWriter(CurlLibrary &curl) : curl_(curl) {}
+
+CurlImpl::HeaderWriter::~HeaderWriter() { curl_.slist_free_all(list_); }
 
 curl_slist *CurlImpl::HeaderWriter::release() {
   auto list = list_;
@@ -431,7 +572,7 @@ void CurlImpl::HeaderWriter::set(StringView key, StringView value) {
   buffer_ += ": ";
   buffer_ += value;
 
-  list_ = curl_slist_append(list_, buffer_.c_str());
+  list_ = curl_.slist_append(list_, buffer_.c_str());
 }
 
 CurlImpl::HeaderReader::HeaderReader(

--- a/src/datadog/curl.h
+++ b/src/datadog/curl.h
@@ -9,9 +9,13 @@
 //
 // [1]: https://curl.se/libcurl/
 
+#include <curl/curl.h>
+
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "http_client.h"
 #include "json_fwd.hpp"
@@ -19,19 +23,77 @@
 namespace datadog {
 namespace tracing {
 
+// `class CurlLibrary` has one member function for every libcurl function used
+// in the implementation of this component.
+//
+// The naming convention is that `CurlLibrary::foo_bar` corresponds to
+// `curl_foo_bar`, with the exception of `curl_easy_getinfo` and
+// `curl_easy_setopt`. `curl_easy_getinfo` and `curl_easy_setopt` have multiple
+// corresponding member functions -- one for each `CURLINFO` value or
+// `CURLoption` value, respectively.
+//
+// The default implementations forward to their libcurl counterparts.  Unit
+// tests override some of the member functions.
+class CurlLibrary {
+ public:
+  typedef size_t (*WriteCallback)(char *ptr, size_t size, size_t nmemb,
+                                  void *userdata);
+  typedef size_t (*HeaderCallback)(char *buffer, size_t size, size_t nitems,
+                                   void *userdata);
+
+  virtual ~CurlLibrary() = default;
+
+  virtual void easy_cleanup(CURL *handle);
+  virtual CURL *easy_init();
+  virtual CURLcode easy_getinfo_private(CURL *curl, char **user_data);
+  virtual CURLcode easy_getinfo_response_code(CURL *curl, long *code);
+  virtual CURLcode easy_setopt_errorbuffer(CURL *handle, char *buffer);
+  virtual CURLcode easy_setopt_headerdata(CURL *handle, void *data);
+  virtual CURLcode easy_setopt_headerfunction(CURL *handle, HeaderCallback);
+  virtual CURLcode easy_setopt_httpheader(CURL *handle, curl_slist *headers);
+  virtual CURLcode easy_setopt_post(CURL *handle, long post);
+  virtual CURLcode easy_setopt_postfields(CURL *handle, const char *data);
+  virtual CURLcode easy_setopt_postfieldsize(CURL *handle, long size);
+  virtual CURLcode easy_setopt_private(CURL *handle, void *pointer);
+  virtual CURLcode easy_setopt_unix_socket_path(CURL *handle, const char *path);
+  virtual CURLcode easy_setopt_url(CURL *handle, const char *url);
+  virtual CURLcode easy_setopt_writedata(CURL *handle, void *data);
+  virtual CURLcode easy_setopt_writefunction(CURL *handle, WriteCallback);
+  virtual const char *easy_strerror(CURLcode error);
+  virtual void global_cleanup();
+  virtual CURLcode global_init(long flags);
+  virtual CURLMcode multi_add_handle(CURLM *multi_handle, CURL *easy_handle);
+  virtual CURLMcode multi_cleanup(CURLM *multi_handle);
+  virtual CURLMsg *multi_info_read(CURLM *multi_handle, int *msgs_in_queue);
+  virtual CURLM *multi_init();
+  virtual CURLMcode multi_perform(CURLM *multi_handle, int *running_handles);
+  virtual CURLMcode multi_poll(CURLM *multi_handle, curl_waitfd extra_fds[],
+                               unsigned extra_nfds, int timeout_ms,
+                               int *numfds);
+  virtual CURLMcode multi_remove_handle(CURLM *multi_handle, CURL *easy_handle);
+  virtual const char *multi_strerror(CURLMcode error);
+  virtual CURLMcode multi_wakeup(CURLM *multi_handle);
+  virtual curl_slist *slist_append(curl_slist *list, const char *string);
+  virtual void slist_free_all(curl_slist *list);
+};
+
 class CurlImpl;
 class Logger;
 
 class Curl : public HTTPClient {
-  CurlImpl* impl_;
+  CurlImpl *impl_;
 
  public:
-  explicit Curl(const std::shared_ptr<Logger>& logger);
+  using ThreadGenerator = std::function<std::thread(std::function<void()> &&)>;
+
+  explicit Curl(const std::shared_ptr<Logger> &);
+  Curl(const std::shared_ptr<Logger> &, CurlLibrary &);
+  Curl(const std::shared_ptr<Logger> &, CurlLibrary &, const ThreadGenerator &);
   ~Curl();
 
-  Curl(const Curl&) = delete;
+  Curl(const Curl &) = delete;
 
-  Expected<void> post(const URL& url, HeadersSetter set_headers,
+  Expected<void> post(const URL &url, HeadersSetter set_headers,
                       std::string body, ResponseHandler on_response,
                       ErrorHandler on_error) override;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,12 +12,13 @@ add_executable(tests
     mocks/event_schedulers.cpp
     mocks/http_clients.cpp
     mocks/loggers.cpp
-    
+
     # utilities
     matchers.cpp
-    
+
     # test cases
     test_cerr_logger.cpp
+    test_curl.cpp
     test_datadog_agent.cpp
     test_glob.cpp
     test_limiter.cpp

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -8,4 +8,10 @@ std::ostream& operator<<(
   return stream << '{' << item.first << ", " << item.second << '}';
 }
 
+std::ostream& operator<<(
+    std::ostream& stream,
+    const datadog::tracing::Optional<datadog::tracing::StringView>& item) {
+  return stream << item.value_or("<null>");
+}
+
 }  // namespace std

--- a/test/test.h
+++ b/test/test.h
@@ -7,6 +7,8 @@
 #define CATCH_CONFIG_CPP17_BYTE
 
 #include <datadog/expected.h>
+#include <datadog/optional.h>
+#include <datadog/string_view.h>
 
 #include <iosfwd>
 #include <string>
@@ -18,6 +20,10 @@ namespace std {
 
 std::ostream& operator<<(std::ostream& stream,
                          const std::pair<const std::string, std::string>& item);
+
+std::ostream& operator<<(
+    std::ostream& stream,
+    const datadog::tracing::Optional<datadog::tracing::StringView>& item);
 
 }  // namespace std
 

--- a/test/test_curl.cpp
+++ b/test/test_curl.cpp
@@ -1,0 +1,350 @@
+#include <curl/curl.h>
+#include <datadog/curl.h>
+#include <datadog/dict_reader.h>
+#include <datadog/error.h>
+#include <datadog/optional.h>
+#include <datadog/tracer.h>
+#include <datadog/tracer_config.h>
+
+#include <chrono>
+#include <exception>
+#include <system_error>
+
+#include "mocks/loggers.h"
+#include "test.h"
+
+using namespace datadog::tracing;
+
+TEST_CASE("parse response headers and body") {
+  class MockCurlLibrary : public CurlLibrary {
+    void *user_data_on_header_ = nullptr;
+    HeaderCallback on_header_ = nullptr;
+    void *user_data_on_write_ = nullptr;
+    WriteCallback on_write_ = nullptr;
+    CURL *handle_ = nullptr;
+    CURLMsg message_;
+
+    CURLcode easy_getinfo_response_code(CURL *, long *code) override {
+      *code = 200;
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_headerdata(CURL *, void *data) override {
+      user_data_on_header_ = data;
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_headerfunction(CURL *,
+                                        HeaderCallback on_header) override {
+      on_header_ = on_header;
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_writedata(CURL *, void *data) override {
+      user_data_on_write_ = data;
+      return CURLE_OK;
+    }
+
+    CURLcode easy_setopt_writefunction(CURL *,
+                                       WriteCallback on_write) override {
+      on_write_ = on_write;
+      return CURLE_OK;
+    }
+    CURLMcode multi_add_handle(CURLM *, CURL *easy_handle) override {
+      handle_ = easy_handle;
+      return CURLM_OK;
+    }
+    CURLMsg *multi_info_read(CURLM *, int *msgs_in_queue) override {
+      *msgs_in_queue = handle_ != nullptr;
+      if (*msgs_in_queue == 0) {
+        return nullptr;
+      }
+      message_.msg = CURLMSG_DONE;
+      message_.easy_handle = handle_;
+      message_.data.result = CURLE_OK;
+      return &message_;
+    }
+    CURLMcode multi_perform(CURLM *, int *running_handles) override {
+      if (!handle_) {
+        *running_handles = 0;
+        return CURLM_OK;
+      }
+
+      // If any of these `REQUIRE`s fail, an exception will be thrown and the
+      // test will abort. The runtime will print the exception first, though.
+      REQUIRE(on_header_);
+      REQUIRE(user_data_on_header_);
+      *running_handles = 1;
+      std::string header = "200 OK";
+      REQUIRE(on_header_(header.data(), 1, header.size(),
+                         user_data_on_header_) == header.size());
+      header = "Foo-Bar: baz";
+      REQUIRE(on_header_(header.data(), 1, header.size(),
+                         user_data_on_header_) == header.size());
+      header = "BOOM-BOOM: boom, boom, boom, boom    ";
+      REQUIRE(on_header_(header.data(), 1, header.size(),
+                         user_data_on_header_) == header.size());
+      header = "BOOM-boom: ignored";
+      REQUIRE(on_header_(header.data(), 1, header.size(),
+                         user_data_on_header_) == header.size());
+
+      REQUIRE(on_write_);
+      REQUIRE(user_data_on_write_);
+      std::string body = "{\"message\": \"Dogs don't know it's not libcurl!\"}";
+      // Send the body in two pieces.
+      REQUIRE(on_write_(body.data(), 1, body.size() / 2, user_data_on_write_) ==
+              body.size() / 2);
+      const auto remaining = body.size() - (body.size() / 2);
+      REQUIRE(on_write_(body.data() + body.size() / 2, 1, remaining,
+                        user_data_on_write_) == remaining);
+
+      return CURLM_OK;
+    }
+    CURLMcode multi_remove_handle(CURLM *, CURL *easy_handle) override {
+      REQUIRE(easy_handle == handle_);
+      handle_ = nullptr;
+      return CURLM_OK;
+    }
+  };
+
+  const auto logger = std::make_shared<MockLogger>();
+  MockCurlLibrary library;
+  const auto client = std::make_shared<Curl>(logger, library);
+
+  SECTION("in the tracer") {
+    // The tracer doesn't read response headers, at least as of this writing.
+    // It's still good to test that everything works with this mock
+    // `CurlLibrary` in place, though.
+    TracerConfig config;
+    config.defaults.service = "testsvc";
+    config.logger = logger;
+    config.agent.http_client = client;
+
+    const auto finalized = finalize_config(config);
+    REQUIRE(finalized);
+    Tracer tracer{*finalized};
+
+    (void)tracer.create_span();
+    // The rest runs as everything in this scope is destroyed.
+  }
+
+  SECTION("by hand") {
+    // Without using a tracer, just make a request using `Curl::post`, and
+    // verify that the received response headers are as expected.
+    Optional<Error> post_error;
+    std::exception_ptr exception;
+    const HTTPClient::URL url = {"http", "whatever", ""};
+    const auto result = client->post(
+        url, [](const auto &) {}, "whatever",
+        [&](int status, const DictReader &headers, std::string body) {
+          try {
+            REQUIRE(status == 200);
+            REQUIRE(headers.lookup("foo-bar") == "baz");
+            REQUIRE(headers.lookup("boom-boom") == "boom, boom, boom, boom");
+            REQUIRE_FALSE(headers.lookup("snafu"));
+            headers.visit([](StringView key, StringView value) {
+              if (key == "foo-bar") {
+                REQUIRE(value == "baz");
+              } else {
+                REQUIRE(key == "boom-boom");
+                REQUIRE(value == "boom, boom, boom, boom");
+              }
+            });
+
+            REQUIRE(body ==
+                    "{\"message\": \"Dogs don't know it's not libcurl!\"}");
+          } catch (...) {
+            exception = std::current_exception();
+          }
+        },
+        [&](const Error &error) { post_error = error; });
+
+    REQUIRE(result);
+    client->drain(std::chrono::steady_clock::now() + std::chrono::seconds(1));
+    if (exception) {
+      std::rethrow_exception(exception);
+    }
+    REQUIRE_FALSE(post_error);
+  }
+}
+
+TEST_CASE("bad multi-handle means error mode") {
+  // If libcurl fails to allocate a multi-handle, then the HTTP client enters a
+  // mode where calls to `post` always return an error.
+  class MockCurlLibrary : public CurlLibrary {
+    CURLM *multi_init() override { return nullptr; }
+  };
+
+  const auto logger = std::make_shared<MockLogger>();
+  MockCurlLibrary library;
+  const auto client = std::make_shared<Curl>(logger, library);
+  REQUIRE(logger->first_error().code == Error::CURL_HTTP_CLIENT_SETUP_FAILED);
+
+  const auto ignore = [](auto &&...) {};
+  const HTTPClient::URL url = {"http", "whatever", ""};
+  const auto result = client->post(url, ignore, "dummy body", ignore, ignore);
+  REQUIRE_FALSE(result);
+  REQUIRE(result.error().code == Error::CURL_HTTP_CLIENT_NOT_RUNNING);
+}
+
+TEST_CASE("bad std::thread means error mode") {
+  // If `Curl` is unable to start its event loop thread, then it enters a mode
+  // where calls to `post` always return an error.
+  const auto logger = std::make_shared<MockLogger>();
+  CurlLibrary libcurl;  // the default implementation
+  const auto client =
+      std::make_shared<Curl>(logger, libcurl, [](auto &&) -> std::thread {
+        throw std::system_error(
+            std::make_error_code(std::errc::resource_unavailable_try_again));
+      });
+  REQUIRE(logger->first_error().code == Error::CURL_HTTP_CLIENT_SETUP_FAILED);
+
+  const auto ignore = [](auto &&...) {};
+  const HTTPClient::URL url = {"http", "whatever", ""};
+  const auto result = client->post(url, ignore, "dummy body", ignore, ignore);
+  REQUIRE_FALSE(result);
+  REQUIRE(result.error().code == Error::CURL_HTTP_CLIENT_NOT_RUNNING);
+}
+
+TEST_CASE("fail to allocate request handle") {
+  // Each call to `Curl::post` allocates a new "easy handle."  If that fails,
+  // then `post` immediately returns an error.
+  class MockCurlLibrary : public CurlLibrary {
+    CURL *easy_init() override { return nullptr; }
+  };
+
+  const auto logger = std::make_shared<NullLogger>();
+  MockCurlLibrary library;
+  const auto client = std::make_shared<Curl>(logger, library);
+
+  const auto ignore = [](auto &&...) {};
+  const HTTPClient::URL url = {"http", "whatever", ""};
+  const auto result = client->post(url, ignore, "dummy body", ignore, ignore);
+  REQUIRE_FALSE(result);
+  REQUIRE(result.error().code == Error::CURL_REQUEST_SETUP_FAILED);
+}
+
+// CURLoption
+
+TEST_CASE("setopt failures") {
+  // Each call to `Curl::post` allocates a new "easy handle" and sets various
+  // options on it.  Any of those setters can fail.  When one does, `post`
+  // immediately returns an error.
+  class MockCurlLibrary : public CurlLibrary {
+   public:
+    CURLoption fail = CURLOPT_LASTENTRY;
+    CURLcode error = CURLE_OUT_OF_MEMORY;
+
+    CURLcode easy_setopt_errorbuffer(CURL *, char *) override {
+      if (fail == CURLOPT_ERRORBUFFER) {
+        return error;
+      }
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_headerdata(CURL *, void *) override {
+      if (fail == CURLOPT_HEADERDATA) {
+        return error;
+      }
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_headerfunction(CURL *, HeaderCallback) override {
+      if (fail == CURLOPT_HEADERFUNCTION) {
+        return error;
+      }
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_httpheader(CURL *, curl_slist *) override {
+      if (fail == CURLOPT_HTTPHEADER) {
+        return error;
+      }
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_post(CURL *, long) override {
+      if (fail == CURLOPT_POST) {
+        return error;
+      }
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_postfields(CURL *, const char *) override {
+      if (fail == CURLOPT_POSTFIELDS) {
+        return error;
+      }
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_postfieldsize(CURL *, long) override {
+      if (fail == CURLOPT_POSTFIELDSIZE) {
+        return error;
+      }
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_private(CURL *, void *) override {
+      if (fail == CURLOPT_PRIVATE) {
+        return error;
+      }
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_unix_socket_path(CURL *, const char *) override {
+      if (fail == CURLOPT_UNIX_SOCKET_PATH) {
+        return error;
+      }
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_url(CURL *, const char *) override {
+      if (fail == CURLOPT_URL) {
+        return error;
+      }
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_writedata(CURL *, void *) override {
+      if (fail == CURLOPT_WRITEDATA) {
+        return error;
+      }
+      return CURLE_OK;
+    }
+    CURLcode easy_setopt_writefunction(CURL *, WriteCallback) override {
+      if (fail == CURLOPT_WRITEFUNCTION) {
+        return error;
+      }
+      return CURLE_OK;
+    }
+  };
+
+  struct TestCase {
+    CURLoption which_fails;
+    std::string name;
+  };
+
+#define CASE(OPTION) \
+  { OPTION, #OPTION }
+
+  const auto &[which_fails, name] = GENERATE(
+      values<TestCase>({CASE(CURLOPT_ERRORBUFFER), CASE(CURLOPT_HEADERDATA),
+                        CASE(CURLOPT_HEADERFUNCTION), CASE(CURLOPT_HTTPHEADER),
+                        CASE(CURLOPT_POST), CASE(CURLOPT_POSTFIELDS),
+                        CASE(CURLOPT_POSTFIELDSIZE), CASE(CURLOPT_PRIVATE),
+                        CASE(CURLOPT_UNIX_SOCKET_PATH), CASE(CURLOPT_URL),
+                        CASE(CURLOPT_WRITEDATA), CASE(CURLOPT_WRITEFUNCTION)}));
+
+#undef CASE
+
+  CAPTURE(name);
+  MockCurlLibrary library;
+  library.fail = which_fails;
+
+  const auto logger = std::make_shared<NullLogger>();
+  const auto client = std::make_shared<Curl>(logger, library);
+
+  const auto ignore = [](auto &&...) {};
+  HTTPClient::URL url;
+  if (which_fails == CURLOPT_UNIX_SOCKET_PATH) {
+    url.scheme = "unix";
+    url.path = "/foo/bar.sock";
+  } else {
+    url.scheme = "http";
+    url.authority = "localhost";
+    url.path = "/trace/thing";
+  }
+  const auto result = client->post(url, ignore, "dummy body", ignore, ignore);
+  REQUIRE_FALSE(result);
+  REQUIRE(result.error().code == Error::CURL_REQUEST_SETUP_FAILED);
+}
+
+// TODO: "multi_*" failures
+// TODO: "getinfo" failures

--- a/test/test_curl.cpp
+++ b/test/test_curl.cpp
@@ -221,8 +221,6 @@ TEST_CASE("fail to allocate request handle") {
   REQUIRE(result.error().code == Error::CURL_REQUEST_SETUP_FAILED);
 }
 
-// CURLoption
-
 TEST_CASE("setopt failures") {
   // Each call to `Curl::post` allocates a new "easy handle" and sets various
   // options on it.  Any of those setters can fail.  When one does, `post`


### PR DESCRIPTION
Envoy doesn't use `class Curl`, but `nginx-datadog` probably will.

This was one of the least tested components of the library.