### PR TITLE
more Span accessors, for use in Envoy's unit tests

### DIFF
--- a/src/datadog/span.cpp
+++ b/src/datadog/span.cpp
@@ -76,6 +76,14 @@ TimePoint Span::start_time() const { return data_->start; }
 
 bool Span::error() const { return data_->error; }
 
+const std::string& Span::service_name() const { return data_->service; }
+
+const std::string& Span::service_type() const { return data_->service_type; }
+
+const std::string& Span::name() const { return data_->name; }
+
+const std::string& Span::resource_name() const { return data_->resource; }
+
 Optional<StringView> Span::lookup_tag(StringView name) const {
   if (tags::is_internal(name)) {
     return nullopt;

--- a/src/datadog/span.h
+++ b/src/datadog/span.h
@@ -106,6 +106,17 @@ class Span {
   // Return whether this span has been marked as an error having occurred during
   // its extent.
   bool error() const;
+  // Return the name of the service associated with this span, e.g.
+  // "ingress-nginx-useast1".
+  const std::string& service_name() const;
+  // Return the type of the service associated with this span, e.g. "web".
+  const std::string& service_type() const;
+  // Return the name of the operation associated with the operation that this
+  // span represents, e.g. "handle.request", "execute.query", or "healthcheck".
+  const std::string& name() const;
+  // Return the name of the resource associated with the operation that this
+  // span represents, e.g. "/api/v1/info" or "select count(*) from users".
+  const std::string& resource_name() const;
 
   // Return the value of the tag having the specified `name`, or return null if
   // there is no such tag.

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -303,7 +303,10 @@ TEST_CASE(".error() and .set_error*()") {
   }
 }
 
-TEST_CASE("property setters") {
+TEST_CASE("property setters and getters") {
+  // Verify that modifications made by `Span::set_...` are visible both in the
+  // corresponding getter method and in the resulting span data sent to the
+  // collector.
   TracerConfig config;
   config.defaults.service = "testsvc";
   auto collector = std::make_shared<MockCollector>();
@@ -318,6 +321,7 @@ TEST_CASE("property setters") {
     {
       auto span = tracer.create_span();
       span.set_service_name("wobble");
+      REQUIRE(span.service_name() == "wobble");
     }
     auto& span = collector->first_span();
     REQUIRE(span.service == "wobble");
@@ -327,6 +331,7 @@ TEST_CASE("property setters") {
     {
       auto span = tracer.create_span();
       span.set_service_type("wobble");
+      REQUIRE(span.service_type() == "wobble");
     }
     auto& span = collector->first_span();
     REQUIRE(span.service_type == "wobble");
@@ -336,6 +341,7 @@ TEST_CASE("property setters") {
     {
       auto span = tracer.create_span();
       span.set_name("wobble");
+      REQUIRE(span.name() == "wobble");
     }
     auto& span = collector->first_span();
     REQUIRE(span.name == "wobble");
@@ -345,6 +351,7 @@ TEST_CASE("property setters") {
     {
       auto span = tracer.create_span();
       span.set_resource_name("wobble");
+      REQUIRE(span.resource_name() == "wobble");
     }
     auto& span = collector->first_span();
     REQUIRE(span.resource == "wobble");


### PR DESCRIPTION
Envoy is being modified to use `dd-trace-cpp` in place of `dd-opentracing-cpp`.

The lower level Datadog tracing components within Envoy can use a mock `Collector` to inspect span data. However, the higher level components do not allow for the injection of a `Collector` (part of their role is to specify the `Collector`). They have access to the `datadog::tracing::Span`, though, so let's make that object easier to inspect.