### PR TITLE
add missing overloads to TraceID's operator== and operator!=

### DIFF
--- a/src/datadog/trace_id.cpp
+++ b/src/datadog/trace_id.cpp
@@ -84,5 +84,9 @@ bool operator!=(TraceID left, std::uint64_t right) {
   return left != TraceID{right};
 }
 
+bool operator==(std::uint64_t left, TraceID right) { return right == left; }
+
+bool operator!=(std::uint64_t left, TraceID right) { return right != left; }
+
 }  // namespace tracing
 }  // namespace datadog

--- a/src/datadog/trace_id.h
+++ b/src/datadog/trace_id.h
@@ -43,6 +43,8 @@ bool operator==(TraceID, TraceID);
 bool operator!=(TraceID, TraceID);
 bool operator==(TraceID, std::uint64_t);
 bool operator!=(TraceID, std::uint64_t);
+bool operator==(std::uint64_t, TraceID);
+bool operator!=(std::uint64_t, TraceID);
 
 }  // namespace tracing
 }  // namespace datadog

--- a/test/test_trace_id.cpp
+++ b/test/test_trace_id.cpp
@@ -57,10 +57,22 @@ TEST_CASE("TraceID comparisons") {
   // First, comparing integers with the `TraceID.low`.
   REQUIRE(TraceID{12345} == 12345);
   REQUIRE_FALSE(TraceID{12345} != 12345);
+
   REQUIRE(TraceID{12345} != 54321);
   REQUIRE_FALSE(TraceID{12345} == 54321);
+
   REQUIRE(TraceID{6789, 12345} != 12345);
   REQUIRE_FALSE(TraceID{6789, 12345} == 12345);
+
+  // And the opposite argument order.
+  REQUIRE(12345 == TraceID{12345});
+  REQUIRE_FALSE(12345 != TraceID{12345});
+
+  REQUIRE(54321 != TraceID{12345});
+  REQUIRE_FALSE(54321 == TraceID{12345});
+
+  REQUIRE(12345 != TraceID{6789, 12345});
+  REQUIRE_FALSE(12345 == TraceID{6789, 12345});
 
   // Second, comparing trace IDs with other trace IDs.
   struct TestCase {


### PR DESCRIPTION
`trace_id == some_int` was defined, but not `some_int == trace_id`.