### PR TITLE
Allow infinity and NaN to be parsed.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ jobs:
     resource_class: xlarge
     environment:
       MAKE_JOB_COUNT: 8
+      # See <https://github.com/llvm/llvm-project/issues/59432>.
+      ASAN_OPTIONS: alloc_dealloc_mismatch=0
     steps:
     - checkout
     - run: mkdir .build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# If we're building with clang, then use the libc++ version of the standard
+# library instead of libstdc++. Better coverage of build configurations.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+endif()
+
 include(ProcessorCount)
 ProcessorCount(NUM_PROCESSORS)
 set(MAKE_JOB_COUNT ${NUM_PROCESSORS} CACHE STRING "Number of jobs to use when building libcurl")

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,13 @@ env DEBIAN_FRONTEND=noninteractive
 # - Make available more recent versions of git.
 # - Update the package lists and upgrade already-installed software.
 # - Install build tooling:
-#   - GCC, clang, make, git, debugger, formatter, and miscellanea
+#   - GCC, clang, libc++, make, git, debugger, formatter, and miscellanea
 run apt-get update && apt-get install --yes software-properties-common && \
     add-apt-repository ppa:git-core/ppa --yes && \
     apt-get update && apt-get upgrade --yes && \
-    apt-get install --yes wget build-essential clang sed gdb clang-format git ssh shellcheck
+    apt-get install --yes \
+        wget build-essential clang sed gdb clang-format git ssh shellcheck \
+        libc++-dev libc++abi-dev
 
 # bazelisk, a launcher for bazel. `bazelisk --help` will cause the latest
 # version to be downloaded.


### PR DESCRIPTION
When building with libc++, as opposed to libstdc++, `operator>>(istream&, double&)` accepts "inf" for infinity and "nan" for NaN. Account for this in some unit tests.

This also modifies the build to use libc++ whenever clang++ is the compiler, instead of the ubuntu default of libstdc++. This required some tweaks to the CI due to a bug in how ubuntu packages clang and libc++.