### PR TITLE
version-checking release script

### DIFF
--- a/bin/check-version
+++ b/bin/check-version
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -e
+
+desired="$1"
+pattern='^v[0-9]\+\.[0-9]\.[0-9]\+$'
+if echo "$desired" | grep -v "$pattern" >/dev/null 2>&1; then
+    >&2 echo "Specified version \"$desired\" does not match the grep pattern $pattern"
+    exit 1
+fi
+
+scratch=$(mktemp -d)
+version_cpp="$(dirname "$0")/../src/datadog/version.cpp"
+cp "$version_cpp" "$scratch"
+cp "${version_cpp%.cpp}.h" "$scratch"
+>"$scratch/print_version.cpp" cat <<'END_CPP'
+
+#include "version.h"
+#include <iostream>
+
+int main() {
+    std::cout << datadog::tracing::tracer_version;
+}
+END_CPP
+
+/usr/bin/c++ -o "$scratch/print_version" "$scratch"/*.cpp
+actual=$("$scratch/print_version")
+rm -r "$scratch"
+
+if [ "$actual" != "$desired" ]; then
+    version_cpp="$(realpath --relative-to="$(pwd)" "$version_cpp")"
+    >&2 echo "Desired release version \"$desired\" is different from that in $version_cpp: \"$actual\""
+    exit 1
+fi

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+version="$1"
+bin="$(dirname "$0")"
+"$bin"/check-version "$version" || exit
+gh release create "$version" --prerelease --draft

--- a/src/datadog/version.cpp
+++ b/src/datadog/version.cpp
@@ -3,8 +3,10 @@
 namespace datadog {
 namespace tracing {
 
-const char* const tracer_version = "v0.1.5";
-const char* const tracer_version_string = "[dd-trace-cpp version v0.1.5]";
+#define VERSION "v0.1.8"
+
+const char* const tracer_version = VERSION;
+const char* const tracer_version_string = "[dd-trace-cpp version " VERSION "]";
 
 }  // namespace tracing
 }  // namespace datadog

--- a/src/datadog/version.h
+++ b/src/datadog/version.h
@@ -2,12 +2,12 @@
 
 // This component provides the release version of this library.
 
-#include "string_view.h"
-
 namespace datadog {
 namespace tracing {
 
 // The release version at or before this code revision, e.g. "v0.1.1".
+// That is, this code is at least as recent as `tracer_version`, but may be
+// more recent.
 extern const char *const tracer_version;
 
 // A string literal that contains `tracer_version` but also is easier to `grep`


### PR DESCRIPTION
Wrap the simple `gh release create` command in a script that also makes sure the desired version is consistent with what's in `version.cpp`. I keep forgetting to update `version.cpp`.