### PR TITLE
prevent leaking of CURL handles

### DIFF
--- a/src/datadog/curl.cpp
+++ b/src/datadog/curl.cpp
@@ -506,6 +506,7 @@ void CurlImpl::run() {
     }
 
     log_on_error(curl_.multi_remove_handle(multi_handle_, handle));
+    curl_.easy_cleanup(handle);
   }
 
   request_handles_.clear();


### PR DESCRIPTION
See <https://github.com/DataDog/dd-trace-cpp/issues/31>.

In addition to the recommended change, this revision also adds unit tests that verify that a CURL handle, once created, is destroyed.