### PR TITLE
suppress compiler errors stemming from bugged warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# This warning has a false positive. See
+# <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108088>.
+add_compile_options(-Wno-error=free-nonheap-object)
+
 # If we're building with clang, then use the libc++ version of the standard
 # library instead of libstdc++. Better coverage of build configurations.
 #


### PR DESCRIPTION
I previously made this change to [nginx-datadog][1], which builds dd-trace-cpp as part of its build. I didn't make the corresponding change in dd-trace-cpp itself because the build image that we use for CI isn't based on Alpine, which packages a newer GCC that has this [bug][2].

[1]: https://github.com/DataDog/nginx-datadog
[2]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108088