### PR TITLE
pass Datadog's internal shared tests for 128-bit trace IDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,9 @@ add_compile_options(-Wno-error=free-nonheap-object)
 
 # This warning has a false positive with clang. See
 # <https://stackoverflow.com/questions/52416362>.
-add_compile_options(-Wno-error=unused-lambda-capture)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    add_compile_options(-Wno-error=unused-lambda-capture)
+endif()
 
 # If we're building with clang, then use the libc++ version of the standard
 # library instead of libstdc++. Better coverage of build configurations.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108088>.
 add_compile_options(-Wno-error=free-nonheap-object)
 
+# This warning has a false positive with clang. See
+# <https://stackoverflow.com/questions/52416362>.
+add_compile_options(-Wno-error=unused-lambda-capture)
+
 # If we're building with clang, then use the libc++ version of the standard
 # library instead of libstdc++. Better coverage of build configurations.
 #

--- a/src/datadog/id_generator.h
+++ b/src/datadog/id_generator.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "clock.h"
 #include "trace_id.h"
 
 namespace datadog {
@@ -21,8 +22,10 @@ class IDGenerator {
  public:
   virtual ~IDGenerator() = default;
 
+  // Generate a span ID.
   virtual std::uint64_t span_id() const = 0;
-  virtual TraceID trace_id() const = 0;
+  // Generate a trace ID for a trace having the specified `start` time.
+  virtual TraceID trace_id(const TimePoint& start) const = 0;
 };
 
 std::shared_ptr<const IDGenerator> default_id_generator(bool trace_id_128_bit);

--- a/src/datadog/tags.cpp
+++ b/src/datadog/tags.cpp
@@ -11,8 +11,6 @@ const std::string service_name = "service.name";
 const std::string span_type = "span.type";
 const std::string operation_name = "operation";
 const std::string resource_name = "resource.name";
-const std::string manual_keep = "manual.keep";
-const std::string manual_drop = "manual.drop";
 const std::string version = "version";
 
 namespace internal {

--- a/src/datadog/tags.h
+++ b/src/datadog/tags.h
@@ -16,8 +16,6 @@ extern const std::string service_name;
 extern const std::string span_type;
 extern const std::string operation_name;
 extern const std::string resource_name;
-extern const std::string manual_keep;
-extern const std::string manual_drop;
 extern const std::string version;
 
 namespace internal {

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -394,6 +394,11 @@ Expected<Span> Tracer::extract_span(const DictReader& reader,
   span_data->trace_id = *trace_id;
   span_data->parent_id = *parent_id;
 
+  if (span_data->trace_id.high) {
+    trace_tags.emplace_back(tags::internal::trace_id_high,
+                            hex(span_data->trace_id.high));
+  }
+
   Optional<SamplingDecision> sampling_decision;
   if (sampling_priority) {
     SamplingDecision decision;

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -54,7 +54,7 @@ void handle_trace_tags(StringView trace_tags, ExtractedData& result,
             error->with_prefix("Unable to parse high bits of the trace ID in "
                                "Datadog style from the "
                                "\"_dd.p.tid\" trace tag: "));
-        span_tags[tags::internal::propagation_error] = "decoding_error";
+        span_tags[tags::internal::propagation_error] = "malformed_tid " + value;
         continue;
       }
 

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -55,10 +55,12 @@ void handle_trace_tags(StringView trace_tags, ExtractedData& result,
                                "Datadog style from the "
                                "\"_dd.p.tid\" trace tag: "));
         span_tags[tags::internal::propagation_error] = "decoding_error";
+        continue;
       }
-      // Note that this assumes the lower 64 bits of the trace ID have already
-      // been extracted (i.e. we look for X-Datadog-Trace-ID first).
+
       if (result.trace_id) {
+        // Note that this assumes the lower 64 bits of the trace ID have already
+        // been extracted (i.e. we look for X-Datadog-Trace-ID first).
         result.trace_id->high = *high;
       }
     }

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -271,7 +271,7 @@ Span Tracer::create_span(const SpanConfig& config) {
   auto span_data = std::make_unique<SpanData>();
   span_data->apply_config(*defaults_, config, clock_);
   std::vector<std::pair<std::string, std::string>> trace_tags;
-  span_data->trace_id = generator_->trace_id();
+  span_data->trace_id = generator_->trace_id(span_data->start);
   if (span_data->trace_id.high) {
     trace_tags.emplace_back(tags::internal::trace_id_high,
                             hex(span_data->trace_id.high));

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -214,12 +214,6 @@ void parse_datadog_tracestate(ExtractedData& result, StringView datadog_value) {
       const auto tag_suffix = key.substr(2);
       std::string tag_name = "_dd.p.";
       append(tag_name, tag_suffix);
-      // The "_dd.p.tid" trace tag is ignored in this context, since its value
-      // is better inferred from the higher 64 bits of the trace ID.
-      if (tag_name == "_dd.p.tid") {
-        pair_begin = pair_end == end ? end : pair_end + 1;
-        continue;
-      }
       // The tag value was encoded with all '=' replaced by '~'.  Undo that
       // transformation.
       std::string decoded_value{value};

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -373,7 +373,7 @@ TEST_CASE("injection") {
   struct Generator : public IDGenerator {
     const std::uint64_t id;
     explicit Generator(std::uint64_t id) : id(id) {}
-    TraceID trace_id() const override { return TraceID(id); }
+    TraceID trace_id(const TimePoint&) const override { return TraceID(id); }
     std::uint64_t span_id() const override { return id; }
   };
   Tracer tracer{*finalized_config, std::make_shared<Generator>(42)};
@@ -478,7 +478,7 @@ TEST_CASE("injecting W3C traceparent header") {
     struct Generator : public IDGenerator {
       const std::uint64_t id;
       explicit Generator(std::uint64_t id) : id(id) {}
-      TraceID trace_id() const override { return TraceID(id); }
+      TraceID trace_id(const TimePoint&) const override { return TraceID(id); }
       std::uint64_t span_id() const override { return id; }
     };
     Tracer tracer{*finalized_config,
@@ -515,7 +515,7 @@ TEST_CASE("injecting W3C traceparent header") {
     struct Generator : public IDGenerator {
       const std::uint64_t id;
       explicit Generator(std::uint64_t id) : id(id) {}
-      TraceID trace_id() const override { return TraceID(id); }
+      TraceID trace_id(const TimePoint&) const override { return TraceID(id); }
       std::uint64_t span_id() const override { return id; }
     };
     Tracer tracer{*finalized_config, std::make_shared<Generator>(expected_id)};
@@ -715,7 +715,7 @@ TEST_CASE("128-bit trace ID injection") {
 
    public:
     explicit MockIDGenerator(TraceID trace_id) : trace_id_(trace_id) {}
-    TraceID trace_id() const override { return trace_id_; }
+    TraceID trace_id(const TimePoint&) const override { return trace_id_; }
     // `span_id` won't be called, because root spans use the lower part of
     // `trace_id` for the span ID.
     std::uint64_t span_id() const override { return 42; }

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -24,6 +24,7 @@
 #include "matchers.h"
 #include "mocks/collectors.h"
 #include "mocks/dict_readers.h"
+#include "mocks/dict_writers.h"
 #include "mocks/loggers.h"
 #include "test.h"
 
@@ -926,6 +927,33 @@ TEST_CASE("span extraction") {
       REQUIRE(!decode_tags(header_value));
       headers["x-datadog-tags"] = header_value;
       REQUIRE(tracer.extract_span(reader));
+    }
+
+    SECTION("_dd.p.tid is not propagated when it is invalid") {
+      const std::string header_value =
+          "_dd.p.foobar=hello,_dd.p.tid=invalidhex";
+      REQUIRE(decode_tags(header_value));
+      headers["x-datadog-tags"] = header_value;
+
+      auto maybe_span = tracer.extract_span(reader);
+      REQUIRE(maybe_span);
+      auto& span = *maybe_span;
+
+      MockDictWriter writer;
+      span.inject(writer);
+      // Expect a valid "x-datadog-tags" header, and it will contain
+      // "_dd.p.foobar", but not "_dd.p.tid".
+      REQUIRE(writer.items.count("x-datadog-tags") == 1);
+      const std::string& injected_header_value =
+          writer.items.find("x-datadog-tags")->second;
+      const auto decoded_tags = decode_tags(injected_header_value);
+      REQUIRE(decoded_tags);
+      CAPTURE(*decoded_tags);
+      const std::unordered_multimap<std::string, std::string> tags{
+          decoded_tags->begin(), decoded_tags->end()};
+      REQUIRE(tags.count("_dd.p.foobar") == 1);
+      REQUIRE(tags.find("_dd.p.foobar")->second == "hello");
+      REQUIRE(tags.count("_dd.p.tid") == 0);
     }
   }
 }

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -995,7 +995,7 @@ TEST_CASE("128-bit trace IDs") {
   // Use a clock that always returns a hard-coded `TimePoint`.
   // May 6, 2010 14:45:13 America/New_York
   const std::time_t flash_crash = 1273171513;
-  const Clock clock = [flash_crash]() {
+  const Clock clock = []() {
     TimePoint result;
     result.wall = std::chrono::system_clock::from_time_t(flash_crash);
     return result;

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -1097,6 +1097,9 @@ TEST_CASE(
        {__LINE__, "_dd.p.tid inconsistent with trace ID", "adfeed",
         "inconsistent_tid "}}));
 
+  CAPTURE(test_case.line);
+  CAPTURE(test_case.name);
+
   TracerConfig config;
   config.defaults.service = "testsvc";
   config.trace_id_128_bit = true;

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -995,7 +995,7 @@ TEST_CASE("128-bit trace IDs") {
   // Use a clock that always returns a hard-coded `TimePoint`.
   // May 6, 2010 14:45:13 America/New_York
   const std::time_t flash_crash = 1273171513;
-  const Clock clock = []() {
+  const Clock clock = [flash_crash]() {
     TimePoint result;
     result.wall = std::chrono::system_clock::from_time_t(flash_crash);
     return result;


### PR DESCRIPTION
These are the changes necessary for dd-trace-cpp to pass applicable test cases in `tests/parametric/test_128_bit_traceids.py` in Datadog's internal shared tests.

See the commit messages for the correspondence with shared tests.