### PR TITLE
support rootless docker in examples

### DIFF
--- a/examples/hasher/docker-compose.yaml
+++ b/examples/hasher/docker-compose.yaml
@@ -3,11 +3,13 @@ services:
     image: datadog/agent
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/run/user:/run/user:ro'
       - '/proc/:/host/proc/:ro'
       - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
     environment:
       - DD_API_KEY
       - DD_APM_ENABLED=true
       - DD_LOG_LEVEL=ERROR
+      - DOCKER_HOST
     ports:
       - 8126:8126

--- a/examples/http-server/docker-compose.yaml
+++ b/examples/http-server/docker-compose.yaml
@@ -43,9 +43,11 @@ services:
         image: datadog/agent
         volumes:
             - '/var/run/docker.sock:/var/run/docker.sock:ro'
+            - '/run/user:/run/user:ro'
             - '/proc/:/host/proc/:ro'
             - '/sys/fs/cgroup/:/host/sys/fs/cgroup:ro'
         environment:
             - DD_API_KEY
             - DD_APM_ENABLED=true
             - DD_LOG_LEVEL=ERROR
+            - DOCKER_HOST


### PR DESCRIPTION
My docker daemon doesn't run as `root`, it runs as me. One side effect of this is that the socket used to communicate with the daemon is not `/var/run/docker.sock`, but instead `/run/user/1000/docker.sock`. The `DOCKER_HOST` environment variable is accordingly `unix:///run/user/1000/docker.sock`.

- Most of the time, the docker daemon is running locally as root at `/var/run/docker.sock`.
- With rootless docker, the docker daemon is running locally as a non-root user at `/run/user/$(id -u)/docker.sock`.
- With remote docker, the docker daemon is running remotely at endpoint `DOCKER_HOST`.

This arrangement of:

- mounting `/var/run/docker.sock` from the host
- mounting `/run/user` from the host
- forwarding the `DOCKER_HOST` environment variable (if present)

supports all three cases.

In particular, it stops the Datadog Agent from breaking for me now that I've switched to rootless docker.