### PR TITLE
update unsuccessful HTTP requests handling (#38)

### DIFF
--- a/src/datadog/datadog_agent.cpp
+++ b/src/datadog/datadog_agent.cpp
@@ -229,7 +229,7 @@ void DatadogAgent::flush() {
       logger->log_error([](auto& stream) {
         stream
             << "Datadog Agent returned response without a body."
-               "This tracer might be sending batches of traces too frequently";
+               " This tracer might be sending batches of traces too frequently";
       });
       return;
     }

--- a/src/datadog/datadog_agent.cpp
+++ b/src/datadog/datadog_agent.cpp
@@ -217,8 +217,9 @@ void DatadogAgent::flush() {
                                         std::string response_body) {
     if (response_status != 200) {
       logger->log_error([&](auto& stream) {
-        stream << "Unexpected response status from Datadog Agent"
-               << response_status << " with body (starts on next line):\n"
+        stream << "Unexpected response status " << response_status
+               << " in Datadog Agent response with body of length "
+               << response_body.size() << " (starts on next line):\n"
                << response_body;
       });
       return;

--- a/src/datadog/datadog_agent.cpp
+++ b/src/datadog/datadog_agent.cpp
@@ -215,11 +215,20 @@ void DatadogAgent::flush() {
                       logger = logger_](int response_status,
                                         const DictReader& /*response_headers*/,
                                         std::string response_body) {
-    if (response_status < 200 || response_status >= 300) {
+    if (response_status != 200) {
       logger->log_error([&](auto& stream) {
-        stream << "Unexpected response status " << response_status
-               << " with body (starts on next line):\n"
+        stream << "Unexpected response status from Datadog Agent"
+               << response_status << " with body (starts on next line):\n"
                << response_body;
+      });
+      return;
+    }
+
+    if (response_body.empty()) {
+      logger->log_error([](auto& stream) {
+        stream
+            << "Datadog Agent returned response without a body."
+               "This tracer might be sending batches of traces too frequently";
       });
       return;
     }

--- a/test/test_datadog_agent.cpp
+++ b/test/test_datadog_agent.cpp
@@ -72,8 +72,6 @@ TEST_CASE("CollectorResponse") {
 
     {
       http_client->response_status = 200;
-      http_client->response_body.str("");
-      http_client->response_body.clear();
       Tracer tracer{*finalized};
       auto span = tracer.create_span();
       (void)span;
@@ -118,6 +116,7 @@ TEST_CASE("CollectorResponse") {
     // Don't echo error messages.
     logger->echo = nullptr;
 
+    // Datadog Agent only returns 200 on success.
     auto status = GENERATE(range(201, 600));
     {
       http_client->response_status = status;

--- a/test/test_datadog_agent.cpp
+++ b/test/test_datadog_agent.cpp
@@ -66,6 +66,23 @@ TEST_CASE("CollectorResponse") {
     REQUIRE(logger->error_count() == 0);
   }
 
+  SECTION("HTTP success with empty body") {
+    // Don't echo error messages.
+    logger->echo = nullptr;
+
+    {
+      http_client->response_status = 200;
+      http_client->response_body.str("");
+      http_client->response_body.clear();
+      Tracer tracer{*finalized};
+      auto span = tracer.create_span();
+      (void)span;
+    }
+
+    REQUIRE(event_scheduler->cancelled);
+    REQUIRE(logger->error_count() == 1);
+  }
+
   SECTION("invalid responses") {
     // Don't echo error messages.
     logger->echo = nullptr;
@@ -101,7 +118,7 @@ TEST_CASE("CollectorResponse") {
     // Don't echo error messages.
     logger->echo = nullptr;
 
-    auto status = GENERATE(range(300, 600));
+    auto status = GENERATE(range(201, 600));
     {
       http_client->response_status = status;
       Tracer tracer{*finalized};


### PR DESCRIPTION
### Content
- consider exclusively 200 as a success HTTP status
- log an error for successfull HTTP status with an empty body
