### PR TITLE
Add ARM64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,9 @@ jobs:
     parameters:
       toolchain:
         type: string
-    docker:
-    - image: "datadog/docker-library:dd-trace-cpp-ci"
-    resource_class: xlarge
+      arch:
+        type: string
+    executor: docker-<< parameters.arch >>
     environment:
       MAKE_JOB_COUNT: 8
     steps:
@@ -87,5 +87,6 @@ workflows:
     - build-bazel:
         matrix:
           parameters:
+            arch: ["amd64", "arm64"]
             toolchain: ["gnu", "llvm"]
     - coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,16 @@
 version: 2.1
 
-jobs:
+executors:
+  docker-amd64:
+    docker:
+      - image: "datadog/docker-library:dd-trace-cpp-ci"
+    resource_class: xlarge
+  docker-arm64:
+    docker:
+      - image: "datadog/docker-library:dd-trace-cpp-ci"
+    resource_class: arm.xlarge
 
+jobs:
   format:
     docker:
     - image: "datadog/docker-library:dd-trace-cpp-ci"
@@ -37,18 +46,17 @@ jobs:
         type: string
       sanitize:
         type: string
-    docker:
-    - image: "datadog/docker-library:dd-trace-cpp-ci"
-    resource_class: xlarge
+      arch:
+        type: string
+    executor: docker-<< parameters.arch >>
     environment:
       MAKE_JOB_COUNT: 8
       # See <https://github.com/llvm/llvm-project/issues/59432>.
       ASAN_OPTIONS: alloc_dealloc_mismatch=0
     steps:
     - checkout
-    - run: mkdir .build
-    - run: cd .build && ../bin/with-toolchain << parameters.toolchain >> cmake .. -DBUILD_TESTING=1 -DSANITIZE=<< parameters.sanitize >>
-    - run: cd .build && make -j $MAKE_JOB_COUNT VERBOSE=1
+    - run: bin/with-toolchain << parameters.toolchain >> cmake . -B .build -DBUILD_TESTING=1 -DSANITIZE=<< parameters.sanitize >>
+    - run: cmake --build .build -j ${MAKE_JOB_COUNT} -v
     - run: cd .build && test/tests
 
   coverage:
@@ -75,6 +83,7 @@ workflows:
           parameters:
             toolchain: ["gnu", "llvm"]
             sanitize: ["on", "off"]
+            arch: ["amd64", "arm64"]
     - build-bazel:
         matrix:
           parameters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@
 
 from ubuntu:22.04
 
+# Expose predefined platform ARGs
+arg TARGETARCH
+
 # Don't issue blocking prompts during installation (sometimes an installer
 # prompts for the current time zone).
 env DEBIAN_FRONTEND=noninteractive
@@ -20,7 +23,7 @@ run apt-get update && apt-get install --yes software-properties-common && \
 
 # bazelisk, a launcher for bazel. `bazelisk --help` will cause the latest
 # version to be downloaded.
-run wget -O/usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64 \
+run wget -O/usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-$TARGETARCH \
     && chmod +x /usr/local/bin/bazelisk \
     && bazelisk --help
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 
 from ubuntu:22.04
 
-# Expose predefined platform ARGs
+# Expose Docker's predefined platform ARGs
+# For more information: <https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope>
 arg TARGETARCH
 
 # Don't issue blocking prompts during installation (sometimes an installer


### PR DESCRIPTION
Content:
- Build and test the library on ARM64
- Update Dockerfile to download bazelisk for the corresponding architecture
- Use cmake to build the library

Side notes:
- I pushed a multi-platform version of `datadog/docker-library:dd-trace-cpp-ci`. It supports `linux/amd64` and `linux/arm64` 