### PR TITLE
Report tracer_version instead of tracer_version_string

### DIFF
--- a/src/datadog/tracer_telemetry.cpp
+++ b/src/datadog/tracer_telemetry.cpp
@@ -69,7 +69,7 @@ nlohmann::json TracerTelemetry::generate_telemetry_body(
       {"application", nlohmann::json::object({
                           {"service_name", span_defaults_->service},
                           {"env", span_defaults_->environment},
-                          {"tracer_version", tracer_version_string},
+                          {"tracer_version", tracer_version},
                           {"language_name", "cpp"},
                           {"language_version", std::to_string(__cplusplus)},
                       })},


### PR DESCRIPTION
Report `v1.2.3` instead of `[dd-trace-cpp version v1.2.3]`.
The latter value doesn't work nicely in telemetry dashboards.