### PR TITLE
curl minutiae

### DIFF
--- a/src/datadog/http_client.h
+++ b/src/datadog/http_client.h
@@ -43,7 +43,8 @@ class HTTPClient {
   // a response is delivered (even if that response contains an error HTTP
   // response status).  Invoke the specified `on_error` if an error occurs
   // outside of HTTP, such as a connection failure.  If an error occurs while
-  // preparing the request, return an `Error`.
+  // preparing the request, return an `Error`. The behavior is undefined if
+  // either of `on_response` or `on_error` throws an exception.
   virtual Expected<void> post(const URL& url, HeadersSetter set_headers,
                               std::string body, ResponseHandler on_response,
                               ErrorHandler on_error) = 0;

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -1017,7 +1017,7 @@ TEST_CASE("128-bit trace IDs") {
   // Use a clock that always returns a hard-coded `TimePoint`.
   // May 6, 2010 14:45:13 America/New_York
   const std::time_t flash_crash = 1273171513;
-  const Clock clock = [flash_crash]() {
+  const Clock clock = []() {
     TimePoint result;
     result.wall = std::chrono::system_clock::from_time_t(flash_crash);
     return result;

--- a/test/test_tracer_telemetry.cpp
+++ b/test/test_tracer_telemetry.cpp
@@ -14,7 +14,7 @@ using namespace datadog::tracing;
 
 TEST_CASE("Tracer telemetry") {
   const std::time_t mock_time = 1672484400;
-  const Clock clock = [mock_time]() {
+  const Clock clock = []() {
     TimePoint result;
     result.wall = std::chrono::system_clock::from_time_t(mock_time);
     return result;


### PR DESCRIPTION
There's no need to hold the lock while executing the response handler. It's not an issue today, but it does prevent a handler from submitting another request.