### PR TITLE
Generate 128-bit trace id by default

### DIFF
--- a/src/datadog/tracer_config.h
+++ b/src/datadog/tracer_config.h
@@ -108,7 +108,7 @@ struct TracerConfig {
   // IDs.  If true, the tracer will generate 128-bit trace IDs. If false, the
   // tracer will generate 64-bit trace IDs. `trace_id_128_bit` is overridden by
   // the `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED` environment variable.
-  bool trace_id_128_bit = false;
+  bool trace_id_128_bit = true;
 
   // `runtime_id` denotes the current run of the application in which the tracer
   // is embedded. If `runtime_id` is not specified, then it defaults to a

--- a/test/test_tracer_config.cpp
+++ b/test/test_tracer_config.cpp
@@ -1224,7 +1224,7 @@ TEST_CASE("configure 128-bit trace IDs") {
   TracerConfig config;
   config.defaults.service = "testsvc";
 
-  SECTION("defaults to false") { REQUIRE(config.trace_id_128_bit == false); }
+  SECTION("defaults to true") { REQUIRE(config.trace_id_128_bit == true); }
 
   SECTION("value honored in finalizer") {
     const auto value = GENERATE(true, false);


### PR DESCRIPTION
## Changes
From now on, the tracer will generate 128-bit trace IDs.

## Next
Remove the option and code related to 64-bit trace IDs.