### PR TITLE
Report `integration` and `integration_version` to telemetry

### DIFF
--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -43,7 +43,8 @@ Tracer::Tracer(const FinalizedTracerConfig& config,
       signature_{runtime_id_, config.defaults.service,
                  config.defaults.environment},
       tracer_telemetry_(std::make_shared<TracerTelemetry>(
-          config.report_telemetry, config.clock, logger_, signature_)),
+          config.report_telemetry, config.clock, logger_, signature_,
+          config.integration_name, config.integration_version)),
       span_sampler_(
           std::make_shared<SpanSampler>(config.span_sampler, config.clock)),
       generator_(generator),

--- a/src/datadog/tracer_config.cpp
+++ b/src/datadog/tracer_config.cpp
@@ -366,6 +366,8 @@ Expected<FinalizedTracerConfig> finalize_config(const TracerConfig &config,
   }
 
   result.runtime_id = config.runtime_id;
+  result.integration_name = config.integration_name;
+  result.integration_version = config.integration_version;
 
   return result;
 }

--- a/src/datadog/tracer_config.h
+++ b/src/datadog/tracer_config.h
@@ -119,6 +119,10 @@ struct TracerConfig {
   // such as those in the worker threads/processes of a reverse proxy, might
   // specify the same `runtime_id` for all tracer instances in the same run.
   Optional<RuntimeID> runtime_id;
+
+  // TODO
+  std::string integration_name;
+  std::string integration_version;
 };
 
 // `FinalizedTracerConfig` contains `Tracer` implementation details derived from
@@ -150,6 +154,8 @@ class FinalizedTracerConfig {
   bool report_telemetry;
   Optional<RuntimeID> runtime_id;
   Clock clock;
+  std::string integration_name;
+  std::string integration_version;
 };
 
 // Return a `FinalizedTracerConfig` from the specified `config` and from any

--- a/src/datadog/tracer_config.h
+++ b/src/datadog/tracer_config.h
@@ -121,11 +121,11 @@ struct TracerConfig {
   Optional<RuntimeID> runtime_id;
 
   // `integration_name` is the name of the product integrating this library.
-  // Example: `nginx`, `envoy` or `istio`.
+  // Example: "nginx", "envoy" or "istio".
   std::string integration_name;
   // `integration_version` is the version of the product integrating this
   // library.
-  // Example: `1.2.3`, `6c44da20`, `2020.02.13`
+  // Example: "1.2.3", "6c44da20", "2020.02.13"
   std::string integration_version;
 };
 

--- a/src/datadog/tracer_config.h
+++ b/src/datadog/tracer_config.h
@@ -120,8 +120,12 @@ struct TracerConfig {
   // specify the same `runtime_id` for all tracer instances in the same run.
   Optional<RuntimeID> runtime_id;
 
-  // TODO
+  // `integration_name` is the name of the product integrating this library.
+  // Example: `nginx`, `envoy` or `istio`.
   std::string integration_name;
+  // `integration_version` is the version of the product integrating this
+  // library.
+  // Example: `1.2.3`, `6c44da20`, `2020.02.13`
   std::string integration_version;
 };
 

--- a/src/datadog/tracer_telemetry.h
+++ b/src/datadog/tracer_telemetry.h
@@ -46,6 +46,8 @@ class TracerTelemetry {
   std::shared_ptr<Logger> logger_;
   TracerSignature tracer_signature_;
   std::string hostname_;
+  std::string integration_name_;
+  std::string integration_version_;
   uint64_t seq_id_ = 0;
   // This structure contains all the metrics that are exposed by tracer
   // telemetry.
@@ -100,7 +102,9 @@ class TracerTelemetry {
  public:
   TracerTelemetry(bool enabled, const Clock& clock,
                   const std::shared_ptr<Logger>& logger,
-                  const TracerSignature& tracer_signature);
+                  const TracerSignature& tracer_signature,
+                  const std::string& integration_name,
+                  const std::string& integration_version);
   bool enabled() { return enabled_; };
   // Provides access to the telemetry metrics for updating the values.
   // This value should not be stored.

--- a/test/test_tracer_telemetry.cpp
+++ b/test/test_tracer_telemetry.cpp
@@ -27,7 +27,10 @@ TEST_CASE("Tracer telemetry") {
       /* service = */ "testsvc",
       /* environment = */ "test"};
 
-  TracerTelemetry tracer_telemetry = {true, clock, logger, tracer_signature};
+  const std::string ignore{""};
+
+  TracerTelemetry tracer_telemetry = {true,   clock, logger, tracer_signature,
+                                      ignore, ignore};
 
   SECTION("generates app-started message") {
     auto app_started_message = tracer_telemetry.app_started();

--- a/test/test_tracer_telemetry.cpp
+++ b/test/test_tracer_telemetry.cpp
@@ -6,6 +6,7 @@
 #include <datadog/tracer_telemetry.h>
 
 #include <datadog/json.hpp>
+#include <unordered_set>
 
 #include "datadog/runtime_id.h"
 #include "mocks/loggers.h"
@@ -13,7 +14,7 @@
 
 using namespace datadog::tracing;
 
-TEST_CASE("Tracer telemetry") {
+TEST_CASE("Tracer telemetry", "[telemetry]") {
   const std::time_t mock_time = 1672484400;
   const Clock clock = []() {
     TimePoint result;
@@ -29,13 +30,33 @@ TEST_CASE("Tracer telemetry") {
 
   const std::string ignore{""};
 
-  TracerTelemetry tracer_telemetry = {true,   clock, logger, tracer_signature,
-                                      ignore, ignore};
+  TracerTelemetry tracer_telemetry{true,   clock, logger, tracer_signature,
+                                   ignore, ignore};
 
   SECTION("generates app-started message") {
-    auto app_started_message = tracer_telemetry.app_started();
-    auto app_started = nlohmann::json::parse(app_started_message);
-    REQUIRE(app_started["request_type"] == "app-started");
+    SECTION("Without a defined integration") {
+      auto app_started_message = tracer_telemetry.app_started();
+      auto app_started = nlohmann::json::parse(app_started_message);
+      REQUIRE(app_started["request_type"] == "message-batch");
+      REQUIRE(app_started["payload"].size() == 1);
+      CHECK(app_started["payload"][0]["request_type"] == "app-started");
+    }
+
+    SECTION("With an integration") {
+      TracerTelemetry tracer_telemetry{
+          true, clock, logger, tracer_signature, "nginx", "1.25.2"};
+      auto app_started_message = tracer_telemetry.app_started();
+      auto app_started = nlohmann::json::parse(app_started_message);
+      REQUIRE(app_started["request_type"] == "message-batch");
+      REQUIRE(app_started["payload"].size() == 2);
+
+      const std::unordered_set<std::string> expected{"app-started",
+                                                     "app-integrations-change"};
+
+      for (const auto& payload : app_started["payload"]) {
+        CHECK(expected.find(payload["request_type"]) != expected.cend());
+      }
+    }
   }
 
   SECTION("generates a heartbeat message") {


### PR DESCRIPTION
## Description

This PR send a new type of payload `app_integrations_change` to Telemetry v2. This new payload allows use know which integration is using the Tracer.
