### PR TITLE
Configure parametric test to get the cpp tracer in same way as system-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
             cd system-tests
             git remote add origin https://github.com/DataDog/system-tests.git
             #git fetch origin << parameters.systemTestsCommit >>
-            git fetch origin 5598dcb607258ad2ee5be79917a344197f862c28
+            git fetch origin f9b90d5ff2ecc7937e68d572ae3c8dcc6812234b
             git reset --hard FETCH_HEAD
       - run:
           name: Install requirements

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
       - run:
           name: Copy tracer to system test binaries folder
           command: |
-            ls -la ~/
+            ls -la ~/project/
             #cp ~/dd-trace-java/workspace/dd-java-agent/build/libs/*.jar system-tests/binaries/
       - run:
           name: Run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,7 @@ jobs:
             git init system-tests
             cd system-tests
             git remote add origin https://github.com/DataDog/system-tests.git
-            #git fetch origin << parameters.systemTestsCommit >>
-            git fetch origin f9b90d5ff2ecc7937e68d572ae3c8dcc6812234b
+            git fetch origin << parameters.systemTestsCommit >>
             git reset --hard FETCH_HEAD
       - run:
           name: Install requirements

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
         - "d3:8f:a8:6e:b6:ef:37:65:1a:dc:2b:88:3b:ff:50:f4"
     - run: bin/publish-coverage
 
-  # Copy-pasta from dd-trace-java. Thank you <3
+  # Copy-paste from dd-trace-java. Thank you <3
   system-tests:
     parameters:
       systemTestsCommit:
@@ -108,19 +108,13 @@ jobs:
             sudo ln -sf /usr/bin/python3.9 /usr/bin/python
 
       - run:
-          name: Configure tracer to use in system test binaries folder
-          environment:
-            DD_TRACE_CPP_COMMIT: << pipeline.git.revision >>
-          command: |
-            echo "https://github.com/DataDog/dd-trace-cpp@$DD_TRACE_CPP_COMMIT" > ~/project/system-tests/binaries/cpp-load-from-git
-            echo "Print file content::::::"
-            cat ~/project/system-tests/binaries/cpp-load-from-git
-      - run:
-          name: Run
+          name: Run Parametric tests
           environment:
             TEST_LIBRARY: cpp
             DD_TRACE_CPP_COMMIT: << pipeline.git.revision >>
-          command: cd system-tests && ./build.sh -i runner && ./run.sh PARAMETRIC --log-cli-level=DEBUG 
+          command: |
+            echo "https://github.com/DataDog/dd-trace-cpp@$DD_TRACE_CPP_COMMIT" > ~/project/system-tests/binaries/cpp-load-from-git
+            cd system-tests && ./build.sh -i runner && ./run.sh PARAMETRIC --log-cli-level=DEBUG 
       - run:
           name: Collect artifacts
           command: tar -cvzf logs_cpp_parametric_dev.tar.gz -C system-tests logs_parametric

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,8 +139,8 @@ workflows:
             arch: ["amd64", "arm64"]
             toolchain: ["gnu", "llvm"]
     - coverage
-    - system-tests #:
-    #    filters:
-    #      branches:
-    #        only:
-    #          - main
+    - system-tests:
+        filters:
+          branches:
+            only:
+              - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
         - "d3:8f:a8:6e:b6:ef:37:65:1a:dc:2b:88:3b:ff:50:f4"
     - run: bin/publish-coverage
 
-  # Copy-paste from dd-trace-java. Thank you <3
+  # Copy-pasta from dd-trace-java. Thank you <3
   system-tests:
     parameters:
       systemTestsCommit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,16 +107,20 @@ jobs:
             sudo ln -sf /usr/bin/python3.9 /usr/bin/python
 
       - run:
-          name: Copy tracer to system test binaries folder
+          name: Configure tracer to use in system test binaries folder
+          environment:
+            DD_TRACE_CPP_COMMIT: << pipeline.git.revision >>
           command: |
-            ls -la ~/project/
-            #cp ~/dd-trace-java/workspace/dd-java-agent/build/libs/*.jar system-tests/binaries/
+            echo $DD_TRACE_CPP_COMMIT > ~/project/system-tests/binaries/cpp-load-from-git
+            echo "Print file content::::::"
+            cat ~/project/system-tests/binaries/cpp-load-from-git
       - run:
           name: Run
           environment:
             TEST_LIBRARY: cpp
             DD_TRACE_CPP_COMMIT: << pipeline.git.revision >>
-          command: cd system-tests && ./build.sh -i runner && ./run.sh PARAMETRIC --log-cli-level=DEBUG 
+          command: echo "DONE!" 
+          #command: cd system-tests && ./build.sh -i runner && ./run.sh PARAMETRIC --log-cli-level=DEBUG 
       - run:
           name: Collect artifacts
           command: tar -cvzf logs_cpp_parametric_dev.tar.gz -C system-tests logs_parametric

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,8 @@ jobs:
             git init system-tests
             cd system-tests
             git remote add origin https://github.com/DataDog/system-tests.git
-            git fetch origin << parameters.systemTestsCommit >>
+            #git fetch origin << parameters.systemTestsCommit >>
+            git fetch origin 5598dcb607258ad2ee5be79917a344197f862c28
             git reset --hard FETCH_HEAD
       - run:
           name: Install requirements
@@ -111,7 +112,7 @@ jobs:
           environment:
             DD_TRACE_CPP_COMMIT: << pipeline.git.revision >>
           command: |
-            echo $DD_TRACE_CPP_COMMIT > ~/project/system-tests/binaries/cpp-load-from-git
+            echo "https://github.com/DataDog/dd-trace-cpp@$DD_TRACE_CPP_COMMIT" > ~/project/system-tests/binaries/cpp-load-from-git
             echo "Print file content::::::"
             cat ~/project/system-tests/binaries/cpp-load-from-git
       - run:
@@ -119,8 +120,7 @@ jobs:
           environment:
             TEST_LIBRARY: cpp
             DD_TRACE_CPP_COMMIT: << pipeline.git.revision >>
-          command: echo "DONE!" 
-          #command: cd system-tests && ./build.sh -i runner && ./run.sh PARAMETRIC --log-cli-level=DEBUG 
+          command: cd system-tests && ./build.sh -i runner && ./run.sh PARAMETRIC --log-cli-level=DEBUG 
       - run:
           name: Collect artifacts
           command: tar -cvzf logs_cpp_parametric_dev.tar.gz -C system-tests logs_parametric

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,12 @@ jobs:
             python3.9 -m pip install wheel
             python3.9 -m pip install -r requirements.txt
             sudo ln -sf /usr/bin/python3.9 /usr/bin/python
+
+      - run:
+          name: Copy tracer to system test binaries folder
+          command: |
+            ls -la ~/
+            #cp ~/dd-trace-java/workspace/dd-java-agent/build/libs/*.jar system-tests/binaries/
       - run:
           name: Run
           environment:
@@ -136,8 +142,8 @@ workflows:
             arch: ["amd64", "arm64"]
             toolchain: ["gnu", "llvm"]
     - coverage
-    - system-tests:
-        filters:
-          branches:
-            only:
-              - main
+    - system-tests #:
+    #    filters:
+    #      branches:
+    #        only:
+    #          - main

--- a/src/datadog/version.cpp
+++ b/src/datadog/version.cpp
@@ -3,7 +3,7 @@
 namespace datadog {
 namespace tracing {
 
-#define VERSION "v0.1.12"
+#define VERSION "v0.1.1299"
 
 const char* const tracer_version = VERSION;
 const char* const tracer_version_string = "[dd-trace-cpp version " VERSION "]";

--- a/src/datadog/version.cpp
+++ b/src/datadog/version.cpp
@@ -3,7 +3,7 @@
 namespace datadog {
 namespace tracing {
 
-#define VERSION "v0.1.1299"
+#define VERSION "v0.1.12"
 
 const char* const tracer_version = VERSION;
 const char* const tracer_version_string = "[dd-trace-cpp version " VERSION "]";


### PR DESCRIPTION
Configure parametric test to get the cpp tracer in same way as system-tests

Related with system-tests PR: https://github.com/DataDog/system-tests/pull/1983