### PR TITLE
TraceSegment can outlive Tracer

### DIFF
--- a/src/datadog/datadog_agent.cpp
+++ b/src/datadog/datadog_agent.cpp
@@ -150,7 +150,8 @@ DatadogAgent::DatadogAgent(
     const FinalizedDatadogAgentConfig& config,
     const std::shared_ptr<TracerTelemetry>& tracer_telemetry,
     const std::shared_ptr<Logger>& logger,
-    const TracerSignature& tracer_signature, ConfigManager& config_manager)
+    const TracerSignature& tracer_signature,
+    const std::shared_ptr<ConfigManager>& config_manager)
     : tracer_telemetry_(tracer_telemetry),
       clock_(config.clock),
       logger_(logger),

--- a/src/datadog/datadog_agent.h
+++ b/src/datadog/datadog_agent.h
@@ -66,7 +66,7 @@ class DatadogAgent : public Collector {
   DatadogAgent(const FinalizedDatadogAgentConfig&,
                const std::shared_ptr<TracerTelemetry>&,
                const std::shared_ptr<Logger>&, const TracerSignature& id,
-               ConfigManager& config_manager);
+               const std::shared_ptr<ConfigManager>& config_manager);
   ~DatadogAgent();
 
   Expected<void> send(

--- a/src/datadog/remote_config.cpp
+++ b/src/datadog/remote_config.cpp
@@ -1,5 +1,6 @@
 #include "remote_config.h"
 
+#include <cassert>
 #include <cstdint>
 #include <type_traits>
 #include <unordered_set>
@@ -64,10 +65,13 @@ ConfigUpdate parse_dynamic_config(const nlohmann::json& j) {
 }  // namespace
 
 RemoteConfigurationManager::RemoteConfigurationManager(
-    const TracerSignature& tracer_signature, ConfigManager& config_manager)
+    const TracerSignature& tracer_signature,
+    const std::shared_ptr<ConfigManager>& config_manager)
     : tracer_signature_(tracer_signature),
       config_manager_(config_manager),
-      client_id_(uuid()) {}
+      client_id_(uuid()) {
+  assert(config_manager_);
+}
 
 bool RemoteConfigurationManager::is_new_config(
     StringView config_path, const nlohmann::json& config_meta) {
@@ -215,11 +219,11 @@ void RemoteConfigurationManager::process_response(const nlohmann::json& json) {
 }
 
 void RemoteConfigurationManager::apply_config(Configuration config) {
-  config_manager_.update(config.content);
+  config_manager_->update(config.content);
 }
 
 void RemoteConfigurationManager::revert_config(Configuration) {
-  config_manager_.reset();
+  config_manager_->reset();
 }
 
 }  // namespace tracing

--- a/src/datadog/remote_config.h
+++ b/src/datadog/remote_config.h
@@ -12,6 +12,7 @@
 // It interacts with the `ConfigManager` to seamlessly apply or revert
 // configurations based on responses received from the remote source.
 
+#include <memory>
 #include <string>
 
 #include "config_manager.h"
@@ -44,15 +45,16 @@ class RemoteConfigurationManager {
   };
 
   TracerSignature tracer_signature_;
-  ConfigManager& config_manager_;
+  std::shared_ptr<ConfigManager> config_manager_;
   std::string client_id_;  ///< Identifier a `RemoteConfigurationManager`
 
   State state_;
   std::unordered_map<std::string, Configuration> applied_config_;
 
  public:
-  RemoteConfigurationManager(const TracerSignature& tracer_signature,
-                             ConfigManager& config_manager);
+  RemoteConfigurationManager(
+      const TracerSignature& tracer_signature,
+      const std::shared_ptr<ConfigManager>& config_manager);
 
   // Construct a JSON object representing the payload to be sent in a remote
   // configuration request.

--- a/src/datadog/remote_config.h
+++ b/src/datadog/remote_config.h
@@ -46,7 +46,7 @@ class RemoteConfigurationManager {
 
   TracerSignature tracer_signature_;
   std::shared_ptr<ConfigManager> config_manager_;
-  std::string client_id_;  ///< Identifier a `RemoteConfigurationManager`
+  std::string client_id_;
 
   State state_;
   std::unordered_map<std::string, Configuration> applied_config_;

--- a/src/datadog/tracer.h
+++ b/src/datadog/tracer.h
@@ -10,6 +10,9 @@
 // obtained from a `TracerConfig` via the `finalize_config` function.  See
 // `tracer_config.h`.
 
+#include <cstddef>
+#include <memory>
+
 #include "clock.h"
 #include "config_manager.h"
 #include "error.h"
@@ -32,6 +35,7 @@ class SpanSampler;
 
 class Tracer {
   std::shared_ptr<Logger> logger_;
+  std::shared_ptr<ConfigManager> config_manager_;
   std::shared_ptr<Collector> collector_;
   std::shared_ptr<const SpanDefaults> defaults_;
   RuntimeID runtime_id_;
@@ -44,7 +48,6 @@ class Tracer {
   std::vector<PropagationStyle> extraction_styles_;
   Optional<std::string> hostname_;
   std::size_t tags_header_max_size_;
-  ConfigManager config_manager_;
   bool sampling_delegation_enabled_;
 
  public:

--- a/test/test_remote_config.cpp
+++ b/test/test_remote_config.cpp
@@ -28,7 +28,8 @@ REMOTE_CONFIG_TEST("first payload") {
   TracerConfig config;
   config.defaults.service = "testsvc";
   config.defaults.environment = "test";
-  ConfigManager config_manager(*finalize_config(config));
+  const auto config_manager =
+      std::make_shared<ConfigManager>(*finalize_config(config));
 
   RemoteConfigurationManager rc(tracer_signature, config_manager);
 
@@ -62,7 +63,8 @@ REMOTE_CONFIG_TEST("response processing") {
   config.defaults.service = "testsvc";
   config.defaults.environment = "test";
   config.trace_sampler.sample_rate = 1.0;
-  ConfigManager config_manager(*finalize_config(config));
+  const auto config_manager =
+      std::make_shared<ConfigManager>(*finalize_config(config));
 
   RemoteConfigurationManager rc(tracer_signature, config_manager);
 
@@ -177,9 +179,9 @@ REMOTE_CONFIG_TEST("response processing") {
 
     REQUIRE(!response_json.is_discarded());
 
-    const auto old_trace_sampler = config_manager.get_trace_sampler();
+    const auto old_trace_sampler = config_manager->get_trace_sampler();
     rc.process_response(response_json);
-    const auto new_trace_sampler = config_manager.get_trace_sampler();
+    const auto new_trace_sampler = config_manager->get_trace_sampler();
 
     CHECK(new_trace_sampler != old_trace_sampler);
 
@@ -201,7 +203,7 @@ REMOTE_CONFIG_TEST("response processing") {
         REQUIRE(!response_json.is_discarded());
 
         rc.process_response(response_json);
-        const auto current_trace_sampler = config_manager.get_trace_sampler();
+        const auto current_trace_sampler = config_manager->get_trace_sampler();
         CHECK(old_trace_sampler == current_trace_sampler);
       }
 
@@ -227,7 +229,7 @@ REMOTE_CONFIG_TEST("response processing") {
         REQUIRE(!response_json.is_discarded());
 
         rc.process_response(response_json);
-        const auto current_trace_sampler = config_manager.get_trace_sampler();
+        const auto current_trace_sampler = config_manager->get_trace_sampler();
         CHECK(old_trace_sampler == current_trace_sampler);
       }
     }
@@ -270,9 +272,9 @@ REMOTE_CONFIG_TEST("response processing") {
 
     REQUIRE(!response_json.is_discarded());
 
-    const auto old_sampling_rate = config_manager.get_trace_sampler();
+    const auto old_sampling_rate = config_manager->get_trace_sampler();
     rc.process_response(response_json);
-    const auto new_sampling_rate = config_manager.get_trace_sampler();
+    const auto new_sampling_rate = config_manager->get_trace_sampler();
 
     CHECK(new_sampling_rate == old_sampling_rate);
   }

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -23,6 +23,7 @@
 #include <ctime>
 #include <iosfwd>
 #include <stdexcept>
+#include <utility>
 
 #include "matchers.h"
 #include "mocks/collectors.h"
@@ -1701,4 +1702,20 @@ TEST_CASE("heterogeneous extraction") {
   span->inject(writer);
 
   REQUIRE(writer.items == test_case.expected_injected_headers);
+}
+
+TEST_CASE("move semantics") {
+  // Verify that `Tracer` can be moved.
+  TracerConfig config;
+  config.defaults.service = "testsvc";
+  config.logger = std::make_shared<NullLogger>();
+  config.collector = std::make_shared<MockCollector>();
+
+  auto finalized_config = finalize_config(config);
+  REQUIRE(finalized_config);
+  Tracer tracer1{*finalized_config};
+
+  // This must compile.
+  Tracer tracer2{std::move(tracer1)};
+  (void)tracer2;
 }


### PR DESCRIPTION
I was integrating the recent sampling delegation changes into the corresponding feature branch in nginx-datadog, and got some compiler errors. They're due to other changes on the dd-trace-cpp main branch.

In nginx-datadog, and in Envoy, the `Tracer` is stored as an `Optional<Tracer>`. A `Tracer` instance is then moved into the variable.

Since `Tracer` now has a `ConfigManager` data member, and `ConfigManager` has a `std::mutex` data member, `Tracer` can no longer be moved (because `std::mutex` cannot be moved).

One thing I could do is use `Optional::emplace` to construct the `Tracer` in place: no move required.

Another thing I could do is make the `Tracer`'s `ConfigManager` a `std::unique_ptr`, so that move semantics are preserved.

Yet another thing I could do is use a `std::unique_ptr` in nginx-datadog and Envoy, so that the `Tracer` itself does not have to be moved.

So, I went about thinking about this. Then, looking at the dd-trace-cpp code, I noticed something.

`Tracer` has `ConfigManager` data member. A reference (pointer) to the `ConfigManager` is then passed into the `DatadogAgent`, which is held by `shared_ptr` in `Tracer`. The `DatadogAgent` has a `RemoveConfigurationManager` data member, which holds a reference (pointer) to the `ConfigManager`.

My initial design of dd-trace-cpp was such that a `TraceSegment` could safely outlive the `Tracer` that created it. The idea was that an application might have a `Tracer` that gets reassigned when reconfiguration occurs, and this would not affect any traces in flight.

The recent remote configuration changes violate this property, because the lifetime of the `ConfigManager` is limited to the lifetime of the `Tracer` that holds it, even though the `ConfigManager` is referred to by objects that can outlive the `Tracer`.

This pull request makes the `Tracer`'s `ConfigManager` a `std::shared_ptr`, and passes it as a `shared_ptr` through `DatadogAgent` and into `RemoteConfigurationManager`. This way, even if the `Tracer` is destroyed, the `RemoteConfigurationManager` still has a valid handle to the `ConfigManager`.