### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.CODEOWNERS
+++ b/.CODEOWNERS
@@ -1,0 +1,2 @@
+## Automatically send PR to apm-cpp team
+* @datadog/apm-cpp


### PR DESCRIPTION
# Description

Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. Code owners are not automatically requested to review draft pull requests.

More details: https://docs.github.com/en/enterprise/2.18/user/github/creating-cloning-and-archiving-repositories/about-code-owners