### PR TITLE
add a microbenchmark that doesn't trace

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -41,10 +41,10 @@ struct SerializingCollector : public dd::Collector {
   }
 };
 
-// The benchmark `BM_TraceTinyCCSource`, for each iteration over `state`,
+// The benchmark `BM_TraceHashTinyCCSource`, for each iteration over `state`,
 // creates a trace whose shape is the same as the file system tree under
 // `./tinycc`. It's similar to what is done in `../example`.
-void BM_TraceTinyCCSource(benchmark::State& state) {
+void BM_TraceHashTinyCCSource(benchmark::State& state) {
   for (auto _ : state) {
     dd::TracerConfig config;
     config.defaults.service = "benchmark";
@@ -56,7 +56,18 @@ void BM_TraceTinyCCSource(benchmark::State& state) {
     sha256_traced("benchmark/tinycc", tracer);
   }
 }
-BENCHMARK(BM_TraceTinyCCSource);
+BENCHMARK(BM_TraceHashTinyCCSource);
+
+// The benchmark `BM_HashTinyCCSource`, for each iteration over `state`, does
+// what `BM_TraceHashTinyCCSource` does, but without any tracing.
+void BM_HashTinyCCSource(benchmark::State& state) {
+  for (auto _ : state) {
+    // Note: This assumes that the benchmark is run from the repository root.
+    sha256_untraced("benchmark/tinycc");
+  }
+}
+BENCHMARK(BM_HashTinyCCSource);
+
 
 } // namespace
 

--- a/benchmark/hasher.h
+++ b/benchmark/hasher.h
@@ -9,3 +9,6 @@ class Tracer;
 // Use the specified `tracer` to create a trace whose structure resembles the
 // file system tree rooted at the specified `path`.
 void sha256_traced(const std::filesystem::path &path, datadog::tracing::Tracer &tracer);
+
+// Perform the same work as `sha256_traced`, but without doing any tracing.
+void sha256_untraced(const std::filesystem::path &path);


### PR DESCRIPTION
This goes against the spirit of "microbenchmarks are for tracking changes only, not for measuring 'overhead'," but the comparison is interesting nonetheless.

On my machine:
```console
david@ein:~/src/dd-trace-cpp$ bin/benchmark --benchmark_time_unit=ms
[...]
+ .build/benchmark/dd_trace_cpp-benchmark --benchmark_time_unit=ms
2024-01-19T15:28:57-05:00
Running .build/benchmark/dd_trace_cpp-benchmark
Run on (16 X 4900 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1280 KiB (x8)
  L3 Unified 24576 KiB (x1)
Load Average: 0.41, 0.44, 0.57
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
BM_TraceHashTinyCCSource       3633 ms         3633 ms            1
BM_HashTinyCCSource            3532 ms         3532 ms            1
david@ein:~/src/dd-trace-cpp$ 
```
Note that "one iteration" doesn't mean that the benchmark code was run only once. Instead, the benchmarking tool will run the code as many times as it needs to get a statistically significant measurement. "Iterations" refers to how many times it goes through that entire process.