### PR TITLE
chore-ci: install python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,3 @@ run chmod +x /tmp/install-cmake && /tmp/install-cmake && rm /tmp/install-cmake
 copy bin/install-lcov /tmp/install-lcov
 run chmod +x /tmp/install-lcov && /tmp/install-lcov && rm /tmp/install-lcov
 
-run apt-get clean -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ run apt-get update && apt-get install --yes software-properties-common && \
     apt-get update && apt-get upgrade --yes && \
     apt-get install --yes \
         wget build-essential clang sed gdb clang-format git ssh shellcheck \
-        libc++-dev libc++abi-dev python3
+        libc++-dev libc++abi-dev python3 pip
 
 # bazelisk, a launcher for bazel. `bazelisk --help` will cause the latest
 # version to be downloaded.

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ run apt-get update && apt-get install --yes software-properties-common && \
     apt-get update && apt-get upgrade --yes && \
     apt-get install --yes \
         wget build-essential clang sed gdb clang-format git ssh shellcheck \
-        libc++-dev libc++abi-dev
+        libc++-dev libc++abi-dev python3
 
 # bazelisk, a launcher for bazel. `bazelisk --help` will cause the latest
 # version to be downloaded.
@@ -35,3 +35,5 @@ run chmod +x /tmp/install-cmake && /tmp/install-cmake && rm /tmp/install-cmake
 # Coverage reporting.
 copy bin/install-lcov /tmp/install-lcov
 run chmod +x /tmp/install-lcov && /tmp/install-lcov && rm /tmp/install-lcov
+
+run apt-get clean -y


### PR DESCRIPTION
# Description
Adds `python` to our CI image.

## Why?
I recently enforced formating/linting in `nginx-datadog`. They share the same CI image.  