### PR TITLE
fix: remote configuration default targets version

### DIFF
--- a/src/datadog/remote_config.h
+++ b/src/datadog/remote_config.h
@@ -30,7 +30,7 @@ class RemoteConfigurationManager {
   // Represents the *current* state of the RemoteConfigurationManager.
   // It is also used to report errors to the remote source.
   struct State {
-    uint64_t targets_version = 1;
+    uint64_t targets_version = 0;
     std::string opaque_backend_state;
     Optional<std::string> error_message;
   };

--- a/test/test_remote_config.cpp
+++ b/test/test_remote_config.cpp
@@ -41,7 +41,7 @@ REMOTE_CONFIG_TEST("first payload") {
   CHECK(payload["client"]["client_tracer"]["service"] == "testsvc");
   CHECK(payload["client"]["client_tracer"]["env"] == "test");
   CHECK(payload["client"]["state"]["root_version"] == 1);
-  CHECK(payload["client"]["state"]["targets_version"] == 1);
+  CHECK(payload["client"]["state"]["targets_version"] == 0);
 }
 
 REMOTE_CONFIG_TEST("response processing") {


### PR DESCRIPTION
# Description
The RFC reference that the default value of `targets_version` should be `0` and not `1`. This PR fix this mistake and also resolves an issue where the agent was producing an error in some situation.

