### PR TITLE
restore "defaults", not "default"

### DIFF
--- a/src/datadog/config_manager.cpp
+++ b/src/datadog/config_manager.cpp
@@ -72,7 +72,7 @@ void ConfigManager::reset() {
 nlohmann::json ConfigManager::config_json() const {
   std::lock_guard<std::mutex> lock(mutex_);
   return nlohmann::json{
-      {"default", to_json(*current_span_defaults_)},
+      {"defaults", to_json(*current_span_defaults_)},
       {"trace_sampler", current_trace_sampler_->config_json()},
       {"report_traces", current_report_traces_}};
 }


### PR DESCRIPTION
There's a test in nginx-datadog that's sensitive to certain fields in the JSON config dump. Recent modifications to dd-trace-cpp changed the name of one of the fields from "defaults" to "default". This PR puts it back.