### PR TITLE
Rename the bot, and add some docs.

### DIFF
--- a/bin/publish-coverage
+++ b/bin/publish-coverage
@@ -19,14 +19,14 @@ echo "Using temporary directory: $temp_dir"
 cd "$temp_dir"
 
 # Clone directory structure of the most recent commit of one
-# branch (main).  Don't fetch any regular files.
+# branch (gh-pages).  Don't fetch any regular files.
 mkdir dd-trace-cpp-coverage
 cd dd-trace-cpp-coverage
 
 git init
 
-git config user.email "david.goffredo@datadoghq.com"
-git config user.name "David Goffredo (via script)"
+git config user.email "damien.mehala@datadoghq.com"
+git config user.name "Damien Mehala (via script)"
 
 git remote add origin 'git@github.com:DataDog/dd-trace-cpp-coverage.git'
 branch=gh-pages
@@ -50,6 +50,15 @@ hex_encode() {
 }
 
 cd "$tracer_dir"
+
+# Summary information about the coverage report is encoded in the directory name
+# that contains the report.
+#
+# It's a bit silly, but it has a couple of advantages:
+#
+# - Concurrent commits are trivial to merge, since they involve git trees only.
+# - The UI (browser) script that tabulates the summary information need not
+#  fetch any actual files: the directory listing is sufficient.
 
 commit_time_iso=$(git show -s --format=%cI)
 commit_hash_short=$(git rev-parse HEAD | head -c 7)


### PR DESCRIPTION
GitHub displays the commit author based on the email address named in the commit. Thing is, you can put any email address you want. Could be Linus Torvalds.

This PR changes the coverage bot so that it uses Damien's Datadog email instead of mine.

Example: https://github.com/DataDog/dd-trace-cpp-coverage/commit/a6f8f24fab800558a6d2c8e75a1350c75a80fa7f