### PR TITLE
chore(bazel): add MODULE.bazel files for bzlmod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bazel-*
 /.build/
 /.coverage/
+MODULE.bazel.lock

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,20 @@
+module(
+    name = "dd-trace-cpp",
+    version = "",
+)
+
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.2.1",
+)
+bazel_dep(
+    name = "rules_cc",
+    version = "0.0.9",
+)
+# -- bazel_dep definitions -- #
+
+non_module_dependencies = use_extension("//:extensions.bzl", "non_module_dependencies")
+use_repo(
+    non_module_dependencies,
+    "com_google_absl",
+)

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -1,0 +1,15 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def _non_module_dependencies_impl(_ctx):
+    http_archive(
+        name = "com_google_absl",
+        patch_args = ["-p1"],
+        patches = ["//:abseil.patch"],
+        sha256 = "aabf6c57e3834f8dc3873a927f37eaf69975d4b28117fc7427dfb1c661542a87",
+        strip_prefix = "abseil-cpp-98eb410c93ad059f9bba1bf43f5bb916fc92a5ea",
+        urls = ["https://github.com/abseil/abseil-cpp/archive/98eb410c93ad059f9bba1bf43f5bb916fc92a5ea.zip"],
+    )
+
+non_module_dependencies = module_extension(
+    implementation = _non_module_dependencies_impl,
+)


### PR DESCRIPTION
Bzlmod is the new way to handle external dependencies.
This applies https://bazel.build/external/migration

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>

