### PR TITLE
chore: add parametric system test server

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,3 +42,5 @@ target_link_libraries(tests dd_trace_cpp-static ${COVERAGE_LIBRARIES})
 if(BUILD_COVERAGE)
     target_link_options(tests PRIVATE -fprofile-arcs -ftest-coverage)
 endif()
+
+add_subdirectory(system-tests)

--- a/test/system-tests/CMakeLists.txt
+++ b/test/system-tests/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_executable(parametric-http-server)
+
+target_sources(parametric-http-server
+  PRIVATE
+  main.cpp
+  developer_noise.cpp
+  request_handler.cpp
+)
+
+target_include_directories(parametric-http-server
+  PRIVATE
+  ../../examples/http-server/common
+)
+
+target_link_libraries(parametric-http-server dd_trace_cpp-static)
+
+install(
+  TARGETS parametric-http-server
+  DESTINATION bin
+)

--- a/test/system-tests/README.md
+++ b/test/system-tests/README.md
@@ -1,0 +1,3 @@
+# System tests
+
+This directory contains the HTTP server for parametric system-tests.

--- a/test/system-tests/developer_noise.cpp
+++ b/test/system-tests/developer_noise.cpp
@@ -1,0 +1,47 @@
+#include "developer_noise.h"
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+
+void DeveloperNoiseLogger::developer_noise(bool enabled) { developer_noise_ = enabled; }
+
+void DeveloperNoiseLogger::log_info(datadog::tracing::StringView message) {
+  if (developer_noise_) {
+    make_noise("INFO", [&](auto& stream) { stream << message; });
+  }
+}
+
+void DeveloperNoiseLogger::log_error(const LogFunc& insert_to_stream) { make_noise("ERROR", insert_to_stream); }
+
+void DeveloperNoiseLogger::log_startup(const LogFunc& insert_to_stream) { make_noise("INFO", insert_to_stream); }
+
+void DeveloperNoiseLogger::make_noise(std::string_view level, const LogFunc& insert_to_stream) {
+  std::time_t t = std::time(0); // get time now
+  auto now = std::localtime(&t);
+
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  std::cerr << "[" << std::put_time(now, "%c") << "] [" << level << "] ";
+  insert_to_stream(std::cerr);
+  std::cerr << std::endl;
+}
+
+std::shared_ptr<DeveloperNoiseLogger> make_logger() {
+  // Initialize a logger that handles errors from the library as well as comforting developer-noise
+  // from the tracing service.
+  auto logger = std::make_shared<DeveloperNoiseLogger>();
+
+  // Enable developer noise when a specific environment variable is set.
+  auto verbose_env = std::getenv("CPP_PARAMETRIC_TEST_VERBOSE");
+  if (verbose_env) {
+    try {
+      if (std::stoi(verbose_env) == 1) {
+        logger->developer_noise(true);
+      }
+    } catch (...) {
+    }
+  }
+
+  return logger;
+}

--- a/test/system-tests/developer_noise.cpp
+++ b/test/system-tests/developer_noise.cpp
@@ -4,7 +4,9 @@
 #include <iomanip>
 #include <iostream>
 
-void DeveloperNoiseLogger::developer_noise(bool enabled) { developer_noise_ = enabled; }
+void DeveloperNoiseLogger::developer_noise(bool enabled) {
+  developer_noise_ = enabled;
+}
 
 void DeveloperNoiseLogger::log_info(datadog::tracing::StringView message) {
   if (developer_noise_) {
@@ -12,12 +14,17 @@ void DeveloperNoiseLogger::log_info(datadog::tracing::StringView message) {
   }
 }
 
-void DeveloperNoiseLogger::log_error(const LogFunc& insert_to_stream) { make_noise("ERROR", insert_to_stream); }
+void DeveloperNoiseLogger::log_error(const LogFunc& insert_to_stream) {
+  make_noise("ERROR", insert_to_stream);
+}
 
-void DeveloperNoiseLogger::log_startup(const LogFunc& insert_to_stream) { make_noise("INFO", insert_to_stream); }
+void DeveloperNoiseLogger::log_startup(const LogFunc& insert_to_stream) {
+  make_noise("INFO", insert_to_stream);
+}
 
-void DeveloperNoiseLogger::make_noise(std::string_view level, const LogFunc& insert_to_stream) {
-  std::time_t t = std::time(0); // get time now
+void DeveloperNoiseLogger::make_noise(std::string_view level,
+                                      const LogFunc& insert_to_stream) {
+  std::time_t t = std::time(0);  // get time now
   auto now = std::localtime(&t);
 
   std::lock_guard<std::mutex> lock(mutex_);
@@ -28,8 +35,8 @@ void DeveloperNoiseLogger::make_noise(std::string_view level, const LogFunc& ins
 }
 
 std::shared_ptr<DeveloperNoiseLogger> make_logger() {
-  // Initialize a logger that handles errors from the library as well as comforting developer-noise
-  // from the tracing service.
+  // Initialize a logger that handles errors from the library as well as
+  // comforting developer-noise from the tracing service.
   auto logger = std::make_shared<DeveloperNoiseLogger>();
 
   // Enable developer noise when a specific environment variable is set.

--- a/test/system-tests/developer_noise.h
+++ b/test/system-tests/developer_noise.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <sstream>
+
+#include <datadog/logger.h>
+
+class DeveloperNoiseLogger : public datadog::tracing::Logger {
+  bool developer_noise_ = false;
+  std::mutex mutex_;
+
+public:
+  void developer_noise(bool enabled);
+  void log_info(datadog::tracing::StringView message);
+  void log_error(const LogFunc&) override;
+  void log_startup(const LogFunc&) override;
+  using Logger::log_error; // other overloads of log_error
+
+private:
+  void make_noise(std::string_view level, const LogFunc&);
+};
+
+std::shared_ptr<DeveloperNoiseLogger> make_logger();

--- a/test/system-tests/developer_noise.h
+++ b/test/system-tests/developer_noise.h
@@ -1,23 +1,23 @@
 #pragma once
 
+#include <datadog/logger.h>
+
 #include <memory>
 #include <mutex>
 #include <sstream>
-
-#include <datadog/logger.h>
 
 class DeveloperNoiseLogger : public datadog::tracing::Logger {
   bool developer_noise_ = false;
   std::mutex mutex_;
 
-public:
+ public:
   void developer_noise(bool enabled);
   void log_info(datadog::tracing::StringView message);
   void log_error(const LogFunc&) override;
   void log_startup(const LogFunc&) override;
-  using Logger::log_error; // other overloads of log_error
+  using Logger::log_error;  // other overloads of log_error
 
-private:
+ private:
   void make_noise(std::string_view level, const LogFunc&);
 };
 

--- a/test/system-tests/main.cpp
+++ b/test/system-tests/main.cpp
@@ -1,0 +1,141 @@
+#include <datadog/optional.h>
+#include <datadog/span_config.h>
+#include <datadog/tracer.h>
+#include <datadog/tracer_config.h>
+
+#include <chrono>
+#include <datadog/json.hpp>
+#include <iostream>
+#include <optional>
+#include <string_view>
+#include <unordered_map>
+
+#include "developer_noise.h"
+#include "httplib.h"
+#include "request_handler.h"
+
+// `hard_stop` is installed as a signal handler for `SIGTERM`.
+// For some reason, the default handler was not being called.
+void hard_stop(int /*signal*/) { std::exit(0); }
+
+std::optional<uint16_t> get_port() {
+  try {
+    auto port_env = std::getenv("APM_TEST_CLIENT_SERVER_PORT");
+    if (port_env == nullptr) {
+      return std::nullopt;
+    }
+
+    uint16_t port = std::atoi(port_env);
+    return port;
+  } catch (...) {
+    return std::nullopt;
+  }
+}
+
+int main() {
+  auto logger = make_logger();
+
+  auto port = get_port();
+  if (!port) {
+    logger->log_error(
+        "environment variable APM_TEST_CLIENT_SERVER_PORT is not set or the "
+        "port is not valid");
+    return 1;
+  }
+
+  // An event scheduler needs to be shared between the TracingService and the
+  // tracer.
+  auto event_scheduler = std::make_shared<ManualScheduler>();
+
+  datadog::tracing::TracerConfig config;
+  config.logger = logger;
+  config.agent.event_scheduler = event_scheduler;
+  config.service = "cpp-parametric-test";
+  config.environment = "staging";
+  config.name = "http.request";
+
+  auto finalized_config = datadog::tracing::finalize_config(config);
+  if (auto error = finalized_config.if_error()) {
+    logger->log_error(error->with_prefix("unable to initialize tracer:"));
+    return 1;
+  }
+
+  RequestHandler handler(*finalized_config, event_scheduler, logger);
+
+  httplib::Server svr;
+  svr.Post("/trace/span/start",
+           [&handler](const httplib::Request& req, httplib::Response& res) {
+             handler.on_span_start(req, res);
+           });
+  svr.Post("/trace/span/finish",
+           [&handler](const httplib::Request& req, httplib::Response& res) {
+             handler.on_span_end(req, res);
+           });
+  svr.Post("/trace/span/set_meta",
+           [&handler](const httplib::Request& req, httplib::Response& res) {
+             handler.on_set_meta(req, res);
+           });
+  svr.Post("/trace/span/inject_headers",
+           [&handler](const httplib::Request& req, httplib::Response& res) {
+             handler.on_inject_headers(req, res);
+           });
+  svr.Post("/trace/span/flush",
+           [&handler](const httplib::Request& req, httplib::Response& res) {
+             handler.on_span_flush(req, res);
+           });
+  svr.Post("/trace/stats/flush",
+           [&handler](const httplib::Request& req, httplib::Response& res) {
+             handler.on_stats_flush(req, res);
+           });
+
+  // Not implemented
+  svr.Post("/trace/span/set_metric",
+           [&handler](const httplib::Request& req, httplib::Response& res) {
+             handler.on_set_metric(req, res);
+           });
+
+  svr.set_logger([&logger](const auto& req, const auto&) {
+    std::string msg{req.method};
+    msg += " ";
+    msg += req.path;
+    msg += " ";
+    msg += req.version;
+    logger->log_info(msg);
+
+    if (!req.body.empty()) {
+      msg = "   body: ";
+      msg += req.body;
+      logger->log_info(msg);
+    }
+  });
+
+  svr.set_exception_handler([](const auto&, auto& res, std::exception_ptr ep) {
+    try {
+      std::rethrow_exception(ep);
+    } catch (const nlohmann::json::exception& e) {
+      // clang-format off
+      nlohmann::json j{
+        {"detail", {
+          {"loc", nlohmann::json::array({__FILE__, __LINE__})},
+          {"type", "JSON Parsing error"},
+          {"msg", e.what()}
+        }}
+      };
+      // clang-format on
+
+      res.set_content(j.dump(), "application/json");
+      res.status = 422;
+      return;
+    } catch (std::exception& e) {
+      res.set_content(e.what(), "text/plain");
+    } catch (...) {
+      res.set_content("Unknown Exception", "text/plain");
+    }
+
+    res.status = 500;
+  });
+
+  std::signal(SIGTERM, hard_stop);
+  svr.listen("0.0.0.0", *port);
+  return 0;
+}

--- a/test/system-tests/main.cpp
+++ b/test/system-tests/main.cpp
@@ -32,7 +32,32 @@ std::optional<uint16_t> get_port() {
   }
 }
 
-int main() {
+void print_usage(std::string_view app) {
+  // clang-format off
+  std::cout << app << "\n\n"
+            << "Usage: HTTP server for parametric system tests\n\n"
+            << "-h, --help\t\tPrint this help message.\n"
+            << "-v, --version\t\tPrint the version of dd-trace-cpp.\n\n"
+            << "Environment variables:\n\n"
+            << "APM_TEST_CLIENT_SERVER_PORT\tDefines port to use."
+            << "\n";
+  // clang-format on
+}
+
+int main(int argc, char* argv[]) {
+  if (argc > 1) {
+    for (int i = 0; i < argc; ++i) {
+      const std::string_view arg{argv[i]};
+      if (arg == "-h" || arg == "--help") {
+        print_usage(argv[0]);
+        return 0;
+      } else if (arg == "-v" || arg == "--version") {
+        std::cout << datadog::tracing::tracer_version << "\n";
+        return 0;
+      }
+    }
+  }
+
   auto logger = make_logger();
 
   auto port = get_port();

--- a/test/system-tests/manual_scheduler.h
+++ b/test/system-tests/manual_scheduler.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cassert>
+#include <datadog/event_scheduler.h>
+#include <datadog/json.hpp>
+
+struct ManualScheduler : public datadog::tracing::EventScheduler {
+  std::function<void()> flush_traces = nullptr;
+  std::function<void()> flush_telemetry = nullptr;
+
+  Cancel schedule_recurring_event(std::chrono::steady_clock::duration /* interval */, std::function<void()> callback) override {
+    assert(callback != nullptr);
+
+    // NOTE: This depends on the precise order that dd-trace-cpp sets up the `schedule_recurring_event`s
+    // for traces and telemetry.
+    if (flush_traces == nullptr) {
+      flush_traces = callback;
+      return {};
+    }
+    if (flush_telemetry == nullptr) {
+      flush_telemetry = callback;
+      return {};
+    }
+    return []() {};
+  }
+
+  nlohmann::json config_json() const override { return nlohmann::json::object({{"type", "ManualScheduler"}}); }
+};

--- a/test/system-tests/manual_scheduler.h
+++ b/test/system-tests/manual_scheduler.h
@@ -1,18 +1,21 @@
 #pragma once
 
-#include <cassert>
 #include <datadog/event_scheduler.h>
+
+#include <cassert>
 #include <datadog/json.hpp>
 
 struct ManualScheduler : public datadog::tracing::EventScheduler {
   std::function<void()> flush_traces = nullptr;
   std::function<void()> flush_telemetry = nullptr;
 
-  Cancel schedule_recurring_event(std::chrono::steady_clock::duration /* interval */, std::function<void()> callback) override {
+  Cancel schedule_recurring_event(
+      std::chrono::steady_clock::duration /* interval */,
+      std::function<void()> callback) override {
     assert(callback != nullptr);
 
-    // NOTE: This depends on the precise order that dd-trace-cpp sets up the `schedule_recurring_event`s
-    // for traces and telemetry.
+    // NOTE: This depends on the precise order that dd-trace-cpp sets up the
+    // `schedule_recurring_event`s for traces and telemetry.
     if (flush_traces == nullptr) {
       flush_traces = callback;
       return {};
@@ -24,5 +27,7 @@ struct ManualScheduler : public datadog::tracing::EventScheduler {
     return []() {};
   }
 
-  nlohmann::json config_json() const override { return nlohmann::json::object({{"type", "ManualScheduler"}}); }
+  nlohmann::json config_json() const override {
+    return nlohmann::json::object({{"type", "ManualScheduler"}});
+  }
 };

--- a/test/system-tests/request_handler.cpp
+++ b/test/system-tests/request_handler.cpp
@@ -1,0 +1,249 @@
+#include "request_handler.h"
+
+#include <datadog/optional.h>
+#include <datadog/span_config.h>
+#include <datadog/tracer.h>
+#include <datadog/tracer_config.h>
+
+#include <datadog/json.hpp>
+
+#include "httplib.h"
+#include "utils.h"
+
+RequestHandler::RequestHandler(
+    datadog::tracing::FinalizedTracerConfig& tracerConfig,
+    std::shared_ptr<ManualScheduler> scheduler,
+    std::shared_ptr<DeveloperNoiseLogger> logger)
+    : tracer_(tracerConfig),
+      scheduler_(scheduler),
+      logger_(std::move(logger)) {}
+
+void RequestHandler::set_error(const char* const file, int line,
+                               const std::string& reason,
+                               httplib::Response& res) {
+  logger_->log_info(reason);
+
+  // clang-format off
+    const auto error = nlohmann::json{
+        {"detail", {
+          {"loc", nlohmann::json::array({file, line})},
+          {"msg", reason},
+          {"type", "Validation Error"}
+        }}
+    };
+  // clang-format on
+
+  res.status = 422;
+  res.set_content(error.dump(), "application/json");
+}
+
+#define VALIDATION_ERROR(res, msg)         \
+  set_error(__FILE__, __LINE__, msg, res); \
+  return
+
+void RequestHandler::on_span_start(const httplib::Request& req,
+                                   httplib::Response& res) {
+  const auto request_json = nlohmann::json::parse(req.body);
+
+  datadog::tracing::SpanConfig span_cfg;
+  span_cfg.name = request_json.at("name");
+
+  if (auto service =
+          utils::get_if_exists<std::string_view>(request_json, "service")) {
+    span_cfg.service = *service;
+  }
+
+  if (auto service_type =
+          utils::get_if_exists<std::string_view>(request_json, "type")) {
+    span_cfg.service_type = *service_type;
+  }
+
+  if (auto resource =
+          utils::get_if_exists<std::string_view>(request_json, "resource")) {
+    span_cfg.resource = *resource;
+  }
+
+  if (auto origin =
+          utils::get_if_exists<std::string_view>(request_json, "origin")) {
+    logger_->log_info(
+        "[start_span] origin, but this can only be set via the "
+        "'x-datadog-origin' header");
+  }
+
+  auto success = [](const datadog::tracing::Span& span,
+                    httplib::Response& res) {
+    // clang-format off
+      const auto response_body = nlohmann::json{
+        { "trace_id", span.trace_id().low },
+        { "span_id", span.id() }
+      };
+    // clang-format on
+
+    res.set_content(response_body.dump(), "application/json");
+  };
+
+  if (auto parent_id =
+          utils::get_if_exists<uint64_t>(request_json, "parent_id")) {
+    if (*parent_id != 0) {
+      auto parent_span_it = active_spans_.find(*parent_id);
+      if (parent_span_it == active_spans_.cend()) {
+        const auto msg = "on_span_start: span not found for id " +
+                         std::to_string(*parent_id);
+        VALIDATION_ERROR(res, msg);
+      }
+
+      auto span = parent_span_it->second.create_child(span_cfg);
+      success(span, res);
+      active_spans_.emplace(span.id(), std::move(span));
+      return;
+    }
+  }
+
+  if (auto http_headers = utils::get_if_exists<nlohmann::json::array_t>(
+          request_json, "http_headers")) {
+    if (!http_headers->empty()) {
+      auto maybe_span = tracer_.extract_or_create_span(
+          utils::HeaderReader(*http_headers), span_cfg);
+      if (auto error = maybe_span.if_error()) {
+        logger_->log_error(
+            error->with_prefix("could not extract span from http_headers: "));
+      } else {
+        success(*maybe_span, res);
+        active_spans_.emplace(maybe_span->id(), std::move(*maybe_span));
+        return;
+      }
+    }
+  }
+
+  auto span = tracer_.create_span(span_cfg);
+  success(span, res);
+  active_spans_.emplace(span.id(), std::move(span));
+}
+
+void RequestHandler::on_span_end(const httplib::Request& req,
+                                 httplib::Response& res) {
+  const auto request_json = nlohmann::json::parse(req.body);
+
+  auto span_id = utils::get_if_exists<uint64_t>(request_json, "span_id");
+  if (!span_id) {
+    VALIDATION_ERROR(res, "on_span_end: missing `span_id` field.");
+  }
+
+  auto span_it = active_spans_.find(*span_id);
+  if (span_it == active_spans_.cend()) {
+    const auto msg =
+        "on_span_end: span not found for id " + std::to_string(*span_id);
+    VALIDATION_ERROR(res, msg);
+  }
+
+  active_spans_.erase(span_it);
+  res.status = 200;
+}
+
+void RequestHandler::on_set_meta(const httplib::Request& req,
+                                 httplib::Response& res) {
+  const auto request_json = nlohmann::json::parse(req.body);
+
+  auto span_id = utils::get_if_exists<uint64_t>(request_json, "span_id");
+  if (!span_id) {
+    VALIDATION_ERROR(res, "on_set_meta: missing `span_id` field.");
+  }
+
+  auto span_it = active_spans_.find(*span_id);
+  if (span_it == active_spans_.cend()) {
+    const auto msg =
+        "on_set_meta: span not found for id " + std::to_string(*span_id);
+    VALIDATION_ERROR(res, msg);
+  }
+
+  auto& span = span_it->second;
+  span.set_tag(request_json.at("key").get<std::string_view>(),
+               request_json.at("value").get<std::string_view>());
+
+  res.status = 200;
+}
+
+void RequestHandler::on_set_metric(const httplib::Request& /* req */,
+                                   httplib::Response& res) {
+  // No method available for directly setting a span metric.
+  // Returning OK instead of UNIMPLEMENTED to satisfy the test framework.
+  res.status = 200;
+}
+
+void RequestHandler::on_inject_headers(const httplib::Request& req,
+                                       httplib::Response& res) {
+  const auto request_json = nlohmann::json::parse(req.body);
+
+  auto span_id = utils::get_if_exists<uint64_t>(request_json, "span_id");
+  if (!span_id) {
+    VALIDATION_ERROR(res, "on_inject_headers: missing `span_id` field.");
+  }
+
+  auto span_it = active_spans_.find(*span_id);
+  if (span_it == active_spans_.cend()) {
+    const auto msg =
+        "on_inject_headers: span not found for id " + std::to_string(*span_id);
+    VALIDATION_ERROR(res, msg);
+  }
+
+  // clang-format off
+    nlohmann::json response_json{
+      { "http_headers", nlohmann::json::array() }
+    };
+  // clang-format on
+
+  utils::HeaderWriter writer(response_json["http_headers"]);
+  span_it->second.inject(writer);
+
+  res.set_content(response_json.dump(), "application/json");
+}
+
+void RequestHandler::on_span_flush(const httplib::Request& /* req */,
+                                   httplib::Response& res) {
+  scheduler_->flush_telemetry();
+  res.status = 200;
+}
+
+void RequestHandler::on_stats_flush(const httplib::Request& /* req */,
+                                    httplib::Response& res) {
+  scheduler_->flush_traces();
+  res.status = 200;
+}
+
+void RequestHandler::on_span_error(const httplib::Request& req,
+                                   httplib::Response& res) {
+  const auto request_json = nlohmann::json::parse(req.body);
+
+  auto span_id = utils::get_if_exists<uint64_t>(request_json, "span_id");
+  if (!span_id) {
+    VALIDATION_ERROR(res, "on_span_error: missing `span_id` field.");
+  }
+
+  auto span_it = active_spans_.find(*span_id);
+  if (span_it == active_spans_.cend()) {
+    const auto msg =
+        "on_span_error: span not found for id " + std::to_string(*span_id);
+    VALIDATION_ERROR(res, msg);
+  }
+
+  auto& span = span_it->second;
+
+  if (auto type =
+          utils::get_if_exists<std::string_view>(request_json, "type")) {
+    if (!type->empty()) span.set_error_type(*type);
+  }
+
+  if (auto message =
+          utils::get_if_exists<std::string_view>(request_json, "message")) {
+    if (!message->empty()) span.set_error_message(*message);
+  }
+
+  if (auto stack =
+          utils::get_if_exists<std::string_view>(request_json, "stack")) {
+    if (!stack->empty()) span.set_error_stack(*stack);
+  }
+
+  res.status = 200;
+}
+
+#undef VALIDATION_ERROR

--- a/test/system-tests/request_handler.h
+++ b/test/system-tests/request_handler.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <datadog/optional.h>
+#include <datadog/span_config.h>
+#include <datadog/tracer.h>
+#include <datadog/tracer_config.h>
+
+#include "developer_noise.h"
+#include "httplib.h"
+#include "manual_scheduler.h"
+#include "utils.h"
+
+class RequestHandler final {
+ public:
+  RequestHandler(datadog::tracing::FinalizedTracerConfig& tracerConfig,
+                 std::shared_ptr<ManualScheduler> scheduler,
+                 std::shared_ptr<DeveloperNoiseLogger> logger);
+
+  void set_error(const char* const file, int line, const std::string& reason,
+                 httplib::Response& res);
+
+  void on_span_start(const httplib::Request& req, httplib::Response& res);
+  void on_span_end(const httplib::Request& req, httplib::Response& res);
+  void on_set_meta(const httplib::Request& req, httplib::Response& res);
+  void on_set_metric(const httplib::Request& /* req */, httplib::Response& res);
+  void on_inject_headers(const httplib::Request& req, httplib::Response& res);
+  void on_span_flush(const httplib::Request& /* req */, httplib::Response& res);
+  void on_stats_flush(const httplib::Request& /* req */,
+                      httplib::Response& res);
+  void on_span_error(const httplib::Request& req, httplib::Response& res);
+
+ private:
+  datadog::tracing::Tracer tracer_;
+  std::shared_ptr<ManualScheduler> scheduler_;
+  std::shared_ptr<DeveloperNoiseLogger> logger_;
+  std::unordered_map<uint64_t, datadog::tracing::Span> active_spans_;
+
+#undef VALIDATION_ERROR
+};

--- a/test/system-tests/utils.h
+++ b/test/system-tests/utils.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <datadog/dict_reader.h>
+#include <datadog/dict_writer.h>
+
+#include <datadog/json.hpp>
+#include <string>
+
+namespace utils {
+
+namespace dd = datadog::tracing;
+
+inline std::string tolower(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return s;
+}
+
+template <typename T>
+std::optional<T> get_if_exists(const nlohmann::json& j, std::string_view key) {
+  if (auto it = j.find(key); it != j.cend()) {
+    return it->get<T>();
+  }
+  return std::nullopt;
+}
+
+class HeaderReader final : public datadog::tracing::DictReader {
+  const nlohmann::json::array_t headers_;
+
+ public:
+  HeaderReader(const nlohmann::json::array_t& headers) : headers_(headers) {}
+  ~HeaderReader() override = default;
+
+  // Return the value at the specified `key`, or return `nullopt` if there
+  // is no value at `key`.
+  dd::Optional<dd::StringView> lookup(dd::StringView key) const override {
+    for (const auto& subarray : headers_) {
+      if (subarray.size() == 2) {
+        if (tolower(subarray[0].get<std::string>()) == std::string(key)) {
+          return subarray[1].get<std::string_view>();
+        } else if (tolower(subarray[1].get<std::string>()) ==
+                   std::string(key)) {
+          return subarray[0].get<std::string_view>();
+        }
+      }
+    }
+
+    return dd::nullopt;
+  };
+
+  // Invoke the specified `visitor` once for each key/value pair in this object.
+  void visit(const std::function<void(dd::StringView key,
+                                      dd::StringView value)>& /* visitor */)
+      const override {}
+};
+
+class HeaderWriter final : public dd::DictWriter {
+  nlohmann::json& j_;
+
+ public:
+  HeaderWriter(nlohmann::json& headers) : j_(headers){};
+  ~HeaderWriter() = default;
+
+  // Associate the specified `value` with the specified `key`.  An
+  // implementation may, but is not required to, overwrite any previous value at
+  // `key`.
+  void set(dd::StringView key, dd::StringView value) override {
+    j_.emplace_back(nlohmann::json::array({key, value}));
+  };
+};
+
+}  // namespace utils


### PR DESCRIPTION
# Description
I've decided to move the parametric system server closer to the source code. This will allow us to give it the attention it deserves. On the other side, system-tests will only need to focus on obtaining a version of dd-trace-cpp, and they'll always build the corresponding parametric HTTP server.

