### PR TITLE
Allow setting internal tags and expose numeric tags as metrics

### DIFF
--- a/src/datadog/span.cpp
+++ b/src/datadog/span.cpp
@@ -124,9 +124,7 @@ void Span::set_metric(StringView name, double value) {
   data_->numeric_tags.insert_or_assign(std::string(name), value);
 }
 
-void Span::remove_tag(StringView name) {
-  data_->tags.erase(std::string(name));
-}
+void Span::remove_tag(StringView name) { data_->tags.erase(std::string(name)); }
 
 void Span::remove_metric(StringView name) {
   data_->numeric_tags.erase(std::string(name));

--- a/src/datadog/span.cpp
+++ b/src/datadog/span.cpp
@@ -101,10 +101,6 @@ const std::string& Span::name() const { return data_->name; }
 const std::string& Span::resource_name() const { return data_->resource; }
 
 Optional<StringView> Span::lookup_tag(StringView name) const {
-  if (tags::is_internal(name)) {
-    return nullopt;
-  }
-
   const auto found = data_->tags.find(std::string(name));
   if (found == data_->tags.end()) {
     return nullopt;
@@ -112,16 +108,28 @@ Optional<StringView> Span::lookup_tag(StringView name) const {
   return found->second;
 }
 
-void Span::set_tag(StringView name, StringView value) {
-  if (!tags::is_internal(name)) {
-    data_->tags.insert_or_assign(std::string(name), std::string(value));
+Optional<double> Span::lookup_metric(StringView name) const {
+  const auto found = data_->numeric_tags.find(std::string(name));
+  if (found == data_->numeric_tags.end()) {
+    return nullopt;
   }
+  return found->second;
+}
+
+void Span::set_tag(StringView name, StringView value) {
+  data_->tags.insert_or_assign(std::string(name), std::string(value));
+}
+
+void Span::set_metric(StringView name, double value) {
+  data_->numeric_tags.insert_or_assign(std::string(name), value);
 }
 
 void Span::remove_tag(StringView name) {
-  if (!tags::is_internal(name)) {
-    data_->tags.erase(std::string(name));
-  }
+  data_->tags.erase(std::string(name));
+}
+
+void Span::remove_metric(StringView name) {
+  data_->numeric_tags.erase(std::string(name));
 }
 
 void Span::set_service_name(StringView service) {

--- a/src/datadog/span.h
+++ b/src/datadog/span.h
@@ -125,12 +125,19 @@ class Span {
   // Return the value of the tag having the specified `name`, or return null if
   // there is no such tag.
   Optional<StringView> lookup_tag(StringView name) const;
+  // Return the value of the metric having the specified `name`, or return null
+  // if there is no such metric.
+  Optional<double> lookup_metric(StringView name) const;
   // Overwrite the tag having the specified `name` so that it has the specified
   // `value`, or create a new tag.
   void set_tag(StringView name, StringView value);
+  // Overwrite the metric having the specified `name` so that it has the
+  // specified `value`, or create a new metric.
+  void set_metric(StringView name, double value);
   // Delete the tag having the specified `name` if it exists.
   void remove_tag(StringView name);
-
+  // Delete the metric having the specified `name` if it exists.
+  void remove_metric(StringView name);
   // Set the name of the service associated with this span, e.g.
   // "ingress-nginx-useast1".
   void set_service_name(StringView);

--- a/src/datadog/span_data.cpp
+++ b/src/datadog/span_data.cpp
@@ -51,9 +51,7 @@ void SpanData::apply_config(const SpanDefaults& defaults,
     tags.insert_or_assign(tags::version, version);
   }
   for (const auto& [key, value] : config.tags) {
-    if (!tags::is_internal(key)) {
-      tags.insert_or_assign(key, value);
-    }
+    tags.insert_or_assign(key, value);
   }
 
   resource = config.resource.value_or(name);

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -197,7 +197,7 @@ TEST_CASE("set_metric") {
       auto span = tracer.create_span();
       span.set_metric("foo", 5.0);
       span.set_metric("foo.bar", 3.0);
-      span.set_metric("foo.baz", 1.0) ;
+      span.set_metric("foo.baz", 1.0);
     }
 
     REQUIRE(collector->chunks.size() == 1);


### PR DESCRIPTION
Simple PR which introduces the following changes:
- Expose `numeric_tags` through the API, although the new API functions refer to `metrics` for consistency with other tracers (e.g. PHP).
- Allow setting internal tags through the API, this is necessary as `dd-trace-cpp` is used by other internal projects such as ASM. 