### PR TITLE
parse_util: include cstdint to fix compilation under GCC 13

### DIFF
--- a/src/datadog/parse_util.h
+++ b/src/datadog/parse_util.h
@@ -2,6 +2,7 @@
 
 // This component provides parsing-related miscellanea.
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
Since GCC 13, std::uint64_t and friends require an explicit include of `<cstdint>`.
See also https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes