### PR TITLE
Add CODEOWNERS and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Automatically assign the team as a reviewer.
+# https://help.github.com/en/articles/about-code-owners
+
+# Default owners, overridden by file/directory specific owners below
+* @DataDog/dd-trace-cpp

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+# What Does This Do
+
+# Motivation
+
+# Additional Notes
+
+Jira ticket: [PROJ-IDENT]
+
+<!--
+# Opening vs Drafting a PR:
+When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.
+
+# Linking a JIRA ticket:
+Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
+This requirement only applies to Datadog employees.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# What Does This Do
+# Description
 
 # Motivation
 


### PR DESCRIPTION
# What Does This Do
Adds CODEOWNERS and PR template to this repository

# Motivation
* Automatic assignment of reviewers
*  baseline for PR descriptions

# Additional Notes

Jira ticket: [APMAPI-60](https://datadoghq.atlassian.net/browse/APMAPI-60)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.
# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->

[APMAPI-60]: https://datadoghq.atlassian.net/browse/APMAPI-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ