### PR TITLE
fix: regex usage in w3c extraction

### DIFF
--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -622,6 +622,13 @@ TEST_CASE("span extraction") {
          67667974448284343ULL, // expected_parent_id
          0}, // expected_sampling_priority
 
+        {__LINE__, "valid: leading and trailing spaces",
+         "    00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01 \t", // traceparent
+         nullopt,
+         *TraceID::parse_hex("4bf92f3577b34da6a3ce929d0e0e4736"), // expected_trace_id
+         67667974448284343ULL, // expected_parent_id
+         1}, // expected_sampling_priority
+
         {__LINE__, "no traceparent",
          nullopt}, // traceparent
 


### PR DESCRIPTION
# Description
Usage of std::regex_match was problematic for traceparent with trailing spaces. The overload use is `std::regex_match(str, str + std::char_traits<CharT>::length(str), m, e, flags)`, which resolves as the whole input instead of the trimmed input.

This regression has been introduced in #119 

Changes:
  - Fix std::regex_match usage.
  - Add unit test.
