### PR TITLE
fix: W3C datadog `p` field propagation

### DIFF
--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -174,6 +174,7 @@ Optional<PartiallyParsedTracestate> parse_tracestate(StringView tracestate) {
 // - `origin`
 // - `trace_tags`
 // - `sampling_priority`
+// - `datadog_w3c_parent_id`
 // - `additional_datadog_w3c_tracestate`
 void parse_datadog_tracestate(ExtractedData& result, StringView datadog_value) {
   const std::size_t end = datadog_value.size();
@@ -217,10 +218,6 @@ void parse_datadog_tracestate(ExtractedData& result, StringView datadog_value) {
         result.sampling_priority = priority;
       }
     } else if (key == "p") {
-      if (value.size() != 16) {
-        continue;
-      }
-
       result.datadog_w3c_parent_id = std::string(value);
     } else if (starts_with(key, "t.")) {
       // The part of the key that follows "t." is the name of a trace tag,

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -899,18 +899,6 @@ TEST_CASE("span extraction") {
 
         {
             __LINE__,
-            "dd parent id is malformed",
-            traceparent_drop,    // traceparent
-            "dd=p:XxDDOGxX",     // tracestate
-            0,                   // expected_sampling_priority
-            nullopt,             // expected_origin
-            {},                  // expected_trace_tags
-            nullopt,             // expected_additional_w3c_tracestate
-            nullopt,             // expected_additional_datadog_w3c_tracestate
-            "0000000000000000",  // expected_datadog_w3c_parent_id,
-        },
-        {
-            __LINE__,
             "dd parent id is propagated even if not valid",
             traceparent_drop,         // traceparent
             "dd=p:yu7C0o3AOmbOcfXw",  // tracestate


### PR DESCRIPTION
# Description

I clarified a misunderstanding of the W3C Phase 2 RFC. The tracer must decode the `p` field, tag the span and propagate the `p` value whether it is valid or not.