### PR TITLE
fix: `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS` support floating point input

### DIFF
--- a/src/datadog/datadog_agent_config.h
+++ b/src/datadog/datadog_agent_config.h
@@ -61,7 +61,7 @@ struct DatadogAgentConfig {
   Optional<bool> remote_configuration_enabled;
   // How often, in seconds, to query the Datadog Agent for remote configuration
   // updates.
-  Optional<int> remote_configuration_poll_interval_seconds;
+  Optional<double> remote_configuration_poll_interval_seconds;
 
   static Expected<HTTPClient::URL> parse(StringView);
 };

--- a/test/test_tracer_config.cpp
+++ b/test/test_tracer_config.cpp
@@ -446,14 +446,6 @@ TEST_CASE("TracerConfig::agent") {
   }
 
   SECTION("remote configuration poll interval") {
-    SECTION("cannot be zero") {
-      config.agent.remote_configuration_poll_interval_seconds = 0;
-      auto finalized = finalize_config(config);
-      REQUIRE(!finalized);
-      REQUIRE(finalized.error().code ==
-              Error::DATADOG_AGENT_INVALID_REMOTE_CONFIG_POLL_INTERVAL);
-    }
-
     SECTION("cannot be negative") {
       config.agent.remote_configuration_poll_interval_seconds = -1337;
       auto finalized = finalize_config(config);
@@ -491,7 +483,7 @@ TEST_CASE("TracerConfig::agent") {
                                  "ddog"};
         auto finalized = finalize_config(config);
         REQUIRE(!finalized);
-        REQUIRE(finalized.error().code == Error::INVALID_INTEGER);
+        REQUIRE(finalized.error().code == Error::INVALID_DOUBLE);
       }
     }
   }


### PR DESCRIPTION
# Description

According to the Remote Configuration specification, `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS` support floating point input and can be set to `0`.

# Motivation

System-tests use sub-seconds value for fast iteration. In order to test the library against remote configuration tests, the library must support sub-seconds inputs.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
