### PR TITLE
api: update the tracer api

### DIFF
--- a/examples/http-server/proxy/proxy.cpp
+++ b/examples/http-server/proxy/proxy.cpp
@@ -51,36 +51,36 @@ int main() {
                              httplib::Response& res) {
     tracingutil::HeaderReader reader(req.headers);
     auto span = tracer.extract_or_create_span(reader);
-    span->set_name("forward.request");
-    span->set_resource_name(req.method + " " + req.path);
-    span->set_tag("network.origin.ip", req.remote_addr);
-    span->set_tag("network.origin.port", std::to_string(req.remote_port));
-    span->set_tag("http.url_details.path", req.target);
-    span->set_tag("http.route", req.path);
-    span->set_tag("http.method", req.method);
+    span.set_name("forward.request");
+    span.set_resource_name(req.method + " " + req.path);
+    span.set_tag("network.origin.ip", req.remote_addr);
+    span.set_tag("network.origin.port", std::to_string(req.remote_port));
+    span.set_tag("http.url_details.path", req.target);
+    span.set_tag("http.route", req.path);
+    span.set_tag("http.method", req.method);
 
     httplib::Error er;
     httplib::Request forward_request(req);
     forward_request.path = req.target;
 
     tracingutil::HeaderWriter writer(forward_request.headers);
-    span->inject(writer);
+    span.inject(writer);
 
     upstream_client.send(forward_request, res, er);
     if (er != httplib::Error::Success) {
       res.status = 500;
-      span->set_error_message(httplib::to_string(er));
+      span.set_error_message(httplib::to_string(er));
       std::cerr << "Error occurred while proxying request: " << req.target
                 << "\n";
     } else {
       tracingutil::HeaderReader reader(res.headers);
-      auto status = span->read_sampling_delegation_response(reader);
+      auto status = span.read_sampling_delegation_response(reader);
       if (auto error = status.if_error()) {
         std::cerr << error << "\n";
       }
     }
 
-    span->set_tag("http.status_code", std::to_string(res.status));
+    span.set_tag("http.status_code", std::to_string(res.status));
   };
 
   httplib::Server server;

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -281,6 +281,10 @@ void TraceSegment::span_finished() {
   tracer_telemetry_->metrics().tracer.trace_segments_closed.inc();
 }
 
+void TraceSegment::override_sampling_priority(SamplingPriority priority) {
+  override_sampling_priority(static_cast<int>(priority));
+}
+
 void TraceSegment::override_sampling_priority(int priority) {
   SamplingDecision decision;
   decision.priority = priority;

--- a/src/datadog/trace_segment.h
+++ b/src/datadog/trace_segment.h
@@ -38,6 +38,7 @@
 #include "optional.h"
 #include "propagation_style.h"
 #include "sampling_decision.h"
+#include "sampling_priority.h"
 #include "tracer_telemetry.h"
 
 namespace datadog {
@@ -147,6 +148,7 @@ class TraceSegment {
   // Set the sampling decision to be a local, manual decision with the specified
   // sampling `priority`.  Overwrite any previous sampling decision.
   void override_sampling_priority(int priority);
+  void override_sampling_priority(SamplingPriority priority);
 
  private:
   // If `sampling_decision_` is null, use `trace_sampler_` to make a

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -310,17 +310,17 @@ Expected<Span> Tracer::extract_span(const DictReader& reader,
   return span;
 }
 
-Expected<Span> Tracer::extract_or_create_span(const DictReader& reader) {
+Span Tracer::extract_or_create_span(const DictReader& reader) {
   return extract_or_create_span(reader, SpanConfig{});
 }
 
-Expected<Span> Tracer::extract_or_create_span(const DictReader& reader,
-                                              const SpanConfig& config) {
+Span Tracer::extract_or_create_span(const DictReader& reader,
+                                    const SpanConfig& config) {
   auto maybe_span = extract_span(reader, config);
-  if (!maybe_span && maybe_span.error().code == Error::NO_SPAN_TO_EXTRACT) {
-    return create_span(config);
+  if (maybe_span) {
+    return std::move(*maybe_span);
   }
-  return maybe_span;
+  return create_span(config);
 }
 
 }  // namespace tracing

--- a/src/datadog/tracer.h
+++ b/src/datadog/tracer.h
@@ -76,9 +76,9 @@ class Tracer {
   // new trace (see `create_span`).  Optionally specify a `config` indicating
   // the attributes of the span.  If a failure occurs, then return an error.
   // Note that the absence of a span to extract is not considered an error.
-  Expected<Span> extract_or_create_span(const DictReader& reader);
-  Expected<Span> extract_or_create_span(const DictReader& reader,
-                                        const SpanConfig& config);
+  Span extract_or_create_span(const DictReader& reader);
+  Span extract_or_create_span(const DictReader& reader,
+                              const SpanConfig& config);
 
   // Return a JSON object describing this Tracer's configuration. It is the same
   // JSON object that was logged when this Tracer was created.

--- a/test/system-tests/request_handler.cpp
+++ b/test/system-tests/request_handler.cpp
@@ -102,16 +102,11 @@ void RequestHandler::on_span_start(const httplib::Request& req,
   if (auto http_headers = utils::get_if_exists<nlohmann::json::array_t>(
           request_json, "http_headers")) {
     if (!http_headers->empty()) {
-      auto maybe_span = tracer_.extract_or_create_span(
+      auto span = tracer_.extract_or_create_span(
           utils::HeaderReader(*http_headers), span_cfg);
-      if (auto error = maybe_span.if_error()) {
-        logger_->log_error(
-            error->with_prefix("could not extract span from http_headers: "));
-      } else {
-        success(*maybe_span, res);
-        active_spans_.emplace(maybe_span->id(), std::move(*maybe_span));
-        return;
-      }
+      success(span, res);
+      active_spans_.emplace(span.id(), std::move(span));
+      return;
     }
   }
 

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -263,8 +263,7 @@ TEST_CASE("span extraction") {
     const std::unordered_map<std::string, std::string> no_headers;
     MockDictReader reader{no_headers};
     auto span = tracer.extract_or_create_span(reader);
-    REQUIRE(span);
-    REQUIRE(!span->parent_id());
+    REQUIRE(!span.parent_id());
   }
 
   SECTION("extraction failures") {
@@ -546,8 +545,7 @@ TEST_CASE("span extraction") {
       auto span = tracer.extract_or_create_span(reader);
       auto method = "extract_or_create_span";
       CAPTURE(method);
-      REQUIRE(span);
-      checks(test_case, *span);
+      checks(test_case, span);
     }
   }
 


### PR DESCRIPTION
## Description
Update the API:
- `extract_or_create_span` always returns a span, either the extracted one or a new span if the extraction fail.
- `override_sampling_priority` accepts `SamplingPriority`. 

## Motivation
`create_span` always returns a span, while `extract_span` may or may not return a span. Logically, one can think the behavior of `extract_or_create_span` should first attempt to `extract_span`, and if the extraction fails, it should then call `create_span`. At least, that's what the name of the function suggest and I think the desired behavior. 

The other one is for simplicity's sake.