### PR TITLE
fix: prevent crash due to invalid headers

### DIFF
--- a/src/datadog/extraction_util.cpp
+++ b/src/datadog/extraction_util.cpp
@@ -7,7 +7,6 @@
 #include <unordered_map>
 
 #include "extracted_data.h"
-#include "json.hpp"
 #include "logger.h"
 #include "parse_util.h"
 #include "string_util.h"
@@ -223,15 +222,15 @@ std::string extraction_error_prefix(
   std::ostringstream stream;
   stream << "While extracting trace context";
   if (style) {
-    stream << " in the " << to_json(*style) << " propagation style";
+    stream << " in the " << to_string_view(*style) << " propagation style";
   }
-  auto it = headers_examined.begin();
-  if (it != headers_examined.end()) {
-    stream << " from the following headers: [";
-    stream << nlohmann::json(it->first + ": " + it->second);
+
+  if (!headers_examined.empty()) {
+    auto it = headers_examined.begin();
+    stream << " from the following headers: [" << it->first << ": "
+           << it->second;
     for (++it; it != headers_examined.end(); ++it) {
-      stream << ", ";
-      stream << nlohmann::json(it->first + ": " + it->second);
+      stream << ", " << it->first << ": " << it->second;
     }
     stream << "]";
   }

--- a/src/datadog/propagation_style.cpp
+++ b/src/datadog/propagation_style.cpp
@@ -8,7 +8,7 @@
 namespace datadog {
 namespace tracing {
 
-nlohmann::json to_json(PropagationStyle style) {
+StringView to_string_view(PropagationStyle style) {
   // Note: Make sure that these strings are consistent (modulo case) with
   // `parse_propagation_styles` in `tracer_config.cpp`.
   switch (style) {
@@ -23,6 +23,8 @@ nlohmann::json to_json(PropagationStyle style) {
       return "none";
   }
 }
+
+nlohmann::json to_json(PropagationStyle style) { return to_string_view(style); }
 
 nlohmann::json to_json(const std::vector<PropagationStyle>& styles) {
   std::vector<nlohmann::json> styles_json;

--- a/src/datadog/propagation_style.h
+++ b/src/datadog/propagation_style.h
@@ -27,6 +27,7 @@ enum class PropagationStyle {
   NONE,
 };
 
+StringView to_string_view(PropagationStyle style);
 nlohmann::json to_json(PropagationStyle style);
 nlohmann::json to_json(const std::vector<PropagationStyle>& styles);
 

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -383,6 +383,13 @@ TEST_CASE("span extraction") {
          {PropagationStyle::B3},
          {{"x-b3-traceid", "0"}, {"x-b3-spanid", "123"}, {"x-b3-sampled", "0"}},
          Error::ZERO_TRACE_ID},
+        {__LINE__,
+         "character encoding",
+         {PropagationStyle::DATADOG},
+         {{"x-datadog-trace-id", "\xFD\xD0\x6C\x6C\x6F\x2C\x20\xC3\xB1\x21"},
+          {"x-datadog-parent-id", "1234"},
+          {"x-datadog-sampling-priority", "0"}},
+         Error::INVALID_INTEGER},
     }));
 
     CAPTURE(test_case.line);


### PR DESCRIPTION
## Description

When the tracer encounters an invalid propagation header value, logging the list of headers and their values can lead to a crash.

## Details
For each key and value in the list of headers, a `nlohmann::json` instance is created with the following code:
```cpp
stream << nlohmann::json(it->first + ": " + it->second);
```

It is possible to craft an input for any of the headers inspected by the tracer that can cause a crash when the JSON library attempts to parse or dump the input.