### PR TITLE
deps: bump libcurl to 8.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
-option(BUILD_STATIC_LIBS "Build static libraries" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(BUILD_STATIC_LIBS "Build static libraries" ON)
 
 # Consumer of the library using FetchContent do not need
 # to build unit tests, fuzzers and examples.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,20 +199,18 @@ target_sources(dd_trace_cpp-objects PUBLIC
   src/datadog/w3c_propagation.h
 )
 
-# TODO: define public/private
 # Headers location are different depending of whether we are building 
 # or installing the library.
-# target_include_directories(dd_trace_cpp-objects
-#   PUBLIC
-#     $<INSTALL_INTERFACE:src>
-#     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-# )
+target_include_directories(dd_trace_cpp-objects
+  PUBLIC
+    $<INSTALL_INTERFACE:src>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+)
 
-add_dependencies(dd_trace_cpp-objects libcurl_object Threads::Threads)
+add_dependencies(dd_trace_cpp-objects Threads::Threads)
 
 target_link_libraries(dd_trace_cpp-objects
   PUBLIC
-    # libcurl_object
     Threads::Threads
   PRIVATE
     dd_trace::specs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_STATIC_LIBS "Build static libraries" ON)
 
+set(DD_TRACE_TRANSPORT "curl" CACHE STRING "HTTP transport that dd-trace-cpp uses to communicate with the Datadog Agent, can be either 'none' or 'curl'")
+
 # Consumer of the library using FetchContent do not need
 # to build unit tests, fuzzers and examples.
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
@@ -29,7 +31,7 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 endif ()
 
-# Linking this library requires libcurl and threads.
+# Linking this library requires threads.
 find_package(Threads REQUIRED)
 include(cmake/deps/curl.cmake)
 
@@ -38,6 +40,8 @@ string(REGEX MATCH "#define DD_TRACE_VERSION \"[^\"]*" DD_TRACE_VERSION ${DD_TRA
 string(REGEX REPLACE "[^\"]+\"" "" DD_TRACE_VERSION ${DD_TRACE_VERSION})
 message(STATUS "dd-trace-cpp version=[${DD_TRACE_VERSION}]")
 unset(DD_TRACE_VERSION_CPP_CONTENTS)
+
+message(STATUS "dd-trace-cpp transport=${DD_TRACE_TRANSPORT}")
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   message(STATUS "Compiler: MSVC ${CMAKE_CXX_COMPILER_VERSION}")
@@ -72,8 +76,6 @@ endif ()
 add_library(dd_trace_cpp-objects OBJECT)
 add_library(dd_trace::obj ALIAS dd_trace_cpp-objects)
 
-add_dependencies(dd_trace_cpp-objects libcurl)
-
 target_sources(dd_trace_cpp-objects
   PRIVATE
     src/datadog/base64.cpp
@@ -81,10 +83,8 @@ target_sources(dd_trace_cpp-objects
     src/datadog/clock.cpp
     src/datadog/config_manager.cpp
     src/datadog/collector_response.cpp
-    src/datadog/curl.cpp
     src/datadog/datadog_agent_config.cpp
     src/datadog/datadog_agent.cpp
-    src/datadog/default_http_client_curl.cpp
 #     src/datadog/default_http_client_null.cpp use libcurl
     src/datadog/environment.cpp
     src/datadog/error.cpp
@@ -208,10 +208,13 @@ target_sources(dd_trace_cpp-objects PUBLIC
 #     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 # )
 
+add_dependencies(dd_trace_cpp-objects libcurl_object Threads::Threads)
+
 target_link_libraries(dd_trace_cpp-objects
-  PRIVATE
-    libcurl
+  PUBLIC
+    # libcurl_object
     Threads::Threads
+  PRIVATE
     dd_trace::specs
 )
 
@@ -220,11 +223,27 @@ if (BUILD_SHARED_LIBS)
   add_library(dd_trace_cpp-shared SHARED $<TARGET_OBJECTS:dd_trace_cpp-objects>)
   add_library(dd_trace::shared ALIAS dd_trace_cpp-shared)
 
-  add_dependencies(dd_trace_cpp-shared dd_trace_cpp-objects)
+  if (DD_TRACE_TRANSPORT STREQUAL "curl")
+    add_dependencies(dd_trace_cpp-shared CURL::libcurl_shared)
+
+    target_sources(dd_trace_cpp-shared
+      PRIVATE
+        src/datadog/curl.cpp
+        src/datadog/default_http_client_curl.cpp
+    )
+
+    target_link_libraries(dd_trace_cpp-shared
+      PRIVATE
+        CURL::libcurl_shared
+    )
+  endif ()
+
+  add_dependencies(dd_trace_cpp-shared dd_trace_cpp-objects CURL::libcurl_shared)
 
   target_link_libraries(dd_trace_cpp-shared
     PUBLIC
       dd_trace::obj
+      CURL::libcurl_shared
     PRIVATE
       dd_trace::specs
   )
@@ -242,6 +261,21 @@ endif ()
 if (BUILD_STATIC_LIBS)
   add_library(dd_trace_cpp-static STATIC $<TARGET_OBJECTS:dd_trace_cpp-objects>)
   add_library(dd_trace::static ALIAS dd_trace_cpp-static)
+
+  if (DD_TRACE_TRANSPORT STREQUAL "curl")
+    add_dependencies(dd_trace_cpp-static CURL::libcurl_static)
+
+    target_sources(dd_trace_cpp-static
+      PRIVATE
+        src/datadog/curl.cpp
+        src/datadog/default_http_client_curl.cpp
+    )
+
+    target_link_libraries(dd_trace_cpp-static 
+      PRIVATE
+        CURL::libcurl_static
+    )
+  endif ()
 
   add_dependencies(dd_trace_cpp-static dd_trace_cpp-objects)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,15 @@
 # Note: Make sure that this version is the same as that in
 # "./CheckRequiredCMakeVersion.cmake".
 cmake_minimum_required(VERSION 3.24)
+cmake_policy(SET CMP0077 NEW)
 
 project(dd-trace-cpp)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(BUILD_STATIC_LIBS "Build static libraries" OFF)
@@ -25,12 +32,6 @@ endif ()
 # Linking this library requires libcurl and threads.
 find_package(Threads REQUIRED)
 include(cmake/deps/curl.cmake)
-
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/src/datadog/version.cpp DD_TRACE_VERSION_CPP_CONTENTS REGEX "#define DD_TRACE_VERSION( |_NUM )")
 string(REGEX MATCH "#define DD_TRACE_VERSION \"[^\"]*" DD_TRACE_VERSION ${DD_TRACE_VERSION_CPP_CONTENTS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,6 @@ endif()
 
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
-elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(DD_TRACE_ENABLE_SANITIZE ON)
 endif ()
 
 # Linking this library requires libcurl and threads.

--- a/cmake/compiler/msvc.cmake
+++ b/cmake/compiler/msvc.cmake
@@ -43,8 +43,7 @@ target_compile_options(dd_trace_cpp-specs
 
 target_link_options(dd_trace_cpp-specs
   INTERFACE
-    ws2_32
-    wsock32
+    ws2_32.lib
 )
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug|RelWithDebInfo")

--- a/cmake/compiler/msvc.cmake
+++ b/cmake/compiler/msvc.cmake
@@ -44,6 +44,7 @@ target_compile_options(dd_trace_cpp-specs
 target_link_options(dd_trace_cpp-specs
   INTERFACE
     ws2_32
+    wsock32
 )
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug|RelWithDebInfo")

--- a/cmake/compiler/msvc.cmake
+++ b/cmake/compiler/msvc.cmake
@@ -41,6 +41,11 @@ target_compile_options(dd_trace_cpp-specs
     /D_WIN32_WINNT=${win_ver}
 )
 
+target_link_options(dd_trace_cpp-specs
+  INTERFACE
+    ws2_32
+)
+
 if (CMAKE_BUILD_TYPE STREQUAL "Debug|RelWithDebInfo")
   target_compile_options(dd_trace_cpp-specs
     INTERFACE

--- a/cmake/deps/curl.cmake
+++ b/cmake/deps/curl.cmake
@@ -24,6 +24,8 @@ set(CURL_DISABLE_INSTALL ON)
 set(CURL_DISABLE_ALTSVC ON)
 set(CURL_DISABLE_SRP ON)
 
+set(SHARE_LIB_OBJECT ON)
+
 FetchContent_Declare(
   curl
   URL "https://github.com/curl/curl/releases/download/curl-8_8_0/curl-8.8.0.tar.gz"

--- a/cmake/deps/curl.cmake
+++ b/cmake/deps/curl.cmake
@@ -4,25 +4,32 @@ include(FetchContent)
 SET(BUILD_CURL_EXE OFF)
 SET(BUILD_SHARED_LIBS OFF)
 SET(BUILD_STATIC_LIBS ON)
+set(BUILD_LIBCURL_DOCS OFF)
+set(BUILD_MISC_DOCS OFF)
 
-# Disables all protocols except HTTP
+# Disable all protocols except HTTP
 SET(HTTP_ONLY ON)
+
+# Disable curl features
+SET(USE_ZLIB OFF)
+SET(USE_LIBIDN2 OFF)
 SET(CURL_ENABLE_SSL OFF)
 SET(CURL_BROTLI OFF)
 SET(CURL_ZSTD OFF)
 SET(CURL_ZLIB OFF)
-SET(USE_ZLIB OFF)
-SET(USE_LIBIDN2 OFF)
 SET(CURL_USE_LIBSSH2 OFF)
 SET(CURL_USE_LIBPSL OFF)
 SET(CURL_DISABLE_HSTS ON)
 set(CURL_CA_PATH "none")
 set(CURL_CA_PATH_SET FALSE)
+set(CURL_DISABLE_INSTALL ON)
+set(CURL_DISABLE_ALTSVC ON)
+set(CURL_DISABLE_SRP ON)
 
 FetchContent_Declare(
   curl
-  URL "https://github.com/curl/curl/releases/download/curl-7_85_0/curl-7.85.0.tar.gz"
-  URL_MD5 "4e9eb4f434e9be889e510f038754d3de"
+  URL "https://github.com/curl/curl/releases/download/curl-8_8_0/curl-8.8.0.tar.gz"
+  URL_MD5 "2300048f61e6196678281a8612a873ef"
 )
 
 FetchContent_MakeAvailable(curl)

--- a/cmake/deps/curl.cmake
+++ b/cmake/deps/curl.cmake
@@ -2,8 +2,6 @@ include(FetchContent)
 
 # No need to build curl executable
 SET(BUILD_CURL_EXE OFF)
-SET(BUILD_SHARED_LIBS OFF)
-SET(BUILD_STATIC_LIBS ON)
 set(BUILD_LIBCURL_DOCS OFF)
 set(BUILD_MISC_DOCS OFF)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,7 +41,7 @@ add_executable(tests
 target_link_libraries(tests 
   PRIVATE
     # TODO: Remove dependency on libcurl
-    libcurl
+    CURL::libcurl_static
     dd_trace_cpp-static
     dd_trace::specs
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,7 +40,6 @@ add_executable(tests
 
 target_link_libraries(tests 
   PRIVATE
-    libcurl
     dd_trace_cpp-static
     dd_trace::specs
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,8 @@ add_executable(tests
 
 target_link_libraries(tests 
   PRIVATE
+    # TODO: Remove dependency on libcurl
+    libcurl
     dd_trace_cpp-static
     dd_trace::specs
 )


### PR DESCRIPTION
# Description

- Fix crash on macOS Sonoma: https://github.com/curl/curl/issues/11893
- Disable more curl features.
- Debug build do not enable sanitizers anymore.
- Fix usage of `BUILD_*_LIBS`

# Before merging
- [x] Assess binary size impact. No increase of binary size.