### PR TITLE
fix: trim inspected headers

### DIFF
--- a/src/datadog/extraction_util.cpp
+++ b/src/datadog/extraction_util.cpp
@@ -71,7 +71,7 @@ Expected<Optional<std::uint64_t>> extract_id_header(const DictReader& headers,
   if (!found) {
     return result;
   }
-  auto parsed_id = parse_uint64(*found, base);
+  auto parsed_id = parse_uint64(trim(*found), base);
   if (auto* error = parsed_id.if_error()) {
     std::string prefix;
     prefix += "Could not extract ";
@@ -127,7 +127,7 @@ Expected<ExtractedData> extract_datadog(
   result.parent_id = *parent_id;
 
   if (auto found = headers.lookup("x-datadog-sampling-priority")) {
-    auto sampling_priority = parse_int(*found, 10);
+    auto sampling_priority = parse_int(trim(*found), 10);
     if (auto* error = sampling_priority.if_error()) {
       std::string prefix;
       prefix +=
@@ -166,7 +166,7 @@ Expected<ExtractedData> extract_b3(
   result.style = PropagationStyle::B3;
 
   if (auto found = headers.lookup("x-b3-traceid")) {
-    auto parsed = TraceID::parse_hex(*found);
+    auto parsed = TraceID::parse_hex(trim(*found));
     if (auto* error = parsed.if_error()) {
       std::string prefix = "Could not extract B3-style trace ID from \"";
       append(prefix, *found);
@@ -185,7 +185,7 @@ Expected<ExtractedData> extract_b3(
 
   const StringView sampling_priority_header = "x-b3-sampled";
   if (auto found = headers.lookup(sampling_priority_header)) {
-    auto sampling_priority = parse_int(*found, 10);
+    auto sampling_priority = parse_int(trim(*found), 10);
     if (auto* error = sampling_priority.if_error()) {
       std::string prefix;
       prefix += "Could not extract B3-style sampling priority from ";

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -446,6 +446,15 @@ TEST_CASE("span extraction") {
          456,
          2},
         {__LINE__,
+         "datadog style with leading and trailing spaces",
+         {PropagationStyle::DATADOG},
+         {{"x-datadog-trace-id", "   123  "},
+          {"x-datadog-parent-id", " 456  "},
+          {"x-datadog-sampling-priority", "    2 "}},
+         TraceID(123),
+         456,
+         2},
+        {__LINE__,
          "datadog style without sampling priority",
          {PropagationStyle::DATADOG},
          {{"x-datadog-trace-id", "123"}, {"x-datadog-parent-id", "456"}},
@@ -465,6 +474,15 @@ TEST_CASE("span extraction") {
          {{"x-b3-traceid", "abc"},
           {"x-b3-spanid", "def"},
           {"x-b3-sampled", "0"}},
+         TraceID(0xabc),
+         0xdef,
+         0},
+        {__LINE__,
+         "B3 style with leading and trailing spaces",
+         {PropagationStyle::B3},
+         {{"x-b3-traceid", "   abc   "},
+          {"x-b3-spanid", " def  "},
+          {"x-b3-sampled", "     0  "}},
          TraceID(0xabc),
          0xdef,
          0},
@@ -593,6 +611,13 @@ TEST_CASE("span extraction") {
         // https://www.w3.org/TR/trace-context/#examples-of-http-traceparent-headers
         {__LINE__, "valid: w3.org example 1",
          "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", // traceparent
+         nullopt,
+         *TraceID::parse_hex("4bf92f3577b34da6a3ce929d0e0e4736"), // expected_trace_id
+         67667974448284343ULL, // expected_parent_id
+         1}, // expected_sampling_priority
+
+        {__LINE__, "valid: w3.org example 1 with leading and trailing spaces",
+         "   00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01   ", // traceparent
          nullopt,
          *TraceID::parse_hex("4bf92f3577b34da6a3ce929d0e0e4736"), // expected_trace_id
          67667974448284343ULL, // expected_parent_id


### PR DESCRIPTION
## Description
Fixed a regression introduced in issue #42  that prevented HTTP headers with leading spaces from being parsed. This issue could result in the failure to extract trace context and the creation of a new trace, even though the trace could have been extracted and continued in versions prior to v0.1.11.

