### PR TITLE
feat: ensure tracecontext headers take precedence over datadog (AIT-10281)

### DIFF
--- a/src/datadog/extraction_util.cpp
+++ b/src/datadog/extraction_util.cpp
@@ -288,8 +288,6 @@ ExtractedData merge(
                  dd->second.trace_id == result.trace_id &&
                  dd->second.parent_id.has_value()) {
         result.datadog_w3c_parent_id = hex_padded(dd->second.parent_id.value());
-        // TODO: Do we add the result.headers_examined for all of the dd ones?
-        // Or just the x-datadog-parent-id?
       }
 
       result.parent_id = w3c->second.parent_id;

--- a/src/datadog/extraction_util.cpp
+++ b/src/datadog/extraction_util.cpp
@@ -251,20 +251,22 @@ void AuditedReader::visit(
   });
 }
 
-ExtractedData merge(const PropagationStyle first_style,
-  const std::unordered_map<PropagationStyle, ExtractedData>& contexts) {
+ExtractedData merge(
+    const PropagationStyle first_style,
+    const std::unordered_map<PropagationStyle, ExtractedData>& contexts) {
   ExtractedData result;
-
-  // `found` refers to the first extracted context that yielded a trace ID.
-  // This will be our main context.
-  //
-  // If the W3C style is present and its trace-id matches, we'll update the main context
-  // with tracestate information that we want to include in `result`.
-  // We may also need to use Datadog header information (only when the trace-id matches).
   const auto found = contexts.find(first_style);
   if (found == contexts.end()) {
     return result;
   }
+
+  // `found` refers to the first extracted context that yielded a trace ID.
+  // This will be our main context.
+  //
+  // If the W3C style is present and its trace-id matches, we'll update the main
+  // context with tracestate information that we want to include in `result`. We
+  // may also need to use Datadog header information (only when the trace-id
+  // matches).
   result = found->second;
 
   const auto w3c = contexts.find(PropagationStyle::W3C);
@@ -282,7 +284,9 @@ ExtractedData merge(const PropagationStyle first_style,
       if (w3c->second.datadog_w3c_parent_id &&
           w3c->second.datadog_w3c_parent_id != "0000000000000000") {
         result.datadog_w3c_parent_id = w3c->second.datadog_w3c_parent_id;
-      } else if (dd != contexts.end() && dd->second.trace_id == result.trace_id && dd->second.parent_id.has_value()) {
+      } else if (dd != contexts.end() &&
+                 dd->second.trace_id == result.trace_id &&
+                 dd->second.parent_id.has_value()) {
         result.datadog_w3c_parent_id = hex_padded(dd->second.parent_id.value());
         // TODO: Do we add the result.headers_examined for all of the dd ones?
         // Or just the x-datadog-parent-id?

--- a/src/datadog/extraction_util.h
+++ b/src/datadog/extraction_util.h
@@ -69,9 +69,10 @@ struct AuditedReader : public DictReader {
 // Combine the specified trace `contexts`, each of which was extracted in a
 // particular propagation style, into one `ExtractedData` that includes fields
 // from compatible elements of `contexts`, and return the resulting
-// `ExtractedData`. The order of the elements of `contexts` must correspond to
-// the order of the configured extraction propagation styles.
-ExtractedData merge(const std::vector<ExtractedData>& contexts);
+// `ExtractedData`. The `first_style` specifies the first configured extraction
+// propagation style that has been extracted and the other contexts will be merged
+// with it, so long as the trace-ids match.
+ExtractedData merge(const PropagationStyle first_style, const std::unordered_map<PropagationStyle,ExtractedData>& contexts);
 
 }  // namespace tracing
 }  // namespace datadog

--- a/src/datadog/extraction_util.h
+++ b/src/datadog/extraction_util.h
@@ -70,9 +70,11 @@ struct AuditedReader : public DictReader {
 // particular propagation style, into one `ExtractedData` that includes fields
 // from compatible elements of `contexts`, and return the resulting
 // `ExtractedData`. The `first_style` specifies the first configured extraction
-// propagation style that has been extracted and the other contexts will be merged
-// with it, so long as the trace-ids match.
-ExtractedData merge(const PropagationStyle first_style, const std::unordered_map<PropagationStyle,ExtractedData>& contexts);
+// propagation style that has been extracted and the other contexts will be
+// merged with it, so long as the trace-ids match.
+ExtractedData merge(
+    const PropagationStyle first_style,
+    const std::unordered_map<PropagationStyle, ExtractedData>& contexts);
 
 }  // namespace tracing
 }  // namespace datadog

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -152,7 +152,7 @@ Expected<Span> Tracer::extract_span(const DictReader& reader,
   auto span_data = std::make_unique<SpanData>();
   Optional<PropagationStyle> first_style_with_trace_id;
   Optional<PropagationStyle> first_style_with_parent_id;
-  std::unordered_map<PropagationStyle,ExtractedData> extracted_contexts;
+  std::unordered_map<PropagationStyle, ExtractedData> extracted_contexts;
 
   for (const auto style : extraction_styles_) {
     using Extractor = decltype(&extract_datadog);  // function pointer
@@ -201,8 +201,7 @@ Expected<Span> Tracer::extract_span(const DictReader& reader,
       assert(other != extracted_contexts.end());
       merged_context = other->second;
     }
-  }
-  else {
+  } else {
     merged_context = merge(*first_style_with_trace_id, extracted_contexts);
   }
 

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -178,15 +178,15 @@ Expected<Span> Tracer::extract_span(const DictReader& reader,
           extraction_error_prefix(style, audited_reader.entries_found));
     }
 
-    if (!first_style_with_trace_id && (*data).trace_id.has_value()) {
+    if (!first_style_with_trace_id && data->trace_id.has_value()) {
       first_style_with_trace_id = style;
     }
 
-    if (!first_style_with_parent_id && (*data).parent_id.has_value()) {
+    if (!first_style_with_parent_id && data->parent_id.has_value()) {
       first_style_with_parent_id = style;
     }
 
-    (*data).headers_examined = audited_reader.entries_found;
+    data->headers_examined = audited_reader.entries_found;
     extracted_contexts.emplace(style, std::move(*data));
   }
 

--- a/test/test_curl.cpp
+++ b/test/test_curl.cpp
@@ -359,7 +359,7 @@ TEST_CASE("setopt failures", "[curl]") {
 #define CASE(OPTION) \
   { OPTION, #OPTION }
 
-  const auto &[which_fails, name] = GENERATE(
+  auto test_case = GENERATE(
       values<TestCase>({CASE(CURLOPT_ERRORBUFFER), CASE(CURLOPT_HEADERDATA),
                         CASE(CURLOPT_HEADERFUNCTION), CASE(CURLOPT_HTTPHEADER),
                         CASE(CURLOPT_POST), CASE(CURLOPT_POSTFIELDS),
@@ -369,9 +369,9 @@ TEST_CASE("setopt failures", "[curl]") {
 
 #undef CASE
 
-  CAPTURE(name);
+  CAPTURE(test_case.name);
   MockCurlLibrary library;
-  library.fail = which_fails;
+  library.fail = test_case.which_fails;
 
   const auto clock = default_clock;
   const auto logger = std::make_shared<NullLogger>();
@@ -379,7 +379,7 @@ TEST_CASE("setopt failures", "[curl]") {
 
   const auto ignore = [](auto &&...) {};
   HTTPClient::URL url;
-  if (which_fails == CURLOPT_UNIX_SOCKET_PATH) {
+  if (test_case.which_fails == CURLOPT_UNIX_SOCKET_PATH) {
     url.scheme = "unix";
     url.path = "/foo/bar.sock";
   } else {

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -633,13 +633,13 @@ TEST_CASE("injecting W3C traceparent header") {
       int sampling_priority;
       std::string expected_flags;
     };
-    const auto& [sampling_priority, expected_flags] = GENERATE(
+    auto test_case = GENERATE(
         values<TestCase>({{-1, "00"}, {0, "00"}, {1, "01"}, {2, "01"}}));
 
-    CAPTURE(sampling_priority);
-    CAPTURE(expected_flags);
+    CAPTURE(test_case.sampling_priority);
+    CAPTURE(test_case.expected_flags);
 
-    span.trace_segment().override_sampling_priority(sampling_priority);
+    span.trace_segment().override_sampling_priority(test_case.sampling_priority);
 
     MockDictWriter writer;
     span.inject(writer);
@@ -649,7 +649,7 @@ TEST_CASE("injecting W3C traceparent header") {
     // The "cafebabe"s come from `expected_id`.
     const std::string expected =
         "00-000000000000000000000000cafebabe-00000000cafebabe-" +
-        expected_flags;
+        test_case.expected_flags;
     REQUIRE(found->second == expected);
   }
 }

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -639,7 +639,8 @@ TEST_CASE("injecting W3C traceparent header") {
     CAPTURE(test_case.sampling_priority);
     CAPTURE(test_case.expected_flags);
 
-    span.trace_segment().override_sampling_priority(test_case.sampling_priority);
+    span.trace_segment().override_sampling_priority(
+        test_case.sampling_priority);
 
     MockDictWriter writer;
     span.inject(writer);


### PR DESCRIPTION
# Description
Adds support for "W3C Phase 3" so that when multiple trace contexts are extracted (with the same trace-id) and the `tracecontext` format is used, the resulting trace context will have:
- `span.parent_id` set to the `tracecontext` parent-id value
- `span.tags["_dd.parent_id"]` set to either the value of `tracestate[dd][p]` or `hex(x-datadog-parent-id)`, in that order of precedence

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
