### PR TITLE
Update README to include maintainers doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Code coverage reports are available [here][2].
 
 Contributing
 ------------
-See the [contributing guidelines](CONTRIBUTING.md).
+See the [contributing guidelines](CONTRIBUTING.md) and the [maintainer docs](doc/maintainers.md) for information on the overall structure of the repository.
 
 [1]: https://cmake.org/
 [2]: https://datadog.github.io/dd-trace-cpp-coverage


### PR DESCRIPTION
# Description
Add maintainers doc as a link from the repository README

# Motivation
Increases discoverability of the maintainers doc since it's very useful for new engs starting in dd-trace-cpp

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
