### PR TITLE
patch some build/test scripts in `bin/`

### DIFF
--- a/bin/bazel-build
+++ b/bin/bazel-build
@@ -4,4 +4,13 @@ set -e
 
 cd "$(dirname "$0")"/..
 
-bazelisk build dd_trace_cpp
+if [ "$1" = '--absl' ]; then
+  rcfile=.bazelrc.absl
+elif [ "$1" = '--std' ]; then
+  rcfile=.bazelrc.std
+elif [ $# -ne 1 ]; then
+  >&2 printf '%s: Specify one of "--absl" or "--std" build modes.\n' "$0"
+  exit 1
+fi
+
+bazelisk --bazelrc="$rcfile" build dd_trace_cpp

--- a/bin/check
+++ b/bin/check
@@ -9,6 +9,14 @@ set -e
 cd "$(dirname "$0")"/..
 
 bin/format --dry-run -Werror
+
 bin/test
-bin/bazel-build
+
+if [ "$1" != '--no-bazel' ]; then
+  # Specifying two different build configurations in bazel seems to trigger a
+  # clean build each time :(
+  bin/bazel-build --absl
+  bin/bazel-build --std
+fi
+
 find bin/ -executable -type f -print0 | xargs -0 shellcheck


### PR DESCRIPTION
I just set up VSCode's clangd extension for C++ source browsing, and was giving it a test drive in dd-trace-cpp.

`bin/test` was failing on my machine due to changes needed in the build configuration of `test/system-tests`, and `bin/check` was failing due to changes needed to `bin/bazel-build`. At least on my machine.

If some of the helper scripts in `bin/` are no longer in use, it might be best to delete them. For now, I propose these changes to get things working again locally on my machine. 