### PR TITLE
fix: telemetry `configuration_change` payload

### DIFF
--- a/src/datadog/tracer_telemetry.cpp
+++ b/src/datadog/tracer_telemetry.cpp
@@ -356,16 +356,12 @@ std::string TracerTelemetry::configuration_change() {
         generate_configuration_field(config_metadata));
   }
 
-  // clang-format off
-  auto configuration_change = nlohmann::json({
-    {"request_type", "app-client-configuration-change"},
-    {"payload", nlohmann::json{
-      {"configuration", configuration_json}
-    }}
-  });
-  // clang-format on
+  auto telemetry_body =
+      generate_telemetry_body("app-client-configuration-change");
+  telemetry_body["payload"] =
+      nlohmann::json{{"configuration", configuration_json}};
 
-  return configuration_change.dump();
+  return telemetry_body.dump();
 }
 
 }  // namespace tracing


### PR DESCRIPTION
# Description
Resolve a regression introduced in #130 where the `configuration_change` payload didn't adhere to the telemetry schema.

# Changes
- Fix the regression.
- Validate top-level telemetry schema in unit tests.
