### PR TITLE
chore(build): use `includes` argument in BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@ cc_library(
       "src/datadog/random.cpp",
       "src/datadog/rate.cpp",
       "src/datadog/remote_config/remote_config.cpp",
+      "src/datadog/remote_config/product.cpp",
       "src/datadog/runtime_id.cpp",
       "src/datadog/span.cpp",
       "src/datadog/span_data.cpp",
@@ -115,7 +116,7 @@ cc_library(
       "include/datadog/remote_config/product.h",
     ],
     strip_include_prefix = "include/",
-    copts = ["-Isrc/datadog"],
+    includes = ["src/datadog"],
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_absl//absl/strings",


### PR DESCRIPTION
# Description
Envoy was failing to build becase it couldn't locate the necessary headers in the `src` directory, even with the `-Isrc/datadog` flag. After investigating, I found that dd-trace-cpp srouce code is actually located at `external/com_github_datadog_dd_trace_cpp/src/datadog`. This means the correct include path should be `-Iexternal/com_github_datadog_dd_trace_cpp/src/datadog`. For some reson Bazel isn't able to handle this path expansion automatically.

After researching, it seems the recommended solution is to use the `includes` argument in `cc_library`. However, the Bazel documentation includes this warning:

> This should only be used for third-party libraries that do not conform to the Google style of writing #include statements. Unlike [COPTS](https://bazel.build/reference/be/c-cpp#cc_binary.copts), these flags are added for this rule and every rule that depends on it. (Note: not the rules it depends upon!) Be very careful, since this may have far-reaching effects.

I'm not entirely sure about the implications here, so I went ahead with this approach despite the warning. If someone with a bigger brain, IQ and experience can suggest a better way™️, I'm happy to adjust accordingly!

# Motivation
Preparing the new release 🎉
