### PR TITLE
chore: bump version to v1.0.0

### DIFF
--- a/src/datadog/version.cpp
+++ b/src/datadog/version.cpp
@@ -3,7 +3,7 @@
 namespace datadog {
 namespace tracing {
 
-#define DD_TRACE_VERSION "v0.2.2"
+#define DD_TRACE_VERSION "v1.0.0"
 
 const char* const tracer_version = DD_TRACE_VERSION;
 const char* const tracer_version_string =


### PR DESCRIPTION
# Description
Our next release will be `v1.0.0` as part of our adherence to semantic versioning (semver). While there are no major changes, commits 32f0338 and d354e96 introduced some API changes that are not backward-compatible.

## Note to reviewers
`v1.0.0` or `v0.3.0`? You decide.