### PR TITLE
test: Update parametric tests for Config Consistency intiative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 dist/
 out/
 MODULE.bazel.lock
+.vscode

--- a/test/system-tests/main.cpp
+++ b/test/system-tests/main.cpp
@@ -90,6 +90,10 @@ int main(int argc, char* argv[]) {
   RequestHandler handler(*finalized_config, event_scheduler, logger);
 
   httplib::Server svr;
+  svr.Get("/trace/config",
+           [&handler](const httplib::Request& req, httplib::Response& res) {
+             handler.on_trace_config(req, res);
+           });
   svr.Post("/trace/span/start",
            [&handler](const httplib::Request& req, httplib::Response& res) {
              handler.on_span_start(req, res);

--- a/test/system-tests/main.cpp
+++ b/test/system-tests/main.cpp
@@ -91,9 +91,9 @@ int main(int argc, char* argv[]) {
 
   httplib::Server svr;
   svr.Get("/trace/config",
-           [&handler](const httplib::Request& req, httplib::Response& res) {
-             handler.on_trace_config(req, res);
-           });
+          [&handler](const httplib::Request& req, httplib::Response& res) {
+            handler.on_trace_config(req, res);
+          });
   svr.Post("/trace/span/start",
            [&handler](const httplib::Request& req, httplib::Response& res) {
              handler.on_span_start(req, res);

--- a/test/system-tests/request_handler.cpp
+++ b/test/system-tests/request_handler.cpp
@@ -86,7 +86,9 @@ void RequestHandler::on_span_start(const httplib::Request& req,
 
   if (auto service =
           utils::get_if_exists<std::string_view>(request_json, "service")) {
-    span_cfg.service = *service;
+    if (!service->empty()) {
+      span_cfg.service = *service;
+    }
   }
 
   if (auto service_type =

--- a/test/system-tests/request_handler.cpp
+++ b/test/system-tests/request_handler.cpp
@@ -42,7 +42,7 @@ void RequestHandler::set_error(const char* const file, int line,
   return
 
 void RequestHandler::on_trace_config(const httplib::Request& /* req */,
-                                   httplib::Response& res) {
+                                     httplib::Response& res) {
   auto tracer_cfg = nlohmann::json::parse(tracer_.config());
 
   // clang-format off
@@ -64,12 +64,11 @@ void RequestHandler::on_trace_config(const httplib::Request& /* req */,
     };
   // clang-format on
 
-  if (tracer_cfg.contains("trace_sampler"))
-  {
+  if (tracer_cfg.contains("trace_sampler")) {
     auto trace_sampler_cfg = tracer_cfg["trace_sampler"];
-    if (trace_sampler_cfg.contains("max_per_second"))
-    {
-      response_body["config"]["dd_trace_rate_limit"] = std::to_string((int)trace_sampler_cfg["max_per_second"]);
+    if (trace_sampler_cfg.contains("max_per_second")) {
+      response_body["config"]["dd_trace_rate_limit"] =
+          std::to_string((int)trace_sampler_cfg["max_per_second"]);
     }
   }
 

--- a/test/system-tests/request_handler.cpp
+++ b/test/system-tests/request_handler.cpp
@@ -55,12 +55,6 @@ void RequestHandler::on_trace_config(const httplib::Request& /* req */,
           { "dd_trace_agent_url", tracer_cfg["environment_variables"]["DD_TRACE_AGENT_URL"]}
         }
       }
-      // { "dd_runtime_metrics_enabled", "null"},
-      // { "dd_tags", "null"},
-      // { "dd_trace_propagation_style", "null"},
-      // { "dd_trace_debug", tracer_cfg["defaults"]["environment"]["DD_TRACE_DEBUG"]},
-      // { "dd_trace_otel_enabled", "false"},
-      // { "dd_log_level", "null"}
     };
   // clang-format on
 

--- a/test/system-tests/request_handler.h
+++ b/test/system-tests/request_handler.h
@@ -19,6 +19,7 @@ class RequestHandler final {
   void set_error(const char* const file, int line, const std::string& reason,
                  httplib::Response& res);
 
+  void on_trace_config(const httplib::Request& req, httplib::Response& res);
   void on_span_start(const httplib::Request& req, httplib::Response& res);
   void on_span_end(const httplib::Request& req, httplib::Response& res);
   void on_set_meta(const httplib::Request& req, httplib::Response& res);


### PR DESCRIPTION
# Description
Adds a new parametric test application endpoint `/trace/config` for retrieving the tracer configuration and fixes a small bug in the `/trace/span/start` handler when no service parameter is provided.

# Motivation
This allows the cpp tracer to run the test cases needed for conformance to our Config Consistency initiative

# Additional Notes

Jira ticket: [APMAPI-511] [APMAPI-516] [APMAPI-709]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-511]: https://datadoghq.atlassian.net/browse/APMAPI-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMAPI-516]: https://datadoghq.atlassian.net/browse/APMAPI-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMAPI-709]: https://datadoghq.atlassian.net/browse/APMAPI-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ