### PR TITLE
fix: Apply "version" tag only when the span service name matches the default service name

### DIFF
--- a/src/datadog/span_data.cpp
+++ b/src/datadog/span_data.cpp
@@ -37,7 +37,19 @@ Optional<StringView> SpanData::version() const {
 
 void SpanData::apply_config(const SpanDefaults& defaults,
                             const SpanConfig& config, const Clock& clock) {
-  service = config.service.value_or(defaults.service);
+  std::string version;
+  if (config.service) {
+    service = *config.service;
+    version = config.version.value_or("");
+  } else {
+    service = defaults.service;
+    version = defaults.version;
+  }
+
+  if (!version.empty()) {
+    tags.insert_or_assign(tags::version, version);
+  }
+
   name = config.name.value_or(defaults.name);
 
   for (const auto& item : defaults.tags) {
@@ -47,11 +59,7 @@ void SpanData::apply_config(const SpanDefaults& defaults,
   if (!environment.empty()) {
     tags.insert_or_assign(tags::environment, environment);
   }
-  std::string version = config.version.value_or(
-      service.compare(defaults.service) == 0 ? defaults.version : "");
-  if (!version.empty()) {
-    tags.insert_or_assign(tags::version, version);
-  }
+
   for (const auto& [key, value] : config.tags) {
     tags.insert_or_assign(key, value);
   }

--- a/src/datadog/span_data.cpp
+++ b/src/datadog/span_data.cpp
@@ -47,7 +47,8 @@ void SpanData::apply_config(const SpanDefaults& defaults,
   if (!environment.empty()) {
     tags.insert_or_assign(tags::environment, environment);
   }
-  std::string version = config.version.value_or(defaults.version);
+  std::string version = config.version.value_or(
+      service.compare(defaults.service) == 0 ? defaults.version : "");
   if (!version.empty()) {
     tags.insert_or_assign(tags::version, version);
   }

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -278,8 +278,7 @@ TEST_CASE("tracer span defaults") {
   SECTION("can be overridden in a child span with empty values") {
     {
       auto parent = tracer.create_span();
-      auto child = parent.create_child(overrides_with_empty_values);
-      (void)child;
+      parent.create_child(overrides_with_empty_values);
     }
     REQUIRE(logger->error_count() == 0);
 


### PR DESCRIPTION
# Description
Apply version tag to a span only if its service name matches the default service name. This may be viewed as a breaking change since now some spans that are started with a new service name will not have the "version" tag set.

# Motivation
This behavior conforms to our Config Consistency initiative

# Additional Notes
As this may be breaking, we could put this new behavior behind a feature flag, but I'm inclined to say that this is a FIX rather than a FEATURE.

Jira ticket: [APMAPI-517]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-517]: https://datadoghq.atlassian.net/browse/APMAPI-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ