### PR TITLE
feat!: Implement Config Consistency consistency for DD_TRACE_RATE_LIMIT default value

### DIFF
--- a/src/datadog/trace_sampler_config.cpp
+++ b/src/datadog/trace_sampler_config.cpp
@@ -224,7 +224,7 @@ Expected<FinalizedTraceSamplerConfig> finalize_config(
   }
 
   const auto [origin, max_per_second] =
-      pick(env_config->max_per_second, config.max_per_second, 200);
+      pick(env_config->max_per_second, config.max_per_second, 100);
   result.metadata[ConfigName::TRACE_SAMPLING_LIMIT] = ConfigMetadata(
       ConfigName::TRACE_SAMPLING_LIMIT, std::to_string(max_per_second), origin);
 

--- a/test/test_tracer_config.cpp
+++ b/test/test_tracer_config.cpp
@@ -707,10 +707,10 @@ TEST_CASE("TracerConfig::trace_sampler") {
   }
 
   SECTION("max_per_second") {
-    SECTION("defaults to 200") {
+    SECTION("defaults to 100") {
       auto finalized = finalize_config(config);
       REQUIRE(finalized);
-      REQUIRE(finalized->trace_sampler.max_per_second == 200);
+      REQUIRE(finalized->trace_sampler.max_per_second == 100);
     }
 
     SECTION("must be >0 and a finite number") {


### PR DESCRIPTION
# Description
Changes the default value of DD_TRACE_RATE_LIMIT to 100 (previously 200)

# Motivation
This aligns the cpp tracer behavior for an unconfigured `DD_TRACE_RATE_LIMIT` with the expected behavior of all the tracers in our Config Consistency initiative.

# Additional Notes
This is technically a breaking change as some users may observe traces being limited. We may consider this more of a FIX or we can put this behind a feature flag. Thoughts?

Jira ticket: [APMAPI-511]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
