### PR TITLE
feat!: Change type of DD_TRACE_RATE_LIMIT to int

### DIFF
--- a/include/datadog/sampling_decision.h
+++ b/include/datadog/sampling_decision.h
@@ -38,7 +38,7 @@ struct SamplingDecision {
   Optional<Rate> limiter_effective_rate;
   // The per-second maximum allowed number of "keeps" configured for the limiter
   // consulted in this decision, if any.
-  Optional<double> limiter_max_per_second;
+  Optional<int> limiter_max_per_second;
   // The provenance of this decision.
   Origin origin;
 };

--- a/include/datadog/span_sampler_config.h
+++ b/include/datadog/span_sampler_config.h
@@ -23,7 +23,7 @@ namespace tracing {
 struct SpanSamplerConfig {
   struct Rule : public SpanMatcher {
     double sample_rate = 1.0;
-    Optional<double> max_per_second;
+    Optional<int> max_per_second;
 
     Rule(const SpanMatcher&);
     Rule() = default;
@@ -45,7 +45,7 @@ class FinalizedSpanSamplerConfig {
  public:
   struct Rule : public SpanMatcher {
     Rate sample_rate;
-    Optional<double> max_per_second;
+    Optional<int> max_per_second;
   };
 
   std::vector<Rule> rules;

--- a/include/datadog/trace_sampler_config.h
+++ b/include/datadog/trace_sampler_config.h
@@ -36,7 +36,7 @@ struct TraceSamplerConfig {
 
   Optional<double> sample_rate;
   std::vector<Rule> rules;
-  Optional<double> max_per_second;
+  Optional<int> max_per_second;
 };
 
 class FinalizedTraceSamplerConfig {
@@ -47,7 +47,7 @@ class FinalizedTraceSamplerConfig {
   FinalizedTraceSamplerConfig() = default;
 
  public:
-  double max_per_second;
+  int max_per_second;
   std::vector<TraceSamplerRule> rules;
   std::unordered_map<ConfigName, ConfigMetadata> metadata;
 };

--- a/src/datadog/span_sampler.cpp
+++ b/src/datadog/span_sampler.cpp
@@ -10,7 +10,7 @@ namespace datadog {
 namespace tracing {
 
 SpanSampler::SynchronizedLimiter::SynchronizedLimiter(const Clock& clock,
-                                                      double max_per_second)
+                                                      int max_per_second)
     : limiter(clock, max_per_second) {}
 
 SpanSampler::Rule::Rule(const FinalizedSpanSamplerConfig::Rule& rule,

--- a/src/datadog/span_sampler.h
+++ b/src/datadog/span_sampler.h
@@ -37,7 +37,7 @@ class SpanSampler {
     std::mutex mutex;
     Limiter limiter;
 
-    SynchronizedLimiter(const Clock&, double max_per_second);
+    SynchronizedLimiter(const Clock&, int max_per_second);
   };
 
   class Rule : public FinalizedSpanSamplerConfig::Rule {

--- a/src/datadog/span_sampler_config.cpp
+++ b/src/datadog/span_sampler_config.cpp
@@ -254,12 +254,8 @@ Expected<FinalizedSpanSamplerConfig> finalize_config(
       return error->with_prefix(prefix);
     }
 
-    const auto allowed_types = {FP_NORMAL, FP_SUBNORMAL};
     if (rule.max_per_second &&
-        (!(*rule.max_per_second > 0) ||
-         std::find(std::begin(allowed_types), std::end(allowed_types),
-                   std::fpclassify(*rule.max_per_second)) ==
-             std::end(allowed_types))) {
+        (!(*rule.max_per_second > 0))) {
       std::string message;
       message += "Span sampling rule with pattern ";
       message += nlohmann::json(static_cast<SpanMatcher>(rule)).dump();

--- a/src/datadog/trace_sampler.h
+++ b/src/datadog/trace_sampler.h
@@ -110,7 +110,7 @@ class TraceSampler {
   std::unordered_map<std::string, Rate> collector_sample_rates_;
   std::vector<TraceSamplerRule> rules_;
   Limiter limiter_;
-  double limiter_max_per_second_;
+  int limiter_max_per_second_;
 
  public:
   TraceSampler(const FinalizedTraceSamplerConfig& config, const Clock& clock);

--- a/src/datadog/trace_sampler_config.cpp
+++ b/src/datadog/trace_sampler_config.cpp
@@ -224,7 +224,7 @@ Expected<FinalizedTraceSamplerConfig> finalize_config(
   }
 
   const auto [origin, max_per_second] =
-      pick(env_config->max_per_second, config.max_per_second, 200);
+      pick(env_config->max_per_second, config.max_per_second, 100);
   result.metadata[ConfigName::TRACE_SAMPLING_LIMIT] = ConfigMetadata(
       ConfigName::TRACE_SAMPLING_LIMIT, std::to_string(max_per_second), origin);
 

--- a/src/datadog/trace_sampler_config.cpp
+++ b/src/datadog/trace_sampler_config.cpp
@@ -228,10 +228,7 @@ Expected<FinalizedTraceSamplerConfig> finalize_config(
   result.metadata[ConfigName::TRACE_SAMPLING_LIMIT] = ConfigMetadata(
       ConfigName::TRACE_SAMPLING_LIMIT, std::to_string(max_per_second), origin);
 
-  const auto allowed_types = {FP_NORMAL, FP_SUBNORMAL};
-  if (!(max_per_second > 0) ||
-      std::find(std::begin(allowed_types), std::end(allowed_types),
-                std::fpclassify(max_per_second)) == std::end(allowed_types)) {
+  if (!(max_per_second > 0)) {
     std::string message;
     message +=
         "Trace sampling max_per_second must be greater than zero, but the "

--- a/src/datadog/trace_sampler_config.cpp
+++ b/src/datadog/trace_sampler_config.cpp
@@ -118,7 +118,7 @@ Expected<TraceSamplerConfig> load_trace_sampler_env_config() {
   }
 
   if (auto limit_env = lookup(environment::DD_TRACE_RATE_LIMIT)) {
-    auto maybe_max_per_second = parse_double(*limit_env);
+    auto maybe_max_per_second = parse_int(*limit_env, 10);
     if (auto *error = maybe_max_per_second.if_error()) {
       std::string prefix;
       prefix += "While parsing ";

--- a/test/test_span_sampler.cpp
+++ b/test/test_span_sampler.cpp
@@ -48,7 +48,7 @@ namespace {
 struct SpanSamplingTags {
   Optional<double> mechanism;
   Optional<double> rule_rate;
-  Optional<double> max_per_second;
+  Optional<int> max_per_second;
 };
 
 SpanSamplingTags span_sampling_tags(const SpanData& span) {
@@ -292,7 +292,7 @@ TEST_CASE("span rule limiter") {
   struct TestCase {
     std::string name;
     std::size_t num_spans;
-    Optional<double> max_per_second;
+    Optional<int> max_per_second;
     std::size_t expected_count;
   };
 

--- a/test/test_trace_sampler.cpp
+++ b/test/test_trace_sampler.cpp
@@ -105,14 +105,14 @@ TEST_CASE("trace sampling rate limiter") {
   // second does not exceed that allowed by the configured limit.
   struct TestCase {
     std::string name;
-    double max_per_second;
+    int max_per_second;
     std::size_t burst_size;
     std::size_t expected_kept_count;
   };
 
-  auto test_case = GENERATE(values<TestCase>({{"allow one", 1.0, 100, 1},
-                                              {"allow all", 100.0, 100, 100},
-                                              {"allow some", 10.0, 100, 10}}));
+  auto test_case = GENERATE(values<TestCase>({{"allow one", 1, 100, 1},
+                                              {"allow all", 100, 100, 100},
+                                              {"allow some", 10, 100, 10}}));
 
   CAPTURE(test_case.name);
   CAPTURE(test_case.max_per_second);

--- a/test/test_tracer_config.cpp
+++ b/test/test_tracer_config.cpp
@@ -707,10 +707,10 @@ TEST_CASE("TracerConfig::trace_sampler") {
   }
 
   SECTION("max_per_second") {
-    SECTION("defaults to 200") {
+    SECTION("defaults to 100") {
       auto finalized = finalize_config(config);
       REQUIRE(finalized);
-      REQUIRE(finalized->trace_sampler.max_per_second == 200);
+      REQUIRE(finalized->trace_sampler.max_per_second == 100);
     }
 
     SECTION("must be >0 and a finite number") {


### PR DESCRIPTION
# Description
Changes the type of the `DD_TRACE_RATE_LIMIT` input to `int` (previously `double`)

# Motivation
This aligns the cpp tracer behavior for DD_TRACE_RATE_LIMIT with the expected behavior of all the tracers in our Config Consistency initiative, such that only integer values are used.

# Additional Notes
This may be unnecessary as we may be able to standardize our documentation that only integer values are accepted (what even is 0.1 of a trace?) and in doing so we are still compatible because integers on the command line can still be interpreted as a double. However, it could be good to do this in the type system just to be more specific. Thoughts?

Jira ticket: [APMAPI-511]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-511]: https://datadoghq.atlassian.net/browse/APMAPI-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ