### PR TITLE
Downgrade CMake version to 3.22.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,10 +82,7 @@ file(GLOB_RECURSE public_header_files ${CMAKE_SOURCE_DIR}/include/*.h)
 
 target_sources(dd_trace_cpp-objects
   PUBLIC
-    FILE_SET public_headers
-    TYPE HEADERS
-    BASE_DIRS include
-    FILES ${public_header_files}
+    ${public_header_files}
   PRIVATE
     src/datadog/base64.cpp
     src/datadog/cerr_logger.cpp
@@ -181,10 +178,15 @@ if (BUILD_SHARED_LIBS)
 
   install(TARGETS dd_trace_cpp-objects dd_trace_cpp-shared
     EXPORT dd_trace_cpp-export
-    FILE_SET public_headers DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+
+  # Install headers separately
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
   )
 endif ()
 
@@ -218,9 +220,14 @@ if (BUILD_STATIC_LIBS)
 
   install(TARGETS dd_trace_cpp-objects dd_trace_cpp-static
     EXPORT dd_trace_cpp-export
-    FILE_SET public_headers DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+
+  # Then, install the public headers separately
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
   )
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Note: Make sure that this version is the same as that in
 # "./CheckRequiredCMakeVersion.cmake".
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.22)
 cmake_policy(SET CMP0077 NEW)
 
 project(dd-trace-cpp)

--- a/CheckRequiredCMakeVersion.cmake
+++ b/CheckRequiredCMakeVersion.cmake
@@ -8,4 +8,4 @@
 # incompatible or something else went wrong.
 #
 # Note: Make sure that this version is the same as that in "./CMakeLists.txt".
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.22)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The library has been tested and is compatible on the following CPU architecture,
 ### Requirements
 `dd-trace-cpp` requires a [supported](#platform-support) C++17 compiler.
 
-A recent version of CMake is required (`3.24`), which might not be in your
+A recent version of CMake is required (`3.22`), which might not be in your
 system's package manager. [bin/install-cmake](bin/install-cmake) is an installer
 for a recent CMake.
 

--- a/bin/install-cmake
+++ b/bin/install-cmake
@@ -10,7 +10,7 @@ if [ "$(uname)" != Linux ]; then
     exit 1
 fi
 
-VERSION=3.24.2
+VERSION=3.22.1
 REPO=$(dirname "$0")/..
 
 # If a suitably recent version of cmake is already installed, then don't bother.


### PR DESCRIPTION
# Description
Downgrade CMake to 3.22.1 from 3.24.2

# Motivation
The latest version of CMake available for Ubuntu 22.04 via apt is [3.22.1](https://launchpad.net/ubuntu/jammy/+source/cmake). Use that version instead of requiring users to install a later version of CMake than may be available on their system.

# Additional Notes
I'm not sure if there are specific features from 3.23 or 3.24 that are required to support Windows or some other features, but I thought I would open a PR to at least start a discussion.

We had to fork the repository internally to downgrade so I thought it was worth committing back upstream to see if this was a change that would be accepted.
