### PR TITLE
fix: telemetry refactoring part 1

### DIFF
--- a/src/datadog/tracer_telemetry.cpp
+++ b/src/datadog/tracer_telemetry.cpp
@@ -64,7 +64,8 @@ TracerTelemetry::TracerTelemetry(
       host_info_(get_host_info()),
       tracer_signature_(tracer_signature),
       integration_name_(integration_name),
-      integration_version_(integration_version) {
+      integration_version_(integration_version),
+      user_metrics_(user_metrics) {
   if (enabled_) {
     if (integration_name_.empty()) {
       integration_name_ = "datadog";
@@ -101,7 +102,7 @@ TracerTelemetry::TracerTelemetry(
     metrics_snapshots_.emplace_back(metrics_.trace_api.errors_status_code,
                                     MetricSnapshot{});
 
-    for (auto& m : user_metrics) {
+    for (auto& m : user_metrics_) {
       metrics_snapshots_.emplace_back(*m, MetricSnapshot{});
     }
   }

--- a/src/datadog/tracer_telemetry.h
+++ b/src/datadog/tracer_telemetry.h
@@ -118,6 +118,8 @@ class TracerTelemetry {
   nlohmann::json generate_configuration_field(
       const ConfigMetadata& config_metadata);
 
+  std::vector<std::shared_ptr<telemetry::Metric>> user_metrics_;
+
  public:
   TracerTelemetry(
       bool enabled, const Clock& clock, const std::shared_ptr<Logger>& logger,


### PR DESCRIPTION
# Description
Keep a reference to user metrics to avoid dereferencing them when they are not alive anymore.
