### PR TITLE
chore: mandatory issue templates (AIDM-428)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,41 @@
+name: "Bug Report (Low Priority)"
+description: "Create a public Bug Report. Note that these may not be addressed as quickly as the helpdesk and that looking up account information will be difficult."
+title: "[BUG]: "
+labels: community, bug
+body:
+  - type: input
+    attributes:
+      label: Tracer Version(s)
+      description: "Version(s) of the tracer affected by this bug"
+      placeholder: "1.23.4, 2.8.0"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Bug Report
+      description: Please add a clear and concise description of the bug here
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Reproduction Code
+      description: Please add code here to help us reproduce the problem
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Error Logs
+      description: "Please provide any error logs from the tracer (`DD_TRACE_DEBUG=true` can help)"
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Operating System
+      description: "Provide your operating system and version (e.g. `uname -a`)"
+      placeholder: Darwin Kernel Version 23.6.0
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -28,7 +28,7 @@ body:
   - type: textarea
     attributes:
       label: Error Logs
-      description: "Please provide any error logs from the tracer (`DD_TRACE_DEBUG=true` can help)"
+      description: "Please provide any error logs from the tracer"
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug Report (High Priority)
+    url: https://help.datadoghq.com/hc/en-us/requests/new?tf_1260824651490=pt_product_type:apm&tf_1900004146284=pt_apm_language:proxy/c__
+    about: Create an expedited Bug Report via the helpdesk (no login required). This will allow us to look up your account and allows you to provide additional information in private. Please do not create a GitHub issue to report a bug.
+  - name: Feature Request (High Priority)
+    url: https://help.datadoghq.com/hc/en-us/requests/new?tf_1260824651490=pt_product_type:apm&tf_1900004146284=pt_apm_language:proxy/c__&tf_1260825272270=pt_apm_category_feature_request
+    about: Create an expedited Feature Request via the helpdesk (no login required). This helps with prioritization and allows you to provide additional information in private. Please do not create a GitHub issue to request a feature.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,34 @@
+name: Feature Request (Low Priority)
+description: Create a public Feature Request. Note that these may not be addressed as quickly as the helpdesk and that looking up account information will be difficult.
+title: "[FEATURE]: "
+labels: feature-request
+body:
+  - type: textarea
+    attributes:
+      label: Describe the goal of the feature
+      description: A clear and concise goal of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: |
+        Please add a clear and concise description of your problem.
+        E.g. I'm unable to instrument my database queries...
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here
+    validations:
+      required: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+This document outlines the security policy for the Datadog C++ client library (aka C++ tracer) and what to do if you discover a security vulnerability in the project.
+Most notably, please do not share the details in a public forum (such as in a discussion, issue, or pull request) but instead reach out to us with the details.
+This gives us an opportunity to release a fix for others to benefit from by the time details are made public.
+
+## Supported Versions
+
+We accept vulnerability submissions for the [currently maintained release](https://github.com/DataDog/dd-trace-cpp/releases).
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability in the Datadog C++ client library (or any Datadog product for that matter) please submit details to the following email address:
+
+* [security@datadoghq.com](mailto:security@datadoghq.com)


### PR DESCRIPTION
# Description
- adds a bug report and feature request issue template
- disables blank issue creation
- adds a security document

# Motivation
- standardizes the create issue experience across tracers
- see the [node.js create issue screen](https://github.com/DataDog/dd-trace-js/issues/new/choose) for an example of what this looks like

# Additional Notes
- does the C++ tracer instrument third party packages? I'm assuming not and have left such fields out
- let me know if there's any other things you need to know (musl, glibc, etc) and we can add fields
