### PR TITLE
fix: Remote config service/env validation

### DIFF
--- a/src/datadog/config_manager.cpp
+++ b/src/datadog/config_manager.cpp
@@ -151,14 +151,6 @@ Optional<std::string> ConfigManager::on_update(const Configuration& config) {
 
   const auto config_json = nlohmann::json::parse(config.content);
 
-  const auto& targeted_service = config_json.at("service_target");
-  if (targeted_service.at("service").get<StringView>() !=
-          tracer_signature_.default_service ||
-      targeted_service.at("env").get<StringView>() !=
-          tracer_signature_.default_environment) {
-    return "Wrong service targeted";
-  }
-
   auto config_update = parse_dynamic_config(config_json.at("lib_config"));
 
   auto config_metadata = apply_update(config_update);

--- a/src/datadog/config_manager.cpp
+++ b/src/datadog/config_manager.cpp
@@ -124,7 +124,6 @@ ConfigManager::Update parse_dynamic_config(const nlohmann::json& j) {
 namespace rc = datadog::remote_config;
 
 ConfigManager::ConfigManager(const FinalizedTracerConfig& config,
-                             const TracerSignature& tracer_signature,
                              const std::shared_ptr<TracerTelemetry>& telemetry)
     : clock_(config.clock),
       default_metadata_(config.metadata),
@@ -133,7 +132,6 @@ ConfigManager::ConfigManager(const FinalizedTracerConfig& config,
       rules_(config.trace_sampler.rules),
       span_defaults_(std::make_shared<SpanDefaults>(config.defaults)),
       report_traces_(config.report_traces),
-      tracer_signature_(tracer_signature),
       telemetry_(telemetry) {}
 
 rc::Products ConfigManager::get_products() { return rc::product::APM_TRACING; }

--- a/src/datadog/config_manager.h
+++ b/src/datadog/config_manager.h
@@ -76,7 +76,6 @@ class ConfigManager : public remote_config::Listener {
   DynamicConfig<std::shared_ptr<const SpanDefaults>> span_defaults_;
   DynamicConfig<bool> report_traces_;
 
-  const TracerSignature& tracer_signature_;
   std::shared_ptr<TracerTelemetry> telemetry_;
 
  private:
@@ -86,7 +85,6 @@ class ConfigManager : public remote_config::Listener {
 
  public:
   ConfigManager(const FinalizedTracerConfig& config,
-                const TracerSignature& signature,
                 const std::shared_ptr<TracerTelemetry>& telemetry);
   ~ConfigManager() override{};
 

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -47,8 +47,8 @@ Tracer::Tracer(const FinalizedTracerConfig& config,
       tracer_telemetry_(std::make_shared<TracerTelemetry>(
           config.telemetry.enabled, config.clock, logger_, signature_,
           config.integration_name, config.integration_version)),
-      config_manager_(std::make_shared<ConfigManager>(config, signature_,
-                                                      tracer_telemetry_)),
+      config_manager_(
+          std::make_shared<ConfigManager>(config, tracer_telemetry_)),
       collector_(/* see constructor body */),
       span_sampler_(
           std::make_shared<SpanSampler>(config.span_sampler, config.clock)),

--- a/test/test_config_manager.cpp
+++ b/test/test_config_manager.cpp
@@ -29,8 +29,7 @@ CONFIG_MANAGER_TEST("remote configuration handling") {
   auto tracer_telemetry = std::make_shared<TracerTelemetry>(
       false, default_clock, nullptr, tracer_signature, "", "");
 
-  ConfigManager config_manager(*finalize_config(config), tracer_signature,
-                               tracer_telemetry);
+  ConfigManager config_manager(*finalize_config(config), tracer_telemetry);
 
   rc::Listener::Configuration config_update{/* id = */ "id",
                                             /* path = */ "",

--- a/test/test_config_manager.cpp
+++ b/test/test_config_manager.cpp
@@ -38,24 +38,6 @@ CONFIG_MANAGER_TEST("remote configuration handling") {
                                             /* version = */ 1,
                                             rc::product::Flag::APM_TRACING};
 
-  SECTION(
-      "configuration updates targetting the wrong tracer reports an error") {
-    // clang-format off
-    auto test_case = GENERATE(values<std::string>({
-      R"({ "service_target": { "service": "not-testsvc", "env": "test" } })",
-      R"({ "service_target": { "service": "testsvc", "env": "not-test" } })"
-    }));
-    // clang-format on
-
-    CAPTURE(test_case);
-
-    config_update.content = test_case;
-
-    // TODO: targetting wrong procut -> error
-    const auto err = config_manager.on_update(config_update);
-    CHECK(err);
-  }
-
   SECTION("handling of `tracing_sampling_rate`") {
     // SECTION("invalid value") {
     //   config_update.content = R"({

--- a/test/test_datadog_agent.cpp
+++ b/test/test_datadog_agent.cpp
@@ -200,8 +200,7 @@ TEST_CASE("Remote Configuration", "[datadog_agent]") {
       finalized->telemetry.enabled, finalized->clock, finalized->logger,
       signature, "", "");
 
-  auto config_manager =
-      std::make_shared<ConfigManager>(*finalized, signature, telemetry);
+  auto config_manager = std::make_shared<ConfigManager>(*finalized, telemetry);
 
   const auto& agent_config =
       std::get<FinalizedDatadogAgentConfig>(finalized->collector);


### PR DESCRIPTION
# Description
Removes the remote config check that asserts a matching env / service, as this is incorrectly causing remote config payloads to be ignored

# Motivation
This was motivated by a customer issue with adaptive sampling not working. When the tracer doesn't report an environment version but the Datadog agent does, incoming remote config payloads (which have already been verified by the Datadog agent) get rejected even though they are correct. This removes the validation and relies upon the Datadog agent verification.

# Testing
The previous unit test has been removed as it's invalid, and the associated system-tests authored here have been tested locally with success: https://github.com/DataDog/system-tests/pull/3778

# Additional Notes

Jira ticket: [APMAPI-1006]


[APMAPI-1006]: https://datadoghq.atlassian.net/browse/APMAPI-1006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ