### PR TITLE
perf: parse w3c traceparent using a customer parser

### DIFF
--- a/fuzz/w3c-propagation/fuzz.cpp
+++ b/fuzz/w3c-propagation/fuzz.cpp
@@ -10,8 +10,6 @@
 #include <cstdlib>
 #include <functional>
 #include <memory>
-#include <string>
-#include <unordered_map>
 
 namespace dd = datadog::tracing;
 
@@ -22,6 +20,7 @@ dd::Tracer& tracer_singleton() {
     dd::TracerConfig config;
     config.service = "fuzzer";
     config.collector = std::make_shared<dd::NullCollector>();
+    config.extraction_styles = {dd::PropagationStyle::W3C};
 
     const auto finalized_config = dd::finalize_config(config);
     if (!finalized_config) {

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -730,15 +730,27 @@ TEST_CASE("span extraction") {
 
         {__LINE__, "invalid: trace ID zero",
          "00-00000000000000000000000000000000-00f067aa0ba902b7-00", // traceparent
-         "trace_id_zero"}, // expected_error_tag_value
+         "malformed_traceid"}, // expected_error_tag_value
 
         {__LINE__, "invalid: parent ID zero",
          "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-00", // traceparent
-         "parent_id_zero"}, // expected_error_tag_value
+         "malformed_parentid"}, // expected_error_tag_value
 
         {__LINE__, "invalid: trailing characters when version is zero",
          "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00-foo", // traceparent
          "malformed_traceparent"}, // expected_error_tag_value
+      
+        {__LINE__, "invalid: non hex trace ID",
+         "00-abcdefghijklmnopqrstuvxyzabcdefg-00f067aa0ba902b7-00", // traceparent
+         "malformed_traceid"}, // expected_error_tag_value
+
+        {__LINE__, "invalid: non hex parent ID",
+         "00-4bf92f3577b34da6a3ce929d0e0e4736-abcdefghijklmnop-00", // traceparent
+         "malformed_parentid"}, // expected_error_tag_value
+
+        {__LINE__, "invalid: non hex trace tag ID",
+         "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-xy", // traceparent
+         "malformed_traceflags"}, // expected_error_tag_value
     }));
     // clang-format on
 


### PR DESCRIPTION
# Description
`std::regex` is [notoriously known to be slow](https://github.com/HFTrader/regex-performance?tab=readme-ov-file#results). This custom parser implementation offers significantly better performance.

## Benchmark
Bench: https://quick-bench.com/q/XJw86Zh_SBDpQ3xhI2nrY-k-Xbc
Result:
<img width="711" alt="image" src="https://github.com/user-attachments/assets/be5e99b2-92ad-486e-82dc-0aa629a8b973" />

## TODO
- [x] fuzz me!