### PR TITLE
fix(telemetry): Handle empty configuration payload properly

### DIFF
--- a/src/datadog/datadog_agent.cpp
+++ b/src/datadog/datadog_agent.cpp
@@ -414,8 +414,9 @@ void DatadogAgent::send_heartbeat_and_telemetry() {
 }
 
 void DatadogAgent::send_configuration_change() {
-  send_telemetry("app-client-configuration-change",
-                 tracer_telemetry_->configuration_change());
+  if (auto payload = tracer_telemetry_->configuration_change()) {
+    send_telemetry("app-client-configuration-change", *payload);
+  }
 }
 
 void DatadogAgent::send_app_closing() {

--- a/src/datadog/tracer_telemetry.cpp
+++ b/src/datadog/tracer_telemetry.cpp
@@ -355,10 +355,14 @@ std::string TracerTelemetry::app_closing() {
   return message_batch_payload;
 }
 
-std::string TracerTelemetry::configuration_change() {
+Optional<std::string> TracerTelemetry::configuration_change() {
+  if (configuration_snapshot_.empty()) return nullopt;
+
+  std::vector<ConfigMetadata> current_configuration;
+  std::swap(current_configuration, configuration_snapshot_);
+
   auto configuration_json = nlohmann::json::array();
-  for (const auto& config_metadata : configuration_snapshot_) {
-    // if (config_metadata.value.empty()) continue;
+  for (const auto& config_metadata : current_configuration) {
     configuration_json.emplace_back(
         generate_configuration_field(config_metadata));
   }

--- a/src/datadog/tracer_telemetry.h
+++ b/src/datadog/tracer_telemetry.h
@@ -150,7 +150,7 @@ class TracerTelemetry {
   // been modified, a `generate-metrics` message.
   std::string app_closing();
   // Construct an `app-client-configuration-change` message.
-  std::string configuration_change();
+  Optional<std::string> configuration_change();
 };
 
 }  // namespace tracing


### PR DESCRIPTION
# Description

This fix addresses two issues:
1. Prevents invalid telemetry payloads when there are no configuration entries.
2. Ensures configuration updates are correctly processed and not carried over to the next update.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
