### PR TITLE
chore: document that `NullLogger` is the default

### DIFF
--- a/doc/maintainers.md
+++ b/doc/maintainers.md
@@ -605,8 +605,11 @@ be to have versions of the `Error`-returning operations that instead accept a
 the present state of things is acceptable and that such a change is not
 warranted.
 
-The default implementation of `Logger` is `CerrLogger`, defined in
-[cerr_logger.h][42]. `CerrLogger` logs to [std::cerr][43] in both `log_error`
+The default implementation of `Logger` is `NullLogger`, defined in
+[null_logger.h][47]. `NullLogger` doesn't log anything.
+
+A client library might wish to install `CerrLogger` instead. `CerrLogger` is
+defined in [cerr_logger.h][42] and logs to [std::cerr][43] in both `log_error`
 and `log_startup`.
 
 The `Logger` used by a `Tracer` is configured via `std::shared_ptr<Logger>
@@ -690,8 +693,9 @@ TODO
 [39]: https://en.cppreference.com/w/cpp/utility/variant/get_if
 [40]: https://en.cppreference.com/w/cpp/language/value_category
 [41]: ../include/datadog/logger.h
-[42]: ../src/datadog/cerr_logger.h
+[42]: ../include/datadog/cerr_logger.h
 [43]: https://en.cppreference.com/w/cpp/io/cerr
 [44]: https://en.cppreference.com/w/cpp/utility/functional/function
 [45]: https://github.com/DataDog/datadog-agent/blob/796ccb9e92326c85b51f519291e86eb5bc950180/pkg/trace/api/endpoints.go#L97
 [46]: https://github.com/DataDog/dd-trace-cpp/tree/david.goffredo/traception
+[47]: ../src/datadog/null_logger.h

--- a/include/datadog/cerr_logger.h
+++ b/include/datadog/cerr_logger.h
@@ -3,9 +3,6 @@
 // This component provides a class, `CerrLogger`, that implements the `Logger`
 // interface from `logger.h`.  `CerrLogger` prints to `std::cerr`, which is
 // typically an unbuffered stream to the standard error file.
-//
-// `CerrLogger` is the default logger used by `Tracer` unless otherwise
-// configured in `TracerConfig`.
 
 #include <datadog/logger.h>
 

--- a/include/datadog/tracer_config.h
+++ b/include/datadog/tracer_config.h
@@ -121,8 +121,8 @@ struct TracerConfig {
   Optional<std::size_t> max_tags_header_size;
 
   // `logger` specifies how the tracer will issue diagnostic messages.  If
-  // `logger` is null, then it defaults to a logger that inserts into
-  // `std::cerr`.
+  // `logger` is null, then it defaults to no logging (`NullLogger`).  See
+  // `CerrLogger` for an alternative.
   std::shared_ptr<Logger> logger;
 
   // `log_on_startup` indicates whether the tracer will log a banner of

--- a/test/test_cerr_logger.cpp
+++ b/test/test_cerr_logger.cpp
@@ -29,8 +29,6 @@ class StreambufGuard {
 
 }  // namespace
 
-// `CerrLogger` is the default logger.
-// These test exist just to cover all of its methods.
 TEST_CASE("CerrLogger") {
   std::ostringstream stream;
   const StreambufGuard guard{std::cerr, stream.rdbuf()};


### PR DESCRIPTION
Commit [9f7d0aa0a82795f8a5a134b4b44332955360d43a][1] introduced `NullLogger` as the default logger, replacing `CerrLogger`.

This revision updates some relevant documentation.

I used `git grep CerrLogger` and [check-markdown-links][2] to find the mismatches.

[1]: https://github.com/DataDog/dd-trace-cpp/commit/9f7d0aa0a82795f8a5a134b4b44332955360d43a
[2]: https://github.com/dgoffredo/check-markdown-links
