### PR TITLE
[part 2] refactor!(telemetry): move telemetry logic from `DatadogAgent`

### DIFF
--- a/include/datadog/datadog_agent_config.h
+++ b/include/datadog/datadog_agent_config.h
@@ -66,8 +66,6 @@ struct DatadogAgentConfig {
   // How often, in seconds, to query the Datadog Agent for remote configuration
   // updates.
   Optional<double> remote_configuration_poll_interval_seconds;
-
-  static Expected<HTTPClient::URL> parse(StringView);
 };
 
 class FinalizedDatadogAgentConfig {

--- a/include/datadog/telemetry/telemetry.h
+++ b/include/datadog/telemetry/telemetry.h
@@ -1,16 +1,21 @@
 #pragma once
 
+#include <datadog/clock.h>
+#include <datadog/config.h>
+#include <datadog/event_scheduler.h>
+#include <datadog/http_client.h>
 #include <datadog/logger.h>
 #include <datadog/telemetry/configuration.h>
 #include <datadog/telemetry/metrics.h>
+#include <datadog/tracer_signature.h>
 
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace datadog {
 
 namespace tracing {
-class DatadogAgent;
 class TracerTelemetry;
 }  // namespace tracing
 
@@ -21,13 +26,74 @@ namespace telemetry {
 ///
 /// IMPORTANT: This is intended for use only by Datadog Engineers.
 class Telemetry final {
+  // This structure contains all the metrics that are exposed by tracer
+  // telemetry.
+  struct {
+    struct {
+      telemetry::CounterMetric spans_created = {
+          "spans_created", "tracers", {}, true};
+      telemetry::CounterMetric spans_finished = {
+          "spans_finished", "tracers", {}, true};
+
+      telemetry::CounterMetric trace_segments_created_new = {
+          "trace_segments_created", "tracers", {"new_continued:new"}, true};
+      telemetry::CounterMetric trace_segments_created_continued = {
+          "trace_segments_created",
+          "tracers",
+          {"new_continued:continued"},
+          true};
+      telemetry::CounterMetric trace_segments_closed = {
+          "trace_segments_closed", "tracers", {}, true};
+      telemetry::CounterMetric baggage_items_exceeded = {
+          "context_header.truncated",
+          "tracers",
+          {{"truncation_reason:baggage_item_count_exceeded"}},
+          true,
+      };
+      telemetry::CounterMetric baggage_bytes_exceeded = {
+          "context_header.truncated",
+          "tracers",
+          {{"truncation_reason:baggage_byte_count_exceeded"}},
+          true,
+      };
+    } tracer;
+    struct {
+      telemetry::CounterMetric requests = {
+          "trace_api.requests", "tracers", {}, true};
+
+      telemetry::CounterMetric responses_1xx = {
+          "trace_api.responses", "tracers", {"status_code:1xx"}, true};
+      telemetry::CounterMetric responses_2xx = {
+          "trace_api.responses", "tracers", {"status_code:2xx"}, true};
+      telemetry::CounterMetric responses_3xx = {
+          "trace_api.responses", "tracers", {"status_code:3xx"}, true};
+      telemetry::CounterMetric responses_4xx = {
+          "trace_api.responses", "tracers", {"status_code:4xx"}, true};
+      telemetry::CounterMetric responses_5xx = {
+          "trace_api.responses", "tracers", {"status_code:5xx"}, true};
+
+      telemetry::CounterMetric errors_timeout = {
+          "trace_api.errors", "tracers", {"type:timeout"}, true};
+      telemetry::CounterMetric errors_network = {
+          "trace_api.errors", "tracers", {"type:network"}, true};
+      telemetry::CounterMetric errors_status_code = {
+          "trace_api.errors", "tracers", {"type:status_code"}, true};
+
+    } trace_api;
+  } metrics_;
+
   /// Configuration object containing the validated settings for telemetry
   FinalizedConfiguration config_;
   /// Shared pointer to the user logger instance.
   std::shared_ptr<tracing::Logger> logger_;
-  /// TODO(@dmehala): Legacy dependency.
-  std::shared_ptr<tracing::DatadogAgent> datadog_agent_;
   std::shared_ptr<tracing::TracerTelemetry> tracer_telemetry_;
+  std::vector<tracing::EventScheduler::Cancel> tasks_;
+  tracing::HTTPClient::ResponseHandler telemetry_on_response_;
+  tracing::HTTPClient::ErrorHandler telemetry_on_error_;
+  tracing::HTTPClient::URL telemetry_endpoint_;
+  tracing::TracerSignature tracer_signature_;
+  std::shared_ptr<tracing::HTTPClient> http_client_;
+  tracing::Clock clock_;
 
  public:
   /// Constructor for the Telemetry class
@@ -37,9 +103,20 @@ class Telemetry final {
   /// @param metrics A vector user metrics to report.
   Telemetry(FinalizedConfiguration configuration,
             std::shared_ptr<tracing::Logger> logger,
-            std::vector<std::shared_ptr<Metric>> metrics);
+            std::shared_ptr<tracing::HTTPClient> client,
+            std::vector<std::shared_ptr<Metric>> metrics,
+            tracing::EventScheduler& scheduler,
+            tracing::HTTPClient::URL agent_url,
+            tracing::Clock clock = tracing::default_clock);
 
-  ~Telemetry() = default;
+  /// Destructor
+  ///
+  /// Send last metrics snapshot and `app-closing` event.
+  ~Telemetry();
+
+  // Provides access to the telemetry metrics for updating the values.
+  // This value should not be stored.
+  inline auto& metrics() { return metrics_; }
 
   /// Capture and report internal error message to Datadog.
   ///
@@ -50,6 +127,22 @@ class Telemetry final {
   ///
   /// @param message The warning message to log.
   void log_warning(std::string message);
+
+  void send_app_started(
+      const std::unordered_map<tracing::ConfigName, tracing::ConfigMetadata>&
+          config_metadata);
+
+  void send_configuration_change();
+
+  void capture_configuration_change(
+      const std::vector<tracing::ConfigMetadata>& new_configuration);
+
+  void send_app_closing();
+
+ private:
+  void send_telemetry(tracing::StringView request_type, std::string payload);
+
+  void send_heartbeat_and_telemetry();
 };
 
 }  // namespace telemetry

--- a/include/datadog/trace_segment.h
+++ b/include/datadog/trace_segment.h
@@ -40,6 +40,9 @@
 #include "sampling_priority.h"
 
 namespace datadog {
+namespace telemetry {
+class Telemetry;
+}
 namespace tracing {
 
 class Collector;
@@ -52,14 +55,13 @@ struct SpanDefaults;
 class SpanSampler;
 class TraceSampler;
 class ConfigManager;
-class TracerTelemetry;
 
 class TraceSegment {
   mutable std::mutex mutex_;
 
   std::shared_ptr<Logger> logger_;
   std::shared_ptr<Collector> collector_;
-  std::shared_ptr<TracerTelemetry> tracer_telemetry_;
+  std::shared_ptr<telemetry::Telemetry> telemetry_;
   std::shared_ptr<TraceSampler> trace_sampler_;
   std::shared_ptr<SpanSampler> span_sampler_;
 
@@ -82,7 +84,7 @@ class TraceSegment {
  public:
   TraceSegment(const std::shared_ptr<Logger>& logger,
                const std::shared_ptr<Collector>& collector,
-               const std::shared_ptr<TracerTelemetry>& tracer_telemetry,
+               const std::shared_ptr<telemetry::Telemetry>& telemetry,
                const std::shared_ptr<TraceSampler>& trace_sampler,
                const std::shared_ptr<SpanSampler>& span_sampler,
                const std::shared_ptr<const SpanDefaults>& defaults,

--- a/include/datadog/tracer.h
+++ b/include/datadog/tracer.h
@@ -10,6 +10,8 @@
 // obtained from a `TracerConfig` via the `finalize_config` function.  See
 // `tracer_config.h`.
 
+#include <datadog/telemetry/telemetry.h>
+
 #include <cstddef>
 #include <memory>
 
@@ -39,7 +41,7 @@ class Tracer {
   std::shared_ptr<Logger> logger_;
   RuntimeID runtime_id_;
   TracerSignature signature_;
-  std::shared_ptr<TracerTelemetry> tracer_telemetry_;
+  std::shared_ptr<telemetry::Telemetry> telemetry_;
   std::shared_ptr<ConfigManager> config_manager_;
   std::shared_ptr<Collector> collector_;
   std::shared_ptr<SpanSampler> span_sampler_;

--- a/include/datadog/tracer_config.h
+++ b/include/datadog/tracer_config.h
@@ -156,11 +156,18 @@ struct TracerConfig {
   // programmatic value in Datadog's Active Configuration, whereas it is
   // actually the default value for the integration.
   Optional<bool> report_service_as_default;
+
   /// The maximum number of baggage items that can be stored or propagated.
   Optional<std::size_t> baggage_max_items;
+
   /// The maximum amount of bytes allowed to be written during tracing context
   /// injection.
   Optional<std::size_t> baggage_max_bytes;
+
+  /// The event scheduler used for scheduling recurring tasks.
+  /// By default, it uses `ThreadedEventScheduler`, which runs tasks on a
+  /// separate thread.
+  std::shared_ptr<EventScheduler> event_scheduler;
 };
 
 // `FinalizedTracerConfig` contains `Tracer` implementation details derived from
@@ -197,6 +204,9 @@ class FinalizedTracerConfig final {
   bool report_traces;
   std::unordered_map<ConfigName, ConfigMetadata> metadata;
   Baggage::Options baggage_opts;
+  HTTPClient::URL agent_url;
+  std::shared_ptr<EventScheduler> event_scheduler;
+  std::shared_ptr<HTTPClient> http_client;
 };
 
 // Return a `FinalizedTracerConfig` from the specified `config` and from any

--- a/src/datadog/config_manager.cpp
+++ b/src/datadog/config_manager.cpp
@@ -123,8 +123,9 @@ ConfigManager::Update parse_dynamic_config(const nlohmann::json& j) {
 
 namespace rc = datadog::remote_config;
 
-ConfigManager::ConfigManager(const FinalizedTracerConfig& config,
-                             const std::shared_ptr<TracerTelemetry>& telemetry)
+ConfigManager::ConfigManager(
+    const FinalizedTracerConfig& config,
+    const std::shared_ptr<telemetry::Telemetry>& telemetry)
     : clock_(config.clock),
       default_metadata_(config.metadata),
       trace_sampler_(

--- a/src/datadog/config_manager.h
+++ b/src/datadog/config_manager.h
@@ -9,12 +9,12 @@
 #include <datadog/optional.h>
 #include <datadog/remote_config/listener.h>
 #include <datadog/span_defaults.h>
+#include <datadog/telemetry/telemetry.h>
 #include <datadog/tracer_config.h>
 
 #include <mutex>
 
 #include "json.hpp"
-#include "tracer_telemetry.h"
 
 namespace datadog {
 namespace tracing {
@@ -76,7 +76,7 @@ class ConfigManager : public remote_config::Listener {
   DynamicConfig<std::shared_ptr<const SpanDefaults>> span_defaults_;
   DynamicConfig<bool> report_traces_;
 
-  std::shared_ptr<TracerTelemetry> telemetry_;
+  std::shared_ptr<telemetry::Telemetry> telemetry_;
 
  private:
   template <typename T>
@@ -85,7 +85,7 @@ class ConfigManager : public remote_config::Listener {
 
  public:
   ConfigManager(const FinalizedTracerConfig& config,
-                const std::shared_ptr<TracerTelemetry>& telemetry);
+                const std::shared_ptr<telemetry::Telemetry>& telemetry);
   ~ConfigManager() override{};
 
   remote_config::Products get_products() override;

--- a/src/datadog/datadog_agent.h
+++ b/src/datadog/datadog_agent.h
@@ -17,11 +17,12 @@
 #include <mutex>
 #include <vector>
 
-#include "config_manager.h"
 #include "remote_config/remote_config.h"
-#include "tracer_telemetry.h"
 
 namespace datadog {
+namespace telemetry {
+class Telemetry;
+}
 namespace tracing {
 
 class FinalizedDatadogAgentConfig;
@@ -39,20 +40,16 @@ class DatadogAgent : public Collector {
 
  private:
   std::mutex mutex_;
-  std::shared_ptr<TracerTelemetry> tracer_telemetry_;
+  std::shared_ptr<telemetry::Telemetry> telemetry_;
   Clock clock_;
   std::shared_ptr<Logger> logger_;
   std::vector<TraceChunk> trace_chunks_;
   HTTPClient::URL traces_endpoint_;
-  HTTPClient::URL telemetry_endpoint_;
   HTTPClient::URL remote_configuration_endpoint_;
   std::shared_ptr<HTTPClient> http_client_;
   std::shared_ptr<EventScheduler> event_scheduler_;
   std::vector<EventScheduler::Cancel> tasks_;
   std::chrono::steady_clock::duration flush_interval_;
-  // Callbacks for submitting telemetry data
-  HTTPClient::ResponseHandler telemetry_on_response_;
-  HTTPClient::ErrorHandler telemetry_on_error_;
   std::chrono::steady_clock::duration request_timeout_;
   std::chrono::steady_clock::duration shutdown_timeout_;
 
@@ -60,13 +57,10 @@ class DatadogAgent : public Collector {
   TracerSignature tracer_signature_;
 
   void flush();
-  void send_telemetry(StringView, std::string);
-  void send_heartbeat_and_telemetry();
-  void send_app_closing();
 
  public:
   DatadogAgent(const FinalizedDatadogAgentConfig&,
-               const std::shared_ptr<TracerTelemetry>&,
+               const std::shared_ptr<telemetry::Telemetry>&,
                const std::shared_ptr<Logger>&, const TracerSignature& id,
                const std::vector<std::shared_ptr<remote_config::Listener>>&
                    rc_listeners);
@@ -75,11 +69,6 @@ class DatadogAgent : public Collector {
   Expected<void> send(
       std::vector<std::unique_ptr<SpanData>>&& spans,
       const std::shared_ptr<TraceSampler>& response_handler) override;
-
-  void send_app_started(
-      const std::unordered_map<ConfigName, ConfigMetadata>& config_metadata);
-
-  void send_configuration_change();
 
   void get_and_apply_remote_configuration_updates();
 

--- a/src/datadog/telemetry/telemetry.cpp
+++ b/src/datadog/telemetry/telemetry.cpp
@@ -1,42 +1,109 @@
 #include <datadog/clock.h>
 #include <datadog/datadog_agent_config.h>
+#include <datadog/dict_writer.h>
 #include <datadog/runtime_id.h>
+#include <datadog/string_view.h>
 #include <datadog/telemetry/telemetry.h>
+
+#include <chrono>
 
 #include "datadog_agent.h"
 #include "platform_util.h"
 #include "tracer_telemetry.h"
 
+using namespace datadog::tracing;
+using namespace std::chrono_literals;
+
 namespace datadog {
 namespace telemetry {
+namespace {
 
+HTTPClient::URL make_telemetry_endpoint(HTTPClient::URL url) {
+  append(url.path, "/telemetry/proxy/api/v2/apmtelemetry");
+  return url;
+}
+
+}  // namespace
 Telemetry::Telemetry(FinalizedConfiguration config,
                      std::shared_ptr<tracing::Logger> logger,
-                     std::vector<std::shared_ptr<Metric>> metrics)
-    : config_(std::move(config)), logger_(std::move(logger)) {
+                     std::shared_ptr<tracing::HTTPClient> client,
+                     std::vector<std::shared_ptr<Metric>> metrics,
+                     tracing::EventScheduler& event_scheduler,
+                     HTTPClient::URL agent_url, Clock clock)
+    : config_(std::move(config)),
+      logger_(std::move(logger)),
+      telemetry_endpoint_(make_telemetry_endpoint(agent_url)),
+      tracer_signature_(tracing::RuntimeID::generate(),
+                        tracing::get_process_name(), ""),
+      http_client_(client),
+      clock_(std::move(clock)) {
+  tracer_telemetry_ = std::make_shared<tracing::TracerTelemetry>(
+      config_.enabled, clock_, logger_, tracer_signature_,
+      config_.integration_name, config_.integration_version,
+      std::vector<std::reference_wrapper<Metric>>{
+          {metrics_.tracer.spans_created},
+          {metrics_.tracer.spans_finished},
+          {metrics_.tracer.trace_segments_created_new},
+          {metrics_.tracer.trace_segments_created_continued},
+          {metrics_.tracer.trace_segments_closed},
+          {metrics_.trace_api.requests},
+          {metrics_.trace_api.responses_1xx},
+          {metrics_.trace_api.responses_2xx},
+          {metrics_.trace_api.responses_3xx},
+          {metrics_.trace_api.responses_4xx},
+          {metrics_.trace_api.responses_5xx},
+          {metrics_.trace_api.errors_timeout},
+          {metrics_.trace_api.errors_network},
+          {metrics_.trace_api.errors_status_code},
+      },
+      metrics);
+
   if (!config_.enabled) {
     return;
   }
 
-  tracing::TracerSignature tracer_signature(tracing::RuntimeID::generate(),
-                                            tracing::get_process_name(), "");
+  // Callback for successful telemetry HTTP requests, to examine HTTP
+  // status.
+  telemetry_on_response_ = [logger = logger_](
+                               int response_status,
+                               const DictReader& /*response_headers*/,
+                               std::string response_body) {
+    if (response_status < 200 || response_status >= 300) {
+      logger->log_error([&](auto& stream) {
+        stream << "Unexpected telemetry response status " << response_status
+               << " with body (if any, starts on next line):\n"
+               << response_body;
+      });
+    }
+  };
 
-  tracer_telemetry_ = std::make_shared<tracing::TracerTelemetry>(
-      config_.enabled, tracing::default_clock, logger_, tracer_signature,
-      config_.integration_name, config_.integration_version, metrics);
+  // Callback for unsuccessful telemetry HTTP requests.
+  telemetry_on_error_ = [logger = logger_](Error error) {
+    logger->log_error(error.with_prefix(
+        "Error occurred during HTTP request for telemetry: "));
+  };
 
-  tracing::DatadogAgentConfig dd_config;
-  dd_config.remote_configuration_enabled = false;
+  // Only schedule this if telemetry is enabled.
+  // Every 10 seconds, have the tracer telemetry capture the metrics
+  // values. Every 60 seconds, also report those values to the datadog
+  // agent.
+  tasks_.emplace_back(event_scheduler.schedule_recurring_event(
+      std::chrono::seconds(10), [this, n = 0]() mutable {
+        n++;
+        tracer_telemetry_->capture_metrics();
+        if (n % 6 == 0) {
+          send_heartbeat_and_telemetry();
+        }
+      }));
+}
 
-  auto final_cfg =
-      tracing::finalize_config(dd_config, logger_, tracing::default_clock);
-  if (!final_cfg) {
-    return;
-  }
-
-  datadog_agent_ = std::make_shared<tracing::DatadogAgent>(
-      *final_cfg, tracer_telemetry_, logger_, tracer_signature,
-      std::vector<std::shared_ptr<remote_config::Listener>>{});
+Telemetry::~Telemetry() {
+  if (!config_.enabled) return;
+  tracer_telemetry_->capture_metrics();
+  // The app-closing message is bundled with a message containing the
+  // final metric values.
+  send_app_closing();
+  http_client_->drain(clock_().tick + 1s);
 }
 
 void Telemetry::log_error(std::string message) {
@@ -45,6 +112,64 @@ void Telemetry::log_error(std::string message) {
 
 void Telemetry::log_warning(std::string message) {
   tracer_telemetry_->log(std::move(message), LogLevel::WARNING);
+}
+
+void Telemetry::send_telemetry(StringView request_type, std::string payload) {
+  if (!config_.enabled) return;
+  auto set_telemetry_headers = [request_type, payload_size = payload.size(),
+                                debug_enabled = tracer_telemetry_->debug(),
+                                tracer_signature =
+                                    &tracer_signature_](DictWriter& headers) {
+    /*
+      TODO:
+        Datadog-Container-ID
+    */
+    headers.set("Content-Type", "application/json");
+    headers.set("Content-Length", std::to_string(payload_size));
+    headers.set("DD-Telemetry-API-Version", "v2");
+    headers.set("DD-Client-Library-Language", "cpp");
+    headers.set("DD-Client-Library-Version", tracer_signature->library_version);
+    headers.set("DD-Telemetry-Request-Type", request_type);
+
+    if (debug_enabled) {
+      headers.set("DD-Telemetry-Debug-Enabled", "true");
+    }
+  };
+
+  // TODO(@dmehala): make `clock::instance()` a singleton
+  auto post_result = http_client_->post(
+      telemetry_endpoint_, set_telemetry_headers, std::move(payload),
+      telemetry_on_response_, telemetry_on_error_,
+      tracing::default_clock().tick + 5s);
+  if (auto* error = post_result.if_error()) {
+    logger_->log_error(
+        error->with_prefix("Unexpected error submitting telemetry event: "));
+  }
+}
+
+void Telemetry::send_app_started(
+    const std::unordered_map<ConfigName, ConfigMetadata>& config_metadata) {
+  send_telemetry("app-started",
+                 tracer_telemetry_->app_started(config_metadata));
+}
+
+void Telemetry::send_app_closing() {
+  send_telemetry("app-closing", tracer_telemetry_->app_closing());
+}
+
+void Telemetry::send_heartbeat_and_telemetry() {
+  send_telemetry("app-heartbeat", tracer_telemetry_->heartbeat_and_telemetry());
+}
+
+void Telemetry::send_configuration_change() {
+  if (auto payload = tracer_telemetry_->configuration_change()) {
+    send_telemetry("app-client-configuration-change", *payload);
+  }
+}
+
+void Telemetry::capture_configuration_change(
+    const std::vector<tracing::ConfigMetadata>& new_configuration) {
+  return tracer_telemetry_->capture_configuration_change(new_configuration);
 }
 
 }  // namespace telemetry

--- a/src/datadog/tracer_telemetry.cpp
+++ b/src/datadog/tracer_telemetry.cpp
@@ -70,7 +70,8 @@ TracerTelemetry::TracerTelemetry(
       host_info_(get_host_info()),
       tracer_signature_(tracer_signature),
       integration_name_(integration_name),
-      integration_version_(integration_version) {
+      integration_version_(integration_version),
+      user_metrics_(user_metrics) {
   if (enabled_) {
     // Register all the metrics that we're tracking by adding them to the
     // metrics_snapshots_ container. This allows for simpler iteration logic
@@ -78,7 +79,7 @@ TracerTelemetry::TracerTelemetry(
     for (auto& m : internal_metrics) {
       metrics_snapshots_.emplace_back(m, MetricSnapshot{});
     }
-    for (auto& m : user_metrics) {
+    for (auto& m : user_metrics_) {
       metrics_snapshots_.emplace_back(*m, MetricSnapshot{});
     }
   }

--- a/src/datadog/tracer_telemetry.cpp
+++ b/src/datadog/tracer_telemetry.cpp
@@ -61,6 +61,8 @@ TracerTelemetry::TracerTelemetry(
     bool enabled, const Clock& clock, const std::shared_ptr<Logger>& logger,
     const TracerSignature& tracer_signature,
     const std::string& integration_name, const std::string& integration_version,
+    const std::vector<std::reference_wrapper<telemetry::Metric>>&
+        internal_metrics,
     const std::vector<std::shared_ptr<telemetry::Metric>>& user_metrics)
     : enabled_(enabled),
       clock_(clock),
@@ -68,42 +70,15 @@ TracerTelemetry::TracerTelemetry(
       host_info_(get_host_info()),
       tracer_signature_(tracer_signature),
       integration_name_(integration_name),
-      integration_version_(integration_version),
-      user_metrics_(user_metrics) {
+      integration_version_(integration_version) {
   if (enabled_) {
     // Register all the metrics that we're tracking by adding them to the
     // metrics_snapshots_ container. This allows for simpler iteration logic
     // when using the values in `generate-metrics` messages.
-    metrics_snapshots_.emplace_back(metrics_.tracer.spans_created,
-                                    MetricSnapshot{});
-    metrics_snapshots_.emplace_back(metrics_.tracer.spans_finished,
-                                    MetricSnapshot{});
-    metrics_snapshots_.emplace_back(metrics_.tracer.trace_segments_created_new,
-                                    MetricSnapshot{});
-    metrics_snapshots_.emplace_back(
-        metrics_.tracer.trace_segments_created_continued, MetricSnapshot{});
-    metrics_snapshots_.emplace_back(metrics_.tracer.trace_segments_closed,
-                                    MetricSnapshot{});
-    metrics_snapshots_.emplace_back(metrics_.trace_api.requests,
-                                    MetricSnapshot{});
-    metrics_snapshots_.emplace_back(metrics_.trace_api.responses_1xx,
-                                    MetricSnapshot{});
-    metrics_snapshots_.emplace_back(metrics_.trace_api.responses_2xx,
-                                    MetricSnapshot{});
-    metrics_snapshots_.emplace_back(metrics_.trace_api.responses_3xx,
-                                    MetricSnapshot{});
-    metrics_snapshots_.emplace_back(metrics_.trace_api.responses_4xx,
-                                    MetricSnapshot{});
-    metrics_snapshots_.emplace_back(metrics_.trace_api.responses_5xx,
-                                    MetricSnapshot{});
-    metrics_snapshots_.emplace_back(metrics_.trace_api.errors_timeout,
-                                    MetricSnapshot{});
-    metrics_snapshots_.emplace_back(metrics_.trace_api.errors_network,
-                                    MetricSnapshot{});
-    metrics_snapshots_.emplace_back(metrics_.trace_api.errors_status_code,
-                                    MetricSnapshot{});
-
-    for (auto& m : user_metrics_) {
+    for (auto& m : internal_metrics) {
+      metrics_snapshots_.emplace_back(m, MetricSnapshot{});
+    }
+    for (auto& m : user_metrics) {
       metrics_snapshots_.emplace_back(*m, MetricSnapshot{});
     }
   }

--- a/src/datadog/tracer_telemetry.h
+++ b/src/datadog/tracer_telemetry.h
@@ -59,61 +59,6 @@ class TracerTelemetry {
   uint64_t seq_id_ = 0;
   // Track sequence id per configuration field
   std::unordered_map<ConfigName, std::size_t> config_seq_ids;
-  // This structure contains all the metrics that are exposed by tracer
-  // telemetry.
-  struct {
-    struct {
-      telemetry::CounterMetric spans_created = {
-          "spans_created", "tracers", {}, true};
-      telemetry::CounterMetric spans_finished = {
-          "spans_finished", "tracers", {}, true};
-
-      telemetry::CounterMetric trace_segments_created_new = {
-          "trace_segments_created", "tracers", {"new_continued:new"}, true};
-      telemetry::CounterMetric trace_segments_created_continued = {
-          "trace_segments_created",
-          "tracers",
-          {"new_continued:continued"},
-          true};
-      telemetry::CounterMetric trace_segments_closed = {
-          "trace_segments_closed", "tracers", {}, true};
-      telemetry::CounterMetric baggage_items_exceeded = {
-          "context_header.truncated",
-          "tracers",
-          {{"truncation_reason:baggage_item_count_exceeded"}},
-          true,
-      };
-      telemetry::CounterMetric baggage_bytes_exceeded = {
-          "context_header.truncated",
-          "tracers",
-          {{"truncation_reason:baggage_byte_count_exceeded"}},
-          true,
-      };
-    } tracer;
-    struct {
-      telemetry::CounterMetric requests = {
-          "trace_api.requests", "tracers", {}, true};
-
-      telemetry::CounterMetric responses_1xx = {
-          "trace_api.responses", "tracers", {"status_code:1xx"}, true};
-      telemetry::CounterMetric responses_2xx = {
-          "trace_api.responses", "tracers", {"status_code:2xx"}, true};
-      telemetry::CounterMetric responses_3xx = {
-          "trace_api.responses", "tracers", {"status_code:3xx"}, true};
-      telemetry::CounterMetric responses_4xx = {
-          "trace_api.responses", "tracers", {"status_code:4xx"}, true};
-      telemetry::CounterMetric responses_5xx = {
-          "trace_api.responses", "tracers", {"status_code:5xx"}, true};
-
-      telemetry::CounterMetric errors_timeout = {
-          "trace_api.errors", "tracers", {"type:timeout"}, true};
-      telemetry::CounterMetric errors_network = {
-          "trace_api.errors", "tracers", {"type:network"}, true};
-      telemetry::CounterMetric errors_status_code = {
-          "trace_api.errors", "tracers", {"type:status_code"}, true};
-
-    } trace_api;
-  } metrics_;
   // Each metric has an associated MetricSnapshot that contains the data points,
   // represented as a timestamp and the value of that metric.
   using MetricSnapshot = std::vector<std::pair<std::time_t, uint64_t>>;
@@ -141,13 +86,12 @@ class TracerTelemetry {
       const TracerSignature& tracer_signature,
       const std::string& integration_name,
       const std::string& integration_version,
+      const std::vector<std::reference_wrapper<telemetry::Metric>>&
+          internal_metrics,
       const std::vector<std::shared_ptr<telemetry::Metric>>& user_metrics =
           std::vector<std::shared_ptr<telemetry::Metric>>{});
   inline bool enabled() { return enabled_; }
   inline bool debug() { return debug_; }
-  // Provides access to the telemetry metrics for updating the values.
-  // This value should not be stored.
-  auto& metrics() { return metrics_; }
   // Constructs an `app-started` message using information provided when
   // constructed and the tracer_config value passed in.
   std::string app_started(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(tests
     # telemetry test cases
     telemetry/test_configuration.cpp
     telemetry/test_metrics.cpp
+    telemetry/test_telemetry.cpp
 
     # test cases
     test_baggage.cpp
@@ -37,7 +38,6 @@ add_executable(tests
     test_trace_id.cpp
     test_trace_segment.cpp
     test_tracer_config.cpp
-    test_tracer_telemetry.cpp
     test_tracer.cpp
     test_trace_sampler.cpp
 

--- a/test/mocks/http_clients.h
+++ b/test/mocks/http_clients.h
@@ -39,12 +39,16 @@ struct MockHTTPClient : public HTTPClient {
   std::mutex mutex_;
   ResponseHandler on_response_;
   ErrorHandler on_error_;
+  std::string request_body;
+
+  void clear() { request_body = ""; }
 
   Expected<void> post(
-      const URL&, HeadersSetter set_headers, std::string /*body*/,
+      const URL&, HeadersSetter set_headers, std::string body,
       ResponseHandler on_response, ErrorHandler on_error,
       std::chrono::steady_clock::time_point /*deadline*/) override {
     std::lock_guard<std::mutex> lock{mutex_};
+    request_body = body;
     if (!post_error) {
       on_response_ = on_response;
       on_error_ = on_error;

--- a/test/test_datadog_agent.cpp
+++ b/test/test_datadog_agent.cpp
@@ -1,4 +1,5 @@
 #include <datadog/collector_response.h>
+#include <datadog/config_manager.h>
 #include <datadog/datadog_agent.h>
 #include <datadog/datadog_agent_config.h>
 #include <datadog/tracer.h>
@@ -12,6 +13,7 @@
 #include "mocks/loggers.h"
 #include "test.h"
 
+using namespace datadog;
 using namespace datadog::tracing;
 using namespace std::chrono_literals;
 
@@ -196,9 +198,10 @@ TEST_CASE("Remote Configuration", "[datadog_agent]") {
 
   const TracerSignature signature(RuntimeID::generate(), "testsvc", "test");
 
-  auto telemetry = std::make_shared<TracerTelemetry>(
-      finalized->telemetry.enabled, finalized->clock, finalized->logger,
-      signature, "", "");
+  auto telemetry = std::make_shared<telemetry::Telemetry>(
+      *telemetry::finalize_config(), finalized->logger, http_client,
+      std::vector<std::shared_ptr<telemetry::Metric>>{},
+      *finalized->event_scheduler, finalized->agent_url);
 
   auto config_manager = std::make_shared<ConfigManager>(*finalized, telemetry);
 


### PR DESCRIPTION
## Description
This PR continues the work of refactoring the telemetry module to provide a clear and structured telemetry API. The goal is to make it easier for Datadog engineers to collect telemetry metrics and logs on the usage of our products.

Specifically, this PR moves the telemetry logic out of `DatadogAgent` and into a the telemetry module.
For reference, Part 1 of this refactoring can be found here: [#166](https://github.com/DataDog/dd-trace-cpp/pull/166).