### PR TITLE
[part 3] refactor!(telemetry): introduce a singleton

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,6 +5,8 @@ cc_library(
       "src/datadog/telemetry/metrics.cpp",
       "src/datadog/telemetry/log.h",
       "src/datadog/telemetry/telemetry.cpp",
+      "src/datadog/telemetry/telemetry_impl.h",
+      "src/datadog/telemetry/telemetry_impl.cpp",
       "src/datadog/baggage.cpp",
       "src/datadog/base64.cpp",
       "src/datadog/cerr_logger.cpp",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ target_sources(dd_trace_cpp-objects
     src/datadog/telemetry/configuration.cpp
     src/datadog/telemetry/metrics.cpp
     src/datadog/telemetry/telemetry.cpp
+    src/datadog/telemetry/telemetry_impl.cpp
     src/datadog/baggage.cpp
     src/datadog/base64.cpp
     src/datadog/cerr_logger.cpp

--- a/include/datadog/telemetry/telemetry.h
+++ b/include/datadog/telemetry/telemetry.h
@@ -7,143 +7,84 @@
 #include <datadog/logger.h>
 #include <datadog/telemetry/configuration.h>
 #include <datadog/telemetry/metrics.h>
-#include <datadog/tracer_signature.h>
 
 #include <memory>
 #include <unordered_map>
 #include <vector>
 
-namespace datadog {
-
-namespace tracing {
-class TracerTelemetry;
-}  // namespace tracing
-
-namespace telemetry {
-
-/// The telemetry class is responsible for handling internal telemetry data to
+/// Telemetry functions are responsibles for handling internal telemetry data to
 /// track Datadog product usage. It _can_ collect and report logs and metrics.
 ///
 /// IMPORTANT: This is intended for use only by Datadog Engineers.
-class Telemetry final {
-  // This structure contains all the metrics that are exposed by tracer
-  // telemetry.
-  struct {
-    struct {
-      telemetry::CounterMetric spans_created = {
-          "spans_created", "tracers", {}, true};
-      telemetry::CounterMetric spans_finished = {
-          "spans_finished", "tracers", {}, true};
+namespace datadog::telemetry {
 
-      telemetry::CounterMetric trace_segments_created_new = {
-          "trace_segments_created", "tracers", {"new_continued:new"}, true};
-      telemetry::CounterMetric trace_segments_created_continued = {
-          "trace_segments_created",
-          "tracers",
-          {"new_continued:continued"},
-          true};
-      telemetry::CounterMetric trace_segments_closed = {
-          "trace_segments_closed", "tracers", {}, true};
-      telemetry::CounterMetric baggage_items_exceeded = {
-          "context_header.truncated",
-          "tracers",
-          {{"truncation_reason:baggage_item_count_exceeded"}},
-          true,
-      };
-      telemetry::CounterMetric baggage_bytes_exceeded = {
-          "context_header.truncated",
-          "tracers",
-          {{"truncation_reason:baggage_byte_count_exceeded"}},
-          true,
-      };
-    } tracer;
-    struct {
-      telemetry::CounterMetric requests = {
-          "trace_api.requests", "tracers", {}, true};
+/// Initialize the telemetry module
+/// Once initialized, the telemetry module is running for the entier lifecycle
+/// of the application.
+///
+/// @param configuration The finalized configuration settings.
+/// @param logger User logger instance.
+/// @param metrics A vector user metrics to report.
+///
+/// NOTE: Make sure to call `init` before calling any of the other telemetry
+/// functions.
+void init(FinalizedConfiguration configuration,
+          std::shared_ptr<tracing::Logger> logger,
+          std::shared_ptr<tracing::HTTPClient> client,
+          std::vector<std::shared_ptr<Metric>> metrics,
+          std::shared_ptr<tracing::EventScheduler> event_scheduler,
+          tracing::HTTPClient::URL agent_url,
+          tracing::Clock clock = tracing::default_clock);
 
-      telemetry::CounterMetric responses_1xx = {
-          "trace_api.responses", "tracers", {"status_code:1xx"}, true};
-      telemetry::CounterMetric responses_2xx = {
-          "trace_api.responses", "tracers", {"status_code:2xx"}, true};
-      telemetry::CounterMetric responses_3xx = {
-          "trace_api.responses", "tracers", {"status_code:3xx"}, true};
-      telemetry::CounterMetric responses_4xx = {
-          "trace_api.responses", "tracers", {"status_code:4xx"}, true};
-      telemetry::CounterMetric responses_5xx = {
-          "trace_api.responses", "tracers", {"status_code:5xx"}, true};
+/// Sends a notification indicating that the application has started.
+///
+/// This function is responsible for reporting the application has successfully
+/// started. It takes a configuration map as a parameter, which contains various
+/// configuration settings helping to understand how our product are used.
+///
+/// @param conf A map containing configuration names and their corresponding
+/// metadata.
+///
+/// @note This function should be called after the application has completed its
+/// initialization process to ensure that all components are aware of the
+/// application's startup status.
+void send_app_started(const std::unordered_map<tracing::ConfigName,
+                                               tracing::ConfigMetadata>& conf);
 
-      telemetry::CounterMetric errors_timeout = {
-          "trace_api.errors", "tracers", {"type:timeout"}, true};
-      telemetry::CounterMetric errors_network = {
-          "trace_api.errors", "tracers", {"type:network"}, true};
-      telemetry::CounterMetric errors_status_code = {
-          "trace_api.errors", "tracers", {"type:status_code"}, true};
+/// Sends configuration changes.
+///
+/// This function is responsible for sending reported configuration changes
+/// reported by `capture_configuration_change`.
+///
+/// @note This function should be called _AFTER_ all configuration changes are
+/// captures by `capture_configuration_change`.
+void send_configuration_change();
 
-    } trace_api;
-  } metrics_;
+/// Captures a change in the application's configuration.
+///
+/// This function is called to report updates to the application's
+/// configuration. It takes a vector of new configuration metadata as a
+/// parameter, which contains the updated settings.
+///
+/// @param new_configuration A vector containing the new configuration metadata.
+///
+/// @note This function should be invoked whenever there is a change in the
+/// configuration.
+void capture_configuration_change(
+    const std::vector<tracing::ConfigMetadata>& new_configuration);
 
-  /// Configuration object containing the validated settings for telemetry
-  FinalizedConfiguration config_;
-  /// Shared pointer to the user logger instance.
-  std::shared_ptr<tracing::Logger> logger_;
-  std::shared_ptr<tracing::TracerTelemetry> tracer_telemetry_;
-  std::vector<tracing::EventScheduler::Cancel> tasks_;
-  tracing::HTTPClient::ResponseHandler telemetry_on_response_;
-  tracing::HTTPClient::ErrorHandler telemetry_on_error_;
-  tracing::HTTPClient::URL telemetry_endpoint_;
-  tracing::TracerSignature tracer_signature_;
-  std::shared_ptr<tracing::HTTPClient> http_client_;
-  tracing::Clock clock_;
+/// Provides access to the telemetry metrics for updating the values.
+/// This value should not be stored.
+DefaultMetrics& metrics();
 
- public:
-  /// Constructor for the Telemetry class
-  ///
-  /// @param configuration The finalized configuration settings.
-  /// @param logger User logger instance.
-  /// @param metrics A vector user metrics to report.
-  Telemetry(FinalizedConfiguration configuration,
-            std::shared_ptr<tracing::Logger> logger,
-            std::shared_ptr<tracing::HTTPClient> client,
-            std::vector<std::shared_ptr<Metric>> metrics,
-            tracing::EventScheduler& scheduler,
-            tracing::HTTPClient::URL agent_url,
-            tracing::Clock clock = tracing::default_clock);
+/// Report internal warning message to Datadog.
+///
+/// @param message The warning message to log.
+void report_warning_log(std::string message);
 
-  /// Destructor
-  ///
-  /// Send last metrics snapshot and `app-closing` event.
-  ~Telemetry();
+/// Report internal error message to Datadog.
+///
+/// @param message The error message.
+void report_error_log(std::string message);
 
-  // Provides access to the telemetry metrics for updating the values.
-  // This value should not be stored.
-  inline auto& metrics() { return metrics_; }
-
-  /// Capture and report internal error message to Datadog.
-  ///
-  /// @param message The error message.
-  void log_error(std::string message);
-
-  /// capture and report internal warning message to Datadog.
-  ///
-  /// @param message The warning message to log.
-  void log_warning(std::string message);
-
-  void send_app_started(
-      const std::unordered_map<tracing::ConfigName, tracing::ConfigMetadata>&
-          config_metadata);
-
-  void send_configuration_change();
-
-  void capture_configuration_change(
-      const std::vector<tracing::ConfigMetadata>& new_configuration);
-
-  void send_app_closing();
-
- private:
-  void send_telemetry(tracing::StringView request_type, std::string payload);
-
-  void send_heartbeat_and_telemetry();
-};
-
-}  // namespace telemetry
-}  // namespace datadog
+}  // namespace datadog::telemetry

--- a/include/datadog/trace_segment.h
+++ b/include/datadog/trace_segment.h
@@ -61,7 +61,6 @@ class TraceSegment {
 
   std::shared_ptr<Logger> logger_;
   std::shared_ptr<Collector> collector_;
-  std::shared_ptr<telemetry::Telemetry> telemetry_;
   std::shared_ptr<TraceSampler> trace_sampler_;
   std::shared_ptr<SpanSampler> span_sampler_;
 
@@ -84,7 +83,6 @@ class TraceSegment {
  public:
   TraceSegment(const std::shared_ptr<Logger>& logger,
                const std::shared_ptr<Collector>& collector,
-               const std::shared_ptr<telemetry::Telemetry>& telemetry,
                const std::shared_ptr<TraceSampler>& trace_sampler,
                const std::shared_ptr<SpanSampler>& span_sampler,
                const std::shared_ptr<const SpanDefaults>& defaults,

--- a/include/datadog/tracer.h
+++ b/include/datadog/tracer.h
@@ -10,8 +10,6 @@
 // obtained from a `TracerConfig` via the `finalize_config` function.  See
 // `tracer_config.h`.
 
-#include <datadog/telemetry/telemetry.h>
-
 #include <cstddef>
 #include <memory>
 
@@ -28,7 +26,6 @@
 namespace datadog {
 namespace tracing {
 
-class TracerTelemetry;
 class ConfigManager;
 class DictReader;
 struct SpanConfig;
@@ -41,7 +38,6 @@ class Tracer {
   std::shared_ptr<Logger> logger_;
   RuntimeID runtime_id_;
   TracerSignature signature_;
-  std::shared_ptr<telemetry::Telemetry> telemetry_;
   std::shared_ptr<ConfigManager> config_manager_;
   std::shared_ptr<Collector> collector_;
   std::shared_ptr<SpanSampler> span_sampler_;

--- a/src/datadog/config_manager.h
+++ b/src/datadog/config_manager.h
@@ -9,7 +9,6 @@
 #include <datadog/optional.h>
 #include <datadog/remote_config/listener.h>
 #include <datadog/span_defaults.h>
-#include <datadog/telemetry/telemetry.h>
 #include <datadog/tracer_config.h>
 
 #include <mutex>
@@ -76,16 +75,13 @@ class ConfigManager : public remote_config::Listener {
   DynamicConfig<std::shared_ptr<const SpanDefaults>> span_defaults_;
   DynamicConfig<bool> report_traces_;
 
-  std::shared_ptr<telemetry::Telemetry> telemetry_;
-
  private:
   template <typename T>
   void reset_config(ConfigName name, T& conf,
                     std::vector<ConfigMetadata>& metadata);
 
  public:
-  ConfigManager(const FinalizedTracerConfig& config,
-                const std::shared_ptr<telemetry::Telemetry>& telemetry);
+  ConfigManager(const FinalizedTracerConfig& config);
   ~ConfigManager() override{};
 
   remote_config::Products get_products() override;

--- a/src/datadog/datadog_agent.h
+++ b/src/datadog/datadog_agent.h
@@ -10,7 +10,6 @@
 #include <datadog/collector.h>
 #include <datadog/event_scheduler.h>
 #include <datadog/http_client.h>
-#include <datadog/telemetry/metrics.h>
 #include <datadog/tracer_signature.h>
 
 #include <memory>
@@ -20,9 +19,6 @@
 #include "remote_config/remote_config.h"
 
 namespace datadog {
-namespace telemetry {
-class Telemetry;
-}
 namespace tracing {
 
 class FinalizedDatadogAgentConfig;
@@ -40,7 +36,6 @@ class DatadogAgent : public Collector {
 
  private:
   std::mutex mutex_;
-  std::shared_ptr<telemetry::Telemetry> telemetry_;
   Clock clock_;
   std::shared_ptr<Logger> logger_;
   std::vector<TraceChunk> trace_chunks_;
@@ -60,7 +55,6 @@ class DatadogAgent : public Collector {
 
  public:
   DatadogAgent(const FinalizedDatadogAgentConfig&,
-               const std::shared_ptr<telemetry::Telemetry>&,
                const std::shared_ptr<Logger>&, const TracerSignature& id,
                const std::vector<std::shared_ptr<remote_config::Listener>>&
                    rc_listeners);

--- a/src/datadog/telemetry/telemetry.cpp
+++ b/src/datadog/telemetry/telemetry.cpp
@@ -18,10 +18,10 @@ Overload(Ts...) -> Overload<Ts...>;
 
 }  // namespace details
 
-/// TODO
 using NoopTelemetry = std::monostate;
 
-/// TODO
+/// `TelemetryProxy` holds either the real implementation or a no-op
+/// implementation.
 using TelemetryProxy = std::variant<NoopTelemetry, Telemetry>;
 
 // NOTE(@dmehala): until metrics handling is improved.
@@ -75,7 +75,7 @@ void send_configuration_change() {
   std::visit(
       details::Overload{
           [&](Telemetry& telemetry) { telemetry.send_configuration_change(); },
-          [](auto&&) {},
+          [](NoopTelemetry) {},
       },
       instance());
 }
@@ -86,7 +86,7 @@ void capture_configuration_change(
                  [&](Telemetry& telemetry) {
                    telemetry.capture_configuration_change(new_configuration);
                  },
-                 [](auto&&) {},
+                 [](NoopTelemetry) {},
              },
              instance());
 }
@@ -103,7 +103,7 @@ DefaultMetrics& metrics() {
 void report_warning_log(std::string message) {
   std::visit(details::Overload{
                  [&](Telemetry& telemetry) { telemetry.log_warning(message); },
-                 [](auto&&) {},
+                 [](NoopTelemetry) {},
              },
              instance());
 }
@@ -111,7 +111,7 @@ void report_warning_log(std::string message) {
 void report_error_log(std::string message) {
   std::visit(details::Overload{
                  [&](Telemetry& telemetry) { telemetry.log_error(message); },
-                 [](auto&&) {},
+                 [](NoopTelemetry) {},
              },
              instance());
 }

--- a/src/datadog/telemetry/telemetry.cpp
+++ b/src/datadog/telemetry/telemetry.cpp
@@ -1,176 +1,119 @@
-#include <datadog/clock.h>
-#include <datadog/datadog_agent_config.h>
-#include <datadog/dict_writer.h>
-#include <datadog/runtime_id.h>
-#include <datadog/string_view.h>
+#include <datadog/optional.h>
 #include <datadog/telemetry/telemetry.h>
 
-#include <chrono>
+#include "telemetry_impl.h"
 
-#include "datadog_agent.h"
-#include "platform_util.h"
-#include "tracer_telemetry.h"
+namespace datadog::telemetry {
+namespace details {
 
-using namespace datadog::tracing;
-using namespace std::chrono_literals;
+/// NOTE(@dmehala): Generic overload function (P0051R3) like implementation.
+template <typename... Ts>
+struct Overload : Ts... {
+  using Ts::operator()...;
+};
 
-namespace datadog {
-namespace telemetry {
-namespace {
+/// NOTE(@dmehala): Guide required for C++17. Remove once we switch to C++20.
+template <class... Ts>
+Overload(Ts...) -> Overload<Ts...>;
 
-HTTPClient::URL make_telemetry_endpoint(HTTPClient::URL url) {
-  append(url.path, "/telemetry/proxy/api/v2/apmtelemetry");
-  return url;
+}  // namespace details
+
+/// TODO
+using NoopTelemetry = std::monostate;
+
+/// TODO
+using TelemetryProxy = std::variant<NoopTelemetry, Telemetry>;
+
+// NOTE(@dmehala): until metrics handling is improved.
+static DefaultMetrics noop_metrics;
+
+/// NOTE(@dmehala): Here to facilitate Meyer's singleton construction.
+struct Ctor_param final {
+  FinalizedConfiguration configuration;
+  std::shared_ptr<tracing::Logger> logger;
+  std::shared_ptr<tracing::HTTPClient> client;
+  std::vector<std::shared_ptr<Metric>> metrics;
+  std::shared_ptr<tracing::EventScheduler> scheduler;
+  tracing::HTTPClient::URL agent_url;
+  tracing::Clock clock = tracing::default_clock;
+};
+
+TelemetryProxy make_telemetry(const Ctor_param& init) {
+  if (!init.configuration.enabled) return NoopTelemetry{};
+  return Telemetry{init.configuration, init.logger,    init.client,
+                   init.metrics,       init.scheduler, init.agent_url,
+                   init.clock};
 }
 
-}  // namespace
-Telemetry::Telemetry(FinalizedConfiguration config,
-                     std::shared_ptr<tracing::Logger> logger,
-                     std::shared_ptr<tracing::HTTPClient> client,
-                     std::vector<std::shared_ptr<Metric>> metrics,
-                     tracing::EventScheduler& event_scheduler,
-                     HTTPClient::URL agent_url, Clock clock)
-    : config_(std::move(config)),
-      logger_(std::move(logger)),
-      telemetry_endpoint_(make_telemetry_endpoint(agent_url)),
-      tracer_signature_(tracing::RuntimeID::generate(),
-                        tracing::get_process_name(), ""),
-      http_client_(client),
-      clock_(std::move(clock)) {
-  tracer_telemetry_ = std::make_shared<tracing::TracerTelemetry>(
-      config_.enabled, clock_, logger_, tracer_signature_,
-      config_.integration_name, config_.integration_version,
-      std::vector<std::reference_wrapper<Metric>>{
-          {metrics_.tracer.spans_created},
-          {metrics_.tracer.spans_finished},
-          {metrics_.tracer.trace_segments_created_new},
-          {metrics_.tracer.trace_segments_created_continued},
-          {metrics_.tracer.trace_segments_closed},
-          {metrics_.trace_api.requests},
-          {metrics_.trace_api.responses_1xx},
-          {metrics_.trace_api.responses_2xx},
-          {metrics_.trace_api.responses_3xx},
-          {metrics_.trace_api.responses_4xx},
-          {metrics_.trace_api.responses_5xx},
-          {metrics_.trace_api.errors_timeout},
-          {metrics_.trace_api.errors_network},
-          {metrics_.trace_api.errors_status_code},
+TelemetryProxy& instance(
+    const tracing::Optional<Ctor_param>& init = tracing::nullopt) {
+  static TelemetryProxy telemetry(make_telemetry(*init));
+  return telemetry;
+}
+
+void init(FinalizedConfiguration configuration,
+          std::shared_ptr<tracing::Logger> logger,
+          std::shared_ptr<tracing::HTTPClient> client,
+          std::vector<std::shared_ptr<Metric>> metrics,
+          std::shared_ptr<tracing::EventScheduler> event_scheduler,
+          tracing::HTTPClient::URL agent_url, tracing::Clock clock) {
+  instance(Ctor_param{configuration, logger, client, metrics, event_scheduler,
+                      agent_url, clock});
+}
+
+void send_app_started(const std::unordered_map<tracing::ConfigName,
+                                               tracing::ConfigMetadata>& conf) {
+  std::visit(
+      details::Overload{
+          [&](Telemetry& telemetry) { telemetry.send_app_started(conf); },
+          [](NoopTelemetry) {},
       },
-      metrics);
-
-  if (!config_.enabled) {
-    return;
-  }
-
-  // Callback for successful telemetry HTTP requests, to examine HTTP
-  // status.
-  telemetry_on_response_ = [logger = logger_](
-                               int response_status,
-                               const DictReader& /*response_headers*/,
-                               std::string response_body) {
-    if (response_status < 200 || response_status >= 300) {
-      logger->log_error([&](auto& stream) {
-        stream << "Unexpected telemetry response status " << response_status
-               << " with body (if any, starts on next line):\n"
-               << response_body;
-      });
-    }
-  };
-
-  // Callback for unsuccessful telemetry HTTP requests.
-  telemetry_on_error_ = [logger = logger_](Error error) {
-    logger->log_error(error.with_prefix(
-        "Error occurred during HTTP request for telemetry: "));
-  };
-
-  // Only schedule this if telemetry is enabled.
-  // Every 10 seconds, have the tracer telemetry capture the metrics
-  // values. Every 60 seconds, also report those values to the datadog
-  // agent.
-  tasks_.emplace_back(event_scheduler.schedule_recurring_event(
-      std::chrono::seconds(10), [this, n = 0]() mutable {
-        n++;
-        tracer_telemetry_->capture_metrics();
-        if (n % 6 == 0) {
-          send_heartbeat_and_telemetry();
-        }
-      }));
+      instance());
 }
 
-Telemetry::~Telemetry() {
-  if (!config_.enabled) return;
-  tracer_telemetry_->capture_metrics();
-  // The app-closing message is bundled with a message containing the
-  // final metric values.
-  send_app_closing();
-  http_client_->drain(clock_().tick + 1s);
+void send_configuration_change() {
+  std::visit(
+      details::Overload{
+          [&](Telemetry& telemetry) { telemetry.send_configuration_change(); },
+          [](auto&&) {},
+      },
+      instance());
 }
 
-void Telemetry::log_error(std::string message) {
-  tracer_telemetry_->log(std::move(message), LogLevel::ERROR);
-}
-
-void Telemetry::log_warning(std::string message) {
-  tracer_telemetry_->log(std::move(message), LogLevel::WARNING);
-}
-
-void Telemetry::send_telemetry(StringView request_type, std::string payload) {
-  if (!config_.enabled) return;
-  auto set_telemetry_headers = [request_type, payload_size = payload.size(),
-                                debug_enabled = tracer_telemetry_->debug(),
-                                tracer_signature =
-                                    &tracer_signature_](DictWriter& headers) {
-    /*
-      TODO:
-        Datadog-Container-ID
-    */
-    headers.set("Content-Type", "application/json");
-    headers.set("Content-Length", std::to_string(payload_size));
-    headers.set("DD-Telemetry-API-Version", "v2");
-    headers.set("DD-Client-Library-Language", "cpp");
-    headers.set("DD-Client-Library-Version", tracer_signature->library_version);
-    headers.set("DD-Telemetry-Request-Type", request_type);
-
-    if (debug_enabled) {
-      headers.set("DD-Telemetry-Debug-Enabled", "true");
-    }
-  };
-
-  // TODO(@dmehala): make `clock::instance()` a singleton
-  auto post_result = http_client_->post(
-      telemetry_endpoint_, set_telemetry_headers, std::move(payload),
-      telemetry_on_response_, telemetry_on_error_,
-      tracing::default_clock().tick + 5s);
-  if (auto* error = post_result.if_error()) {
-    logger_->log_error(
-        error->with_prefix("Unexpected error submitting telemetry event: "));
-  }
-}
-
-void Telemetry::send_app_started(
-    const std::unordered_map<ConfigName, ConfigMetadata>& config_metadata) {
-  send_telemetry("app-started",
-                 tracer_telemetry_->app_started(config_metadata));
-}
-
-void Telemetry::send_app_closing() {
-  send_telemetry("app-closing", tracer_telemetry_->app_closing());
-}
-
-void Telemetry::send_heartbeat_and_telemetry() {
-  send_telemetry("app-heartbeat", tracer_telemetry_->heartbeat_and_telemetry());
-}
-
-void Telemetry::send_configuration_change() {
-  if (auto payload = tracer_telemetry_->configuration_change()) {
-    send_telemetry("app-client-configuration-change", *payload);
-  }
-}
-
-void Telemetry::capture_configuration_change(
+void capture_configuration_change(
     const std::vector<tracing::ConfigMetadata>& new_configuration) {
-  return tracer_telemetry_->capture_configuration_change(new_configuration);
+  std::visit(details::Overload{
+                 [&](Telemetry& telemetry) {
+                   telemetry.capture_configuration_change(new_configuration);
+                 },
+                 [](auto&&) {},
+             },
+             instance());
 }
 
-}  // namespace telemetry
-}  // namespace datadog
+DefaultMetrics& metrics() {
+  auto& proxy = instance();
+  if (std::holds_alternative<NoopTelemetry>(proxy)) {
+    return noop_metrics;
+  } else {
+    return std::get<Telemetry>(proxy).metrics();
+  }
+}
+
+void report_warning_log(std::string message) {
+  std::visit(details::Overload{
+                 [&](Telemetry& telemetry) { telemetry.log_warning(message); },
+                 [](auto&&) {},
+             },
+             instance());
+}
+
+void report_error_log(std::string message) {
+  std::visit(details::Overload{
+                 [&](Telemetry& telemetry) { telemetry.log_error(message); },
+                 [](auto&&) {},
+             },
+             instance());
+}
+
+}  // namespace datadog::telemetry

--- a/src/datadog/telemetry/telemetry_impl.cpp
+++ b/src/datadog/telemetry/telemetry_impl.cpp
@@ -1,0 +1,266 @@
+#include "telemetry_impl.h"
+
+#include <datadog/clock.h>
+#include <datadog/datadog_agent_config.h>
+#include <datadog/dict_writer.h>
+#include <datadog/runtime_id.h>
+#include <datadog/string_view.h>
+#include <datadog/telemetry/telemetry.h>
+#include <datadog/tracer_signature.h>
+
+#include <chrono>
+
+#include "datadog_agent.h"
+#include "platform_util.h"
+#include "tracer_telemetry.h"
+
+using namespace datadog::tracing;
+using namespace std::chrono_literals;
+
+namespace datadog::telemetry {
+namespace {
+
+HTTPClient::URL make_telemetry_endpoint(HTTPClient::URL url) {
+  append(url.path, "/telemetry/proxy/api/v2/apmtelemetry");
+  return url;
+}
+
+void cancel_tasks(std::vector<tracing::EventScheduler::Cancel>& tasks) {
+  for (auto& cancel_task : tasks) {
+    cancel_task();
+  }
+  tasks.clear();
+}
+
+}  // namespace
+
+Telemetry::Telemetry(FinalizedConfiguration config,
+                     std::shared_ptr<tracing::Logger> logger,
+                     std::shared_ptr<tracing::HTTPClient> client,
+                     std::vector<std::shared_ptr<Metric>> metrics,
+                     std::shared_ptr<tracing::EventScheduler> event_scheduler,
+                     HTTPClient::URL agent_url, Clock clock)
+    : config_(std::move(config)),
+      logger_(std::move(logger)),
+      telemetry_endpoint_(make_telemetry_endpoint(agent_url)),
+      tracer_signature_(tracing::RuntimeID::generate(),
+                        tracing::get_process_name(), ""),
+      http_client_(client),
+      clock_(std::move(clock)),
+      scheduler_(event_scheduler) {
+  tracer_telemetry_ = std::make_shared<tracing::TracerTelemetry>(
+      config_.enabled, clock_, logger_, tracer_signature_,
+      config_.integration_name, config_.integration_version,
+      std::vector<std::reference_wrapper<Metric>>{
+          {metrics_.tracer.spans_created},
+          {metrics_.tracer.spans_finished},
+          {metrics_.tracer.trace_segments_created_new},
+          {metrics_.tracer.trace_segments_created_continued},
+          {metrics_.tracer.trace_segments_closed},
+          {metrics_.trace_api.requests},
+          {metrics_.trace_api.responses_1xx},
+          {metrics_.trace_api.responses_2xx},
+          {metrics_.trace_api.responses_3xx},
+          {metrics_.trace_api.responses_4xx},
+          {metrics_.trace_api.responses_5xx},
+          {metrics_.trace_api.errors_timeout},
+          {metrics_.trace_api.errors_network},
+          {metrics_.trace_api.errors_status_code},
+      },
+      metrics);
+
+  // Callback for successful telemetry HTTP requests, to examine HTTP
+  // status.
+  telemetry_on_response_ = [logger = logger_](
+                               int response_status,
+                               const DictReader& /*response_headers*/,
+                               std::string response_body) {
+    if (response_status < 200 || response_status >= 300) {
+      logger->log_error([&](auto& stream) {
+        stream << "Unexpected telemetry response status " << response_status
+               << " with body (if any, starts on next line):\n"
+               << response_body;
+      });
+    }
+  };
+
+  // Callback for unsuccessful telemetry HTTP requests.
+  telemetry_on_error_ = [logger = logger_](Error error) {
+    logger->log_error(error.with_prefix(
+        "Error occurred during HTTP request for telemetry: "));
+  };
+
+  schedule_tasks();
+}
+
+void Telemetry::schedule_tasks() {
+  // Only schedule this if telemetry is enabled.
+  // Every 10 seconds, have the tracer telemetry capture the metrics
+  // values. Every 60 seconds, also report those values to the datadog
+  // agent.
+  tasks_.emplace_back(scheduler_->schedule_recurring_event(
+      std::chrono::seconds(10), [this, n = 0]() mutable {
+        n++;
+        tracer_telemetry_->capture_metrics();
+        if (n % 6 == 0) {
+          send_heartbeat_and_telemetry();
+        }
+      }));
+}
+
+Telemetry::~Telemetry() {
+  if (!tasks_.empty()) {
+    cancel_tasks(tasks_);
+    tracer_telemetry_->capture_metrics();
+    // The app-closing message is bundled with a message containing the
+    // final metric values.
+    send_app_closing();
+    http_client_->drain(clock_().tick + 1s);
+  }
+}
+
+Telemetry::Telemetry(Telemetry&& rhs)
+    : metrics_(std::move(rhs.metrics_)),
+      config_(std::move(rhs.config_)),
+      logger_(std::move(rhs.logger_)),
+      // tracer_telemetry_(std::move(rhs.tracer_telemetry_)),
+      telemetry_on_response_(std::move(rhs.telemetry_on_response_)),
+      telemetry_on_error_(std::move(rhs.telemetry_on_error_)),
+      telemetry_endpoint_(std::move(rhs.telemetry_endpoint_)),
+      tracer_signature_(std::move(rhs.tracer_signature_)),
+      http_client_(rhs.http_client_),
+      clock_(std::move(rhs.clock_)),
+      scheduler_(std::move(rhs.scheduler_)) {
+  cancel_tasks(rhs.tasks_);
+
+  tracer_telemetry_ = std::make_shared<tracing::TracerTelemetry>(
+      config_.enabled, clock_, logger_, tracer_signature_,
+      config_.integration_name, config_.integration_version,
+      std::vector<std::reference_wrapper<Metric>>{
+          {metrics_.tracer.spans_created},
+          {metrics_.tracer.spans_finished},
+          {metrics_.tracer.trace_segments_created_new},
+          {metrics_.tracer.trace_segments_created_continued},
+          {metrics_.tracer.trace_segments_closed},
+          {metrics_.trace_api.requests},
+          {metrics_.trace_api.responses_1xx},
+          {metrics_.trace_api.responses_2xx},
+          {metrics_.trace_api.responses_3xx},
+          {metrics_.trace_api.responses_4xx},
+          {metrics_.trace_api.responses_5xx},
+          {metrics_.trace_api.errors_timeout},
+          {metrics_.trace_api.errors_network},
+          {metrics_.trace_api.errors_status_code},
+      },
+      std::vector<std::shared_ptr<Metric>>{});
+  schedule_tasks();
+}
+
+Telemetry& Telemetry::operator=(Telemetry&& rhs) {
+  if (&rhs != this) {
+    std::swap(metrics_, rhs.metrics_);
+    std::swap(config_, rhs.config_);
+    std::swap(logger_, rhs.logger_);
+    std::swap(tracer_telemetry_, rhs.tracer_telemetry_);
+    std::swap(telemetry_on_response_, rhs.telemetry_on_response_);
+    std::swap(telemetry_on_error_, rhs.telemetry_on_error_);
+    std::swap(telemetry_endpoint_, rhs.telemetry_endpoint_);
+    std::swap(http_client_, rhs.http_client_);
+    std::swap(tracer_signature_, rhs.tracer_signature_);
+    std::swap(http_client_, rhs.http_client_);
+    std::swap(clock_, rhs.clock_);
+
+    cancel_tasks(rhs.tasks_);
+
+    tracer_telemetry_ = std::make_shared<tracing::TracerTelemetry>(
+        config_.enabled, clock_, logger_, tracer_signature_,
+        config_.integration_name, config_.integration_version,
+        std::vector<std::reference_wrapper<Metric>>{
+            {metrics_.tracer.spans_created},
+            {metrics_.tracer.spans_finished},
+            {metrics_.tracer.trace_segments_created_new},
+            {metrics_.tracer.trace_segments_created_continued},
+            {metrics_.tracer.trace_segments_closed},
+            {metrics_.trace_api.requests},
+            {metrics_.trace_api.responses_1xx},
+            {metrics_.trace_api.responses_2xx},
+            {metrics_.trace_api.responses_3xx},
+            {metrics_.trace_api.responses_4xx},
+            {metrics_.trace_api.responses_5xx},
+            {metrics_.trace_api.errors_timeout},
+            {metrics_.trace_api.errors_network},
+            {metrics_.trace_api.errors_status_code},
+        },
+        std::vector<std::shared_ptr<Metric>>{});
+    schedule_tasks();
+  }
+  return *this;
+}
+
+void Telemetry::log_error(std::string message) {
+  tracer_telemetry_->log(std::move(message), LogLevel::ERROR);
+}
+
+void Telemetry::log_warning(std::string message) {
+  tracer_telemetry_->log(std::move(message), LogLevel::WARNING);
+}
+
+void Telemetry::send_telemetry(StringView request_type, std::string payload) {
+  auto set_telemetry_headers = [request_type, payload_size = payload.size(),
+                                debug_enabled = tracer_telemetry_->debug(),
+                                tracer_signature =
+                                    &tracer_signature_](DictWriter& headers) {
+    /*
+      TODO:
+        Datadog-Container-ID
+    */
+    headers.set("Content-Type", "application/json");
+    headers.set("Content-Length", std::to_string(payload_size));
+    headers.set("DD-Telemetry-API-Version", "v2");
+    headers.set("DD-Client-Library-Language", "cpp");
+    headers.set("DD-Client-Library-Version", tracer_signature->library_version);
+    headers.set("DD-Telemetry-Request-Type", request_type);
+
+    if (debug_enabled) {
+      headers.set("DD-Telemetry-Debug-Enabled", "true");
+    }
+  };
+
+  // TODO(@dmehala): make `clock::instance()` a singleton
+  auto post_result = http_client_->post(
+      telemetry_endpoint_, set_telemetry_headers, std::move(payload),
+      telemetry_on_response_, telemetry_on_error_,
+      tracing::default_clock().tick + 5s);
+  if (auto* error = post_result.if_error()) {
+    logger_->log_error(
+        error->with_prefix("Unexpected error submitting telemetry event: "));
+  }
+}
+
+void Telemetry::send_app_started(
+    const std::unordered_map<tracing::ConfigName, tracing::ConfigMetadata>&
+        config_metadata) {
+  send_telemetry("app-started",
+                 tracer_telemetry_->app_started(config_metadata));
+}
+
+void Telemetry::send_app_closing() {
+  send_telemetry("app-closing", tracer_telemetry_->app_closing());
+}
+
+void Telemetry::send_heartbeat_and_telemetry() {
+  send_telemetry("app-heartbeat", tracer_telemetry_->heartbeat_and_telemetry());
+}
+
+void Telemetry::send_configuration_change() {
+  if (auto payload = tracer_telemetry_->configuration_change()) {
+    send_telemetry("app-client-configuration-change", *payload);
+  }
+}
+
+void Telemetry::capture_configuration_change(
+    const std::vector<tracing::ConfigMetadata>& new_configuration) {
+  return tracer_telemetry_->capture_configuration_change(new_configuration);
+}
+
+}  // namespace datadog::telemetry

--- a/src/datadog/telemetry/telemetry_impl.h
+++ b/src/datadog/telemetry/telemetry_impl.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <datadog/event_scheduler.h>
+#include <datadog/http_client.h>
+#include <datadog/logger.h>
+#include <datadog/telemetry/configuration.h>
+
+#include "tracer_telemetry.h"
+
+namespace datadog::telemetry {
+
+/// The telemetry class is responsible for handling internal telemetry data to
+/// track Datadog product usage. It _can_ collect and report logs and metrics.
+class Telemetry final {
+  DefaultMetrics metrics_;
+  /// Configuration object containing the validated settings for telemetry
+  FinalizedConfiguration config_;
+  /// Shared pointer to the user logger instance.
+  std::shared_ptr<tracing::Logger> logger_;
+  std::shared_ptr<tracing::TracerTelemetry> tracer_telemetry_;
+  std::vector<tracing::EventScheduler::Cancel> tasks_;
+  tracing::HTTPClient::ResponseHandler telemetry_on_response_;
+  tracing::HTTPClient::ErrorHandler telemetry_on_error_;
+  tracing::HTTPClient::URL telemetry_endpoint_;
+  tracing::TracerSignature tracer_signature_;
+  std::shared_ptr<tracing::HTTPClient> http_client_;
+  tracing::Clock clock_;
+  std::shared_ptr<tracing::EventScheduler> scheduler_;
+
+ public:
+  /// Constructor for the Telemetry class
+  ///
+  /// @param configuration The finalized configuration settings.
+  /// @param logger User logger instance.
+  /// @param metrics A vector user metrics to report.
+  Telemetry(FinalizedConfiguration configuration,
+            std::shared_ptr<tracing::Logger> logger,
+            std::shared_ptr<tracing::HTTPClient> client,
+            std::vector<std::shared_ptr<Metric>> metrics,
+            std::shared_ptr<tracing::EventScheduler> event_scheduler,
+            tracing::HTTPClient::URL agent_url,
+            tracing::Clock clock = tracing::default_clock);
+
+  /// Destructor
+  ///
+  /// Send last metrics snapshot and `app-closing` event.
+  ~Telemetry();
+
+  /// Move semantics.
+  Telemetry(Telemetry&& rhs);
+  Telemetry& operator=(Telemetry&&);
+
+  // Provides access to the telemetry metrics for updating the values.
+  // This value should not be stored.
+  inline auto& metrics() { return metrics_; }
+
+  /// Capture and report internal error message to Datadog.
+  ///
+  /// @param message The error message.
+  void log_error(std::string message);
+
+  /// capture and report internal warning message to Datadog.
+  ///
+  /// @param message The warning message to log.
+  void log_warning(std::string message);
+
+  void send_app_started(
+      const std::unordered_map<tracing::ConfigName, tracing::ConfigMetadata>&
+          config_metadata);
+
+  void send_configuration_change();
+
+  void capture_configuration_change(
+      const std::vector<tracing::ConfigMetadata>& new_configuration);
+
+  void send_app_closing();
+
+ private:
+  void send_telemetry(tracing::StringView request_type, std::string payload);
+
+  void send_heartbeat_and_telemetry();
+  void schedule_tasks();
+};
+
+}  // namespace datadog::telemetry

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -27,7 +27,6 @@
 #include "tag_propagation.h"
 #include "tags.h"
 #include "trace_sampler.h"
-#include "tracer_telemetry.h"
 #include "w3c_propagation.h"
 
 namespace datadog {
@@ -86,7 +85,6 @@ void inject_trace_tags(
 TraceSegment::TraceSegment(
     const std::shared_ptr<Logger>& logger,
     const std::shared_ptr<Collector>& collector,
-    const std::shared_ptr<telemetry::Telemetry>& tracer_telemetry,
     const std::shared_ptr<TraceSampler>& trace_sampler,
     const std::shared_ptr<SpanSampler>& span_sampler,
     const std::shared_ptr<const SpanDefaults>& defaults,
@@ -102,7 +100,6 @@ TraceSegment::TraceSegment(
     std::unique_ptr<SpanData> local_root)
     : logger_(logger),
       collector_(collector),
-      telemetry_(tracer_telemetry),
       trace_sampler_(trace_sampler),
       span_sampler_(span_sampler),
       defaults_(defaults),
@@ -120,7 +117,6 @@ TraceSegment::TraceSegment(
       config_manager_(config_manager) {
   assert(logger_);
   assert(collector_);
-  assert(telemetry_);
   assert(trace_sampler_);
   assert(span_sampler_);
   assert(defaults_);
@@ -146,7 +142,7 @@ Optional<SamplingDecision> TraceSegment::sampling_decision() const {
 Logger& TraceSegment::logger() const { return *logger_; }
 
 void TraceSegment::register_span(std::unique_ptr<SpanData> span) {
-  telemetry_->metrics().tracer.spans_created.inc();
+  telemetry::metrics().tracer.spans_created.inc();
 
   std::lock_guard<std::mutex> lock(mutex_);
   assert(spans_.empty() || num_finished_spans_ < spans_.size());
@@ -155,7 +151,7 @@ void TraceSegment::register_span(std::unique_ptr<SpanData> span) {
 
 void TraceSegment::span_finished() {
   {
-    telemetry_->metrics().tracer.spans_finished.inc();
+    // telemetry_->metrics().tracer.spans_finished.inc();
     std::lock_guard<std::mutex> lock(mutex_);
     ++num_finished_spans_;
     assert(num_finished_spans_ <= spans_.size());
@@ -246,7 +242,7 @@ void TraceSegment::span_finished() {
     }
   }
 
-  telemetry_->metrics().tracer.trace_segments_closed.inc();
+  // telemetry_->metrics().tracer.trace_segments_closed.inc();
 }
 
 void TraceSegment::override_sampling_priority(SamplingPriority priority) {

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -151,7 +151,7 @@ void TraceSegment::register_span(std::unique_ptr<SpanData> span) {
 
 void TraceSegment::span_finished() {
   {
-    // telemetry_->metrics().tracer.spans_finished.inc();
+    telemetry::metrics().tracer.spans_finished.inc();
     std::lock_guard<std::mutex> lock(mutex_);
     ++num_finished_spans_;
     assert(num_finished_spans_ <= spans_.size());
@@ -242,7 +242,7 @@ void TraceSegment::span_finished() {
     }
   }
 
-  // telemetry_->metrics().tracer.trace_segments_closed.inc();
+  telemetry::metrics().tracer.trace_segments_closed.inc();
 }
 
 void TraceSegment::override_sampling_priority(SamplingPriority priority) {

--- a/test/telemetry/test_telemetry.cpp
+++ b/test/telemetry/test_telemetry.cpp
@@ -4,7 +4,6 @@
 
 #include <datadog/clock.h>
 #include <datadog/span_defaults.h>
-// #include <datadog/telemetry/telemetry.h>
 #include <datadog/json.hpp>
 #include <unordered_set>
 

--- a/test/telemetry/test_telemetry.cpp
+++ b/test/telemetry/test_telemetry.cpp
@@ -4,12 +4,12 @@
 
 #include <datadog/clock.h>
 #include <datadog/span_defaults.h>
-#include <datadog/telemetry/telemetry.h>
-
+// #include <datadog/telemetry/telemetry.h>
 #include <datadog/json.hpp>
 #include <unordered_set>
 
 #include "datadog/runtime_id.h"
+#include "datadog/telemetry/telemetry_impl.h"
 #include "mocks/event_schedulers.h"
 #include "mocks/http_clients.h"
 #include "mocks/loggers.h"
@@ -69,7 +69,7 @@ TEST_CASE("Tracer telemetry", "[telemetry]") {
                       logger,
                       client,
                       std::vector<std::shared_ptr<Metric>>{},
-                      *scheduler,
+                      scheduler,
                       *url,
                       clock};
 
@@ -98,7 +98,7 @@ TEST_CASE("Tracer telemetry", "[telemetry]") {
                            logger,
                            client,
                            std::vector<std::shared_ptr<Metric>>{},
-                           *scheduler,
+                           scheduler,
                            *url};
 
       client->clear();

--- a/test/telemetry/test_telemetry.cpp
+++ b/test/telemetry/test_telemetry.cpp
@@ -4,6 +4,7 @@
 
 #include <datadog/clock.h>
 #include <datadog/span_defaults.h>
+
 #include <datadog/json.hpp>
 #include <unordered_set>
 

--- a/test/test_config_manager.cpp
+++ b/test/test_config_manager.cpp
@@ -1,7 +1,6 @@
 #include "catch.hpp"
 #include "datadog/config_manager.h"
 #include "datadog/remote_config/listener.h"
-#include "datadog/telemetry/telemetry.h"
 #include "datadog/trace_sampler.h"
 #include "mocks/http_clients.h"
 
@@ -21,11 +20,6 @@ nlohmann::json load_json(std::string_view sv) {
 }
 
 CONFIG_MANAGER_TEST("remote configuration handling") {
-  const TracerSignature tracer_signature{
-      /* runtime_id = */ RuntimeID::generate(),
-      /* service = */ "testsvc",
-      /* environment = */ "test"};
-
   TracerConfig config;
   config.service = "testsvc";
   config.environment = "test";
@@ -33,12 +27,9 @@ CONFIG_MANAGER_TEST("remote configuration handling") {
   auto final_cfg = *finalize_config(config);
 
   auto http_client = std::make_shared<MockHTTPClient>();
-  auto tracer_telemetry = std::make_shared<telemetry::Telemetry>(
-      *telemetry::finalize_config(), final_cfg.logger, http_client,
-      std::vector<std::shared_ptr<telemetry::Metric>>{},
-      *final_cfg.event_scheduler, final_cfg.agent_url);
 
-  ConfigManager config_manager(final_cfg, tracer_telemetry);
+  // TODO: set mock telemetry
+  ConfigManager config_manager(final_cfg);
 
   rc::Listener::Configuration config_update{/* id = */ "id",
                                             /* path = */ "",

--- a/test/test_datadog_agent.cpp
+++ b/test/test_datadog_agent.cpp
@@ -2,6 +2,7 @@
 #include <datadog/config_manager.h>
 #include <datadog/datadog_agent.h>
 #include <datadog/datadog_agent_config.h>
+#include <datadog/telemetry/telemetry.h>
 #include <datadog/tracer.h>
 #include <datadog/tracer_config.h>
 
@@ -198,16 +199,12 @@ TEST_CASE("Remote Configuration", "[datadog_agent]") {
 
   const TracerSignature signature(RuntimeID::generate(), "testsvc", "test");
 
-  auto telemetry = std::make_shared<telemetry::Telemetry>(
-      *telemetry::finalize_config(), finalized->logger, http_client,
-      std::vector<std::shared_ptr<telemetry::Metric>>{},
-      *finalized->event_scheduler, finalized->agent_url);
-
-  auto config_manager = std::make_shared<ConfigManager>(*finalized, telemetry);
+  // TODO: set telemetry mock
+  auto config_manager = std::make_shared<ConfigManager>(*finalized);
 
   const auto& agent_config =
       std::get<FinalizedDatadogAgentConfig>(finalized->collector);
-  DatadogAgent agent(agent_config, telemetry, config.logger, signature, {});
+  DatadogAgent agent(agent_config, config.logger, signature, {});
 
   SECTION("404 do not log an error") {
     http_client->response_status = 404;


### PR DESCRIPTION
## Description
This is Part 3 of the telemetry module refactoring. This PR introduces a singleton for the telemetry module, allowing external usage outside of the tracer API while ensuring all components access the same instance. Additionally, this change simplifies internal telemetry usage.  

For reference:  
- **Part 1:** #166
- **Part 2:** #194