### PR TITLE
Kristjan/container

### DIFF
--- a/include/datadog/config.h
+++ b/include/datadog/config.h
@@ -27,6 +27,9 @@ enum class ConfigName : char {
   SPAN_SAMPLING_RULES,
   TRACE_BAGGAGE_MAX_BYTES,
   TRACE_BAGGAGE_MAX_ITEMS,
+  ENTITY_ID,
+  EXTERNAL_ENV,
+  CONTAINER_ID,
 };
 
 // Represents metadata for configuration parameters

--- a/include/datadog/datadog_agent_config.h
+++ b/include/datadog/datadog_agent_config.h
@@ -66,6 +66,18 @@ struct DatadogAgentConfig {
   // How often, in seconds, to query the Datadog Agent for remote configuration
   // updates.
   Optional<double> remote_configuration_poll_interval_seconds;
+  // External environment, used to populate headers. Overriden by the
+  // DD_EXTERNAL_ENV variable, usually supplied by the Datadog Admission
+  // Controller.
+  Optional<std::string> external_env;
+  // Container ID, used to populate trace headers. Overriden by the
+  // `DD_CONTAINER_ID` environment variable.  This is used to populate a
+  // header to help the datadog agent identify the container, from an
+  // external origin discovery script.
+  // Typcially "ci-<container_id>" where container_id is the GUID container
+  // id of the container, or "in-<inode>" where inode is the inode of the
+  // containers's cgroup.
+  Optional<std::string> container_id;
 
   static Expected<HTTPClient::URL> parse(StringView);
 };
@@ -89,6 +101,7 @@ class FinalizedDatadogAgentConfig {
   std::chrono::steady_clock::duration shutdown_timeout;
   std::chrono::steady_clock::duration remote_configuration_poll_interval;
   std::unordered_map<ConfigName, ConfigMetadata> metadata;
+  std::unordered_map<std::string, std::string> extra_headers;
 };
 
 Expected<FinalizedDatadogAgentConfig> finalize_config(

--- a/include/datadog/environment.h
+++ b/include/datadog/environment.h
@@ -25,7 +25,10 @@ namespace environment {
 // preprocessor is used so that the DD_* symbols are listed exactly once.
 #define LIST_ENVIRONMENT_VARIABLES(MACRO)            \
   MACRO(DD_AGENT_HOST)                               \
+  MACRO(DD_CONTAINER_ID)                             \
   MACRO(DD_ENV)                                      \
+  MACRO(DD_ENTITY_ID)                                \
+  MACRO(DD_EXTERNAL_ENV)                             \
   MACRO(DD_INSTRUMENTATION_TELEMETRY_ENABLED)        \
   MACRO(DD_PROPAGATION_STYLE_EXTRACT)                \
   MACRO(DD_PROPAGATION_STYLE_INJECT)                 \

--- a/include/datadog/tracer_config.h
+++ b/include/datadog/tracer_config.h
@@ -161,6 +161,10 @@ struct TracerConfig {
   /// The maximum amount of bytes allowed to be written during tracing context
   /// injection.
   Optional<std::size_t> baggage_max_bytes;
+  // Entity ID to add as internal tag. Overridden by the `DD_ENTITY_ID`,
+  // usually supplied by Datadog's Admission Controller to help identify traces
+  // coming from kubernetes pods.
+  Optional<std::string> entity_id;
 };
 
 // `FinalizedTracerConfig` contains `Tracer` implementation details derived from

--- a/src/datadog/datadog_agent.cpp
+++ b/src/datadog/datadog_agent.cpp
@@ -214,6 +214,8 @@ DatadogAgent::DatadogAgent(
         config.remote_configuration_poll_interval,
         [this] { get_and_apply_remote_configuration_updates(); }));
   }
+
+  extra_headers = config.extra_headers;
 }
 
 DatadogAgent::~DatadogAgent() {
@@ -298,6 +300,9 @@ void DatadogAgent::flush() {
     headers.set("Datadog-Meta-Tracer-Version",
                 tracer_signature_.library_version);
     headers.set("X-Datadog-Trace-Count", std::to_string(trace_chunks.size()));
+    for (const auto& [key, value] : extra_headers) {
+      headers.set(key, value);
+    }
   };
 
   // This is the callback for the HTTP response.  It's invoked

--- a/src/datadog/datadog_agent.h
+++ b/src/datadog/datadog_agent.h
@@ -55,6 +55,7 @@ class DatadogAgent : public Collector {
   HTTPClient::ErrorHandler telemetry_on_error_;
   std::chrono::steady_clock::duration request_timeout_;
   std::chrono::steady_clock::duration shutdown_timeout_;
+  std::unordered_map<std::string, std::string> extra_headers;
 
   remote_config::Manager remote_config_;
   TracerSignature tracer_signature_;

--- a/src/datadog/tags.cpp
+++ b/src/datadog/tags.cpp
@@ -10,6 +10,7 @@ const std::string span_type = "span.type";
 const std::string operation_name = "operation";
 const std::string resource_name = "resource.name";
 const std::string version = "version";
+const std::string entity_id = "dd.internal.entity_id";
 
 namespace internal {
 

--- a/src/datadog/tags.h
+++ b/src/datadog/tags.h
@@ -19,6 +19,7 @@ extern const std::string span_type;
 extern const std::string operation_name;
 extern const std::string resource_name;
 extern const std::string version;
+extern const std::string entity_id;
 
 namespace internal {
 extern const std::string propagation_error;

--- a/test/test_tracer_config.cpp
+++ b/test/test_tracer_config.cpp
@@ -4,6 +4,7 @@
 #include <datadog/threaded_event_scheduler.h>
 #include <datadog/tracer.h>
 #include <datadog/tracer_config.h>
+#include <datadog/tags.h>
 
 #include <chrono>
 #include <cmath>
@@ -208,6 +209,14 @@ TRACER_CONFIG_TEST("TracerConfig::defaults") {
       REQUIRE(finalized);
       REQUIRE(finalized->defaults.tags == test_case.expected_tags);
     }
+  }
+  
+  SECTION("DD_ENTITY_ID") {
+    const EnvGuard guard{"DD_ENTITY_ID", "entity1"};
+    config.entity_id = "entity2";
+    auto finalized = finalize_config(config);
+    REQUIRE(finalized);
+    REQUIRE(finalized->defaults.tags[tags::entity_id] == "entity1");
   }
 }
 


### PR DESCRIPTION
# Description

Add support for the DD_EXTERNAL_ENV, DD_ENTITY_ID and DD_CONTAINER_ID configurables

# Motivation

Other implementations, such as dd-trace-python, already support these, which help with running tracing from containerized
environments.  The Datadog Admission Controller sets DD_EXTERNAL_ENV and DD_ENTITY_ID, and the DD_CONTAINER_ID can be provided by the user if he has previously discovered the ID using an external script.

# Additional Notes

See issue $193

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
