### PR TITLE
chore(ci): pin cmake version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
     - run:
         name: Install dependencies
         command: |
-          choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=System'
+          choco install -y cmake --version=3.31.6 --installargs 'ADD_CMAKE_TO_PATH=System'
           choco install -y ninja
     - run: 
         name: Building

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,10 +29,11 @@ jobs:
       with:
         languages: ${{ matrix.language }}
 
+    - name: Install dependencies
+      run: bin/install-cmake
+
     - name: Build dd-trace-cpp
-      run: |
-        bin/install-cmake
-        bin/cmake-build
+      run: bin/cmake-build --preset=ci-codeql
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,6 +12,13 @@
         "DD_TRACE_STATIC_CRT": "1",
         "DD_TRACE_BUILD_TESTING": "1"
       }
+    },
+    {
+      "name": "ci-codeql",
+      "displayName": "CI CodeQL",
+      "cacheVariables": {
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Description
The CI started fails recently because chocolatey and ubuntu-latest install the latest version of CMake (4.0.0), which remove compatibility with CMake < 3.5. Until we update the CMake version (and because it's good pratice), pin the version of CMake to 3.31.6 which is still compatible with 3.5 and older.

Changes:
- Add a new cmake preset for codeql.