### PR TITLE
[part 5] refactor!(telemetry): use configured intervals

### DIFF
--- a/src/datadog/telemetry/telemetry_impl.cpp
+++ b/src/datadog/telemetry/telemetry_impl.cpp
@@ -194,8 +194,6 @@ Telemetry& Telemetry::operator=(Telemetry&& rhs) {
   return *this;
 }
 
-// TODO(@dmehala): Move `report_logs` check in the serialization once
-// `TracerTelemetry` will be removed.
 void Telemetry::log_error(std::string message) {
   if (!config_.report_logs) return;
   tracer_telemetry_->log(std::move(message), LogLevel::ERROR);

--- a/src/datadog/telemetry/telemetry_impl.cpp
+++ b/src/datadog/telemetry/telemetry_impl.cpp
@@ -94,18 +94,15 @@ Telemetry::Telemetry(FinalizedConfiguration config,
 }
 
 void Telemetry::schedule_tasks() {
-  // Only schedule this if telemetry is enabled.
-  // Every 10 seconds, have the tracer telemetry capture the metrics
-  // values. Every 60 seconds, also report those values to the datadog
-  // agent.
   tasks_.emplace_back(scheduler_->schedule_recurring_event(
-      std::chrono::seconds(10), [this, n = 0]() mutable {
-        n++;
-        tracer_telemetry_->capture_metrics();
-        if (n % 6 == 0) {
-          send_heartbeat_and_telemetry();
-        }
-      }));
+      config_.heartbeat_interval,
+      [this]() { send_heartbeat_and_telemetry(); }));
+
+  if (config_.report_metrics) {
+    tasks_.emplace_back(scheduler_->schedule_recurring_event(
+        config_.metrics_interval,
+        [this]() mutable { tracer_telemetry_->capture_metrics(); }));
+  }
 }
 
 Telemetry::~Telemetry() {
@@ -197,15 +194,20 @@ Telemetry& Telemetry::operator=(Telemetry&& rhs) {
   return *this;
 }
 
+// TODO(@dmehala): Move `report_logs` check in the serialization once
+// `TracerTelemetry` will be removed.
 void Telemetry::log_error(std::string message) {
+  if (!config_.report_logs) return;
   tracer_telemetry_->log(std::move(message), LogLevel::ERROR);
 }
 
 void Telemetry::log_error(std::string message, std::string stacktrace) {
+  if (!config_.report_logs) return;
   tracer_telemetry_->log(std::move(message), LogLevel::ERROR, stacktrace);
 }
 
 void Telemetry::log_warning(std::string message) {
+  if (!config_.report_logs) return;
   tracer_telemetry_->log(std::move(message), LogLevel::WARNING);
 }
 

--- a/test/telemetry/test_telemetry.cpp
+++ b/test/telemetry/test_telemetry.cpp
@@ -31,7 +31,7 @@ bool is_valid_telemetry_payload(const nlohmann::json& json) {
          json.contains("/host"_json_pointer);
 }
 
-struct FakeEventScehduler : public EventScheduler {
+struct FakeEventScheduler : public EventScheduler {
   size_t count_tasks = 0;
   std::function<void()> heartbeat_callback = nullptr;
   std::function<void()> metrics_callback = nullptr;
@@ -80,7 +80,7 @@ TEST_CASE("Tracer telemetry", "[telemetry]") {
 
   auto logger = std::make_shared<MockLogger>();
   auto client = std::make_shared<MockHTTPClient>();
-  auto scheduler = std::make_shared<FakeEventScehduler>();
+  auto scheduler = std::make_shared<FakeEventScheduler>();
 
   const TracerSignature tracer_signature{
       /* runtime_id = */ RuntimeID::generate(),

--- a/test/telemetry/test_telemetry.cpp
+++ b/test/telemetry/test_telemetry.cpp
@@ -379,7 +379,7 @@ TEST_CASE("Tracer telemetry configuration", "[telemetry]") {
 
   auto logger = std::make_shared<MockLogger>();
   auto client = std::make_shared<MockHTTPClient>();
-  auto scheduler = std::make_shared<FakeEventScehduler>();
+  auto scheduler = std::make_shared<FakeEventScheduler>();
   std::vector<std::shared_ptr<Metric>> metrics;
 
   const TracerSignature tracer_signature{


### PR DESCRIPTION
## Description
Previously, telemetry metrics were collected every 10 seconds and heartbeats were sent every 60 seconds, matching the default configuration. However, these intervals can be customized via environment variables or code.

This commit updates the telemetry logic to use the configured intervals—whether set through environment variables or directly in the code—ensuring that metrics , heartbeat and logs messages are sent accordingly.
