### PR TITLE
fix(telemetry): report logs only once

### DIFF
--- a/include/datadog/telemetry/telemetry.h
+++ b/include/datadog/telemetry/telemetry.h
@@ -57,21 +57,24 @@ void send_configuration_change();
 void capture_configuration_change(
     const std::vector<tracing::ConfigMetadata>& new_configuration);
 
+/// The `log` namespace provides functions for reporting logs.
+namespace log {
 /// Report internal warning message to Datadog.
 ///
 /// @param message The warning message to log.
-void report_warning_log(std::string message);
+void warning(std::string message);
 
 /// Report internal error message to Datadog.
 ///
 /// @param message The error message.
-void report_error_log(std::string message);
+void error(std::string message);
 
 /// Report internal error message to Datadog.
 ///
 /// @param message The error message.
 /// @param stacktrace Stacktrace leading to the error.
-void report_error_log(std::string message, std::string stacktrace);
+void error(std::string message, std::string stacktrace);
+}  // namespace log
 
 /// The `counter` namespace provides functions to track values.
 /// Counters can be useful for tracking the total number of an event occurring

--- a/src/datadog/telemetry/telemetry.cpp
+++ b/src/datadog/telemetry/telemetry.cpp
@@ -75,7 +75,8 @@ void capture_configuration_change(
              instance());
 }
 
-void report_warning_log(std::string message) {
+namespace log {
+void warning(std::string message) {
   std::visit(details::Overload{
                  [&](Telemetry& telemetry) { telemetry.log_warning(message); },
                  [](NoopTelemetry) {},
@@ -83,7 +84,7 @@ void report_warning_log(std::string message) {
              instance());
 }
 
-void report_error_log(std::string message) {
+void error(std::string message) {
   std::visit(details::Overload{
                  [&](Telemetry& telemetry) { telemetry.log_error(message); },
                  [](NoopTelemetry) {},
@@ -91,7 +92,7 @@ void report_error_log(std::string message) {
              instance());
 }
 
-void report_error_log(std::string message, std::string stacktrace) {
+void error(std::string message, std::string stacktrace) {
   std::visit(details::Overload{
                  [&](Telemetry& telemetry) {
                    telemetry.log_error(message, stacktrace);
@@ -100,6 +101,7 @@ void report_error_log(std::string message, std::string stacktrace) {
              },
              instance());
 }
+}  // namespace log
 
 namespace counter {
 void increment(const Counter& counter) {

--- a/src/datadog/telemetry/telemetry_impl.h
+++ b/src/datadog/telemetry/telemetry_impl.h
@@ -61,6 +61,7 @@ class Telemetry final {
   /// Configuration
   std::vector<tracing::ConfigMetadata> configuration_snapshot_;
 
+  std::mutex log_mutex_;
   std::vector<telemetry::LogMessage> logs_;
 
   // Track sequence id per payload generated


### PR DESCRIPTION
# Description

Changes:
  - Update telemetry API for logs to be consistent with metrics.
  - Add test to validate logs are send in `app-closing`.