### PR TITLE
fix(telemetry): concurrency issue on endpoint unreachable

### DIFF
--- a/src/datadog/telemetry/telemetry_impl.h
+++ b/src/datadog/telemetry/telemetry_impl.h
@@ -9,6 +9,7 @@
 #include <datadog/telemetry/metrics.h>
 #include <datadog/tracer_signature.h>
 
+#include <atomic>
 #include <mutex>
 
 #include "json.hpp"
@@ -39,6 +40,7 @@ class Telemetry final {
   std::shared_ptr<tracing::HTTPClient> http_client_;
   tracing::Clock clock_;
   std::shared_ptr<tracing::EventScheduler> scheduler_;
+  std::atomic<bool> shutting_down_{false};
 
   /// Counter
   std::mutex counter_mutex_;


### PR DESCRIPTION
# Description

Apparent when upgrading dd-trace-cpp for rum injection IIS e2e tests. This situation pops up when the request to telemetry takes longer than the drain time in the constructor.

The issue is sort of hiding in this part of the code
```cpp
TelemetryProxy make_telemetry(const Ctor_param& init) {
  if (!init.configuration.enabled) return NoopTelemetry{};
  return Telemetry{init.configuration, init.logger,    init.client,
                   init.scheduler,     init.agent_url, init.clock};
}

TelemetryProxy& instance(
    const tracing::Optional<Ctor_param>& init = tracing::nullopt) {
  static TelemetryProxy telemetry(make_telemetry(*init));
  return telemetry;
}

void init(FinalizedConfiguration configuration,
          std::shared_ptr<tracing::Logger> logger,
          std::shared_ptr<tracing::HTTPClient> client,
          std::shared_ptr<tracing::EventScheduler> event_scheduler,
          tracing::HTTPClient::URL agent_url, tracing::Clock clock) {
  instance(Ctor_param{configuration, logger, client, event_scheduler, agent_url,
                      clock});
}
```

A first Telemetry instance is created in `make_telemetry`. When constructing `TelemetryProxy` that instance is not passed as a reference, but instead the `Telemetry(Telemetry&&)` constructor is invoked, which moves members from the first instance to the second. The initial Telemetry instance which attempted to send the `app-started` event, calls back on error a bit over 2 seconds after (In my Windows machine, it takes ~2200ms to error), accessing a variable (`counters_` in this case) that was moved from and now in an invalid state.

If the request takes shorter than the drain time, it is not an issue because when `drain()` exits all callbacks are already complete, and no more callbacks will be done to the original Telemetry object.

This is not a great solution, because the update to `counters_` will be ignored, but created the PR for illustration purposes. A better solution might be to not do `send_telemetry("app-started", app_started());` in the constructor and instead do it in the init function, which will avoid receiving callbacks in a moved-from instance.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
