### PR TITLE
Implement DD_APM_TRACING_ENABLED=false

### DIFF
--- a/include/datadog/collector.h
+++ b/include/datadog/collector.h
@@ -19,7 +19,7 @@ namespace datadog {
 namespace tracing {
 
 struct SpanData;
-class TraceSampler;
+class ErasedTraceSampler;
 
 class Collector {
  public:
@@ -29,7 +29,7 @@ class Collector {
   // occurs.
   virtual Expected<void> send(
       std::vector<std::unique_ptr<SpanData>>&& spans,
-      const std::shared_ptr<TraceSampler>& response_handler) = 0;
+      const std::shared_ptr<ErasedTraceSampler>& response_handler) = 0;
 
   // Return a JSON representation of this object's configuration. The JSON
   // representation is an object with the following properties:

--- a/include/datadog/config.h
+++ b/include/datadog/config.h
@@ -27,6 +27,7 @@ enum class ConfigName : char {
   SPAN_SAMPLING_RULES,
   TRACE_BAGGAGE_MAX_BYTES,
   TRACE_BAGGAGE_MAX_ITEMS,
+  APM_TRACING_ENABLED,
 };
 
 // Represents metadata for configuration parameters

--- a/include/datadog/datadog_agent_config.h
+++ b/include/datadog/datadog_agent_config.h
@@ -66,6 +66,9 @@ struct DatadogAgentConfig {
   // How often, in seconds, to query the Datadog Agent for remote configuration
   // updates.
   Optional<double> remote_configuration_poll_interval_seconds;
+  // Whether APM tracing is enabled. This affects whether the
+  // "Datadog-Client-Computed-Stats: yes" header is sent with trace requests.
+  Optional<bool> apm_tracing_enabled;
 };
 
 class FinalizedDatadogAgentConfig {
@@ -87,6 +90,7 @@ class FinalizedDatadogAgentConfig {
   std::chrono::steady_clock::duration shutdown_timeout;
   std::chrono::steady_clock::duration remote_configuration_poll_interval;
   std::unordered_map<ConfigName, ConfigMetadata> metadata;
+  bool apm_tracing_enabled;
 
   // Origin detection
   Optional<std::string> admission_controller_uid;

--- a/include/datadog/environment.h
+++ b/include/datadog/environment.h
@@ -60,6 +60,7 @@ namespace environment {
   MACRO(DD_INSTRUMENTATION_INSTALL_ID)               \
   MACRO(DD_INSTRUMENTATION_INSTALL_TYPE)             \
   MACRO(DD_INSTRUMENTATION_INSTALL_TIME)             \
+  MACRO(DD_APM_TRACING_ENABLED)                      \
   MACRO(DD_EXTERNAL_ENV)
 
 #define WITH_COMMA(ARG) ARG,

--- a/include/datadog/injection_options.h
+++ b/include/datadog/injection_options.h
@@ -4,11 +4,18 @@
 // parameters to `Span::inject` that alter the behavior of trace context
 // propagation.
 
+#include <array>
+
+#include "optional.h"
+
 namespace datadog {
 namespace tracing {
 
 struct InjectionOptions {
-  bool has_appsec_matches{};
+  // If DD_APM_TRACING_ENABLED=false and what we're injecting is not an APM
+  // trace, then the code for the trace source (e.g. 02 for Appsec) can be
+  // set here.
+  Optional<std::array<char, 2>> trace_source{};
 };
 
 }  // namespace tracing

--- a/include/datadog/injection_options.h
+++ b/include/datadog/injection_options.h
@@ -7,7 +7,9 @@
 namespace datadog {
 namespace tracing {
 
-struct InjectionOptions {};
+struct InjectionOptions {
+  bool has_appsec_matches{};
+};
 
 }  // namespace tracing
 }  // namespace datadog

--- a/include/datadog/null_collector.h
+++ b/include/datadog/null_collector.h
@@ -11,7 +11,7 @@ namespace tracing {
 class NullCollector : public Collector {
  public:
   Expected<void> send(std::vector<std::unique_ptr<SpanData>>&&,
-                      const std::shared_ptr<TraceSampler>&) override {
+                      const std::shared_ptr<ErasedTraceSampler>&) override {
     return {};
   }
 

--- a/include/datadog/sampling_mechanism.h
+++ b/include/datadog/sampling_mechanism.h
@@ -49,7 +49,7 @@ enum class SamplingMechanism {
   // The sampling decision was made explicitly by the user, who set a sampling
   // priority.
   MANUAL = 4,
-  // Reserved for future use.
+  // Trace was kept because of AppSec event.
   APP_SEC = 5,
   // Reserved for future use.
   REMOTE_RATE_USER_DEFINED = 6,

--- a/include/datadog/trace_segment.h
+++ b/include/datadog/trace_segment.h
@@ -53,7 +53,7 @@ class Logger;
 struct SpanData;
 struct SpanDefaults;
 class SpanSampler;
-class TraceSampler;
+class ErasedTraceSampler;
 class ConfigManager;
 
 class TraceSegment {
@@ -61,7 +61,8 @@ class TraceSegment {
 
   std::shared_ptr<Logger> logger_;
   std::shared_ptr<Collector> collector_;
-  std::shared_ptr<TraceSampler> trace_sampler_;
+  std::shared_ptr<ErasedTraceSampler> trace_sampler_;
+  bool apm_tracing_enabled_;
   std::shared_ptr<SpanSampler> span_sampler_;
 
   std::shared_ptr<const SpanDefaults> defaults_;
@@ -83,7 +84,8 @@ class TraceSegment {
  public:
   TraceSegment(const std::shared_ptr<Logger>& logger,
                const std::shared_ptr<Collector>& collector,
-               const std::shared_ptr<TraceSampler>& trace_sampler,
+               std::shared_ptr<ErasedTraceSampler> trace_sampler,
+               bool apm_tracing_enabled,
                const std::shared_ptr<SpanSampler>& span_sampler,
                const std::shared_ptr<const SpanDefaults>& defaults,
                const std::shared_ptr<ConfigManager>& config_manager,

--- a/include/datadog/tracer.h
+++ b/include/datadog/tracer.h
@@ -29,7 +29,7 @@ namespace tracing {
 class ConfigManager;
 class DictReader;
 struct SpanConfig;
-class TraceSampler;
+class ErasedTraceSampler;
 class SpanSampler;
 class IDGenerator;
 class InMemoryFile;
@@ -39,6 +39,8 @@ class Tracer {
   RuntimeID runtime_id_;
   TracerSignature signature_;
   std::shared_ptr<ConfigManager> config_manager_;
+  std::shared_ptr<ErasedTraceSampler>
+      apm_tracing_disabled_sampler_;  // empty if enabled
   std::shared_ptr<Collector> collector_;
   std::shared_ptr<SpanSampler> span_sampler_;
   std::shared_ptr<const IDGenerator> generator_;
@@ -103,6 +105,10 @@ class Tracer {
   // Return a JSON object describing this Tracer's configuration. It is the
   // same JSON object that was logged when this Tracer was created.
   std::string config() const;
+
+  bool is_apm_tracing_enabled() const {
+    return apm_tracing_disabled_sampler_ == nullptr;
+  }
 
  private:
   void store_config();

--- a/include/datadog/tracer_config.h
+++ b/include/datadog/tracer_config.h
@@ -28,6 +28,7 @@ class Collector;
 class Logger;
 class SpanSampler;
 class TraceSampler;
+class ErasedTraceSampler;
 
 struct TracerConfig {
   // Set the service name.
@@ -79,6 +80,16 @@ struct TracerConfig {
   // `telemetry` configures the telemetry module. See
   // `telemetry/configuration.h` By default, the telemetry module is enabled.
   telemetry::Configuration telemetry;
+
+  // `apm_tracing_enabled` indicates whether APM traces and APM trace metrics
+  // are enabled. If `false`, APM-specific traces are dropped and APM trace
+  // metrics are not computed. This allows other products (e.g., AppSec) to
+  // operate independently.
+  // This is distinct from `report_traces`, which controls whether any traces
+  // are sent at all.
+  // `apm_tracing_enabled` is overridden by the `DD_APM_TRACING_ENABLED`
+  // environment variable. Defaults to `true`.
+  Optional<bool> apm_tracing_enabled;
 
   // `trace_sampler` configures trace sampling.  Trace sampling determines which
   // traces are sent to Datadog.  See `trace_sampler_config.h`.
@@ -197,6 +208,7 @@ class FinalizedTracerConfig final {
   std::shared_ptr<Logger> logger;
   bool log_on_startup;
   bool generate_128bit_trace_ids;
+  bool apm_tracing_enabled;
   Optional<RuntimeID> runtime_id;
   Clock clock;
   std::string integration_name;

--- a/src/datadog/config_manager.cpp
+++ b/src/datadog/config_manager.cpp
@@ -130,6 +130,8 @@ ConfigManager::ConfigManager(const FinalizedTracerConfig& config)
       default_metadata_(config.metadata),
       trace_sampler_(
           std::make_shared<TraceSampler>(config.trace_sampler, clock_)),
+      erased_trace_sampler_(
+          std::make_shared<ErasedTraceSampler>(trace_sampler_)),
       rules_(config.trace_sampler.rules),
       span_defaults_(std::make_shared<SpanDefaults>(config.defaults)),
       report_traces_(config.report_traces) {}
@@ -163,9 +165,9 @@ void ConfigManager::on_revert(const Configuration&) {
   telemetry::capture_configuration_change(config_metadata);
 }
 
-std::shared_ptr<TraceSampler> ConfigManager::trace_sampler() {
+std::shared_ptr<ErasedTraceSampler> ConfigManager::trace_sampler() {
   std::lock_guard<std::mutex> lock(mutex_);
-  return trace_sampler_;
+  return erased_trace_sampler_;
 }
 
 std::shared_ptr<const SpanDefaults> ConfigManager::span_defaults() {

--- a/src/datadog/config_manager.h
+++ b/src/datadog/config_manager.h
@@ -70,6 +70,9 @@ class ConfigManager : public remote_config::Listener {
   std::unordered_map<ConfigName, ConfigMetadata> default_metadata_;
 
   std::shared_ptr<TraceSampler> trace_sampler_;
+  // wraps trace_sampler_ and should be changed if trace_sampler_ is changed
+  // Could be created every time, but that would be a waste
+  std::shared_ptr<ErasedTraceSampler> erased_trace_sampler_;
   std::vector<TraceSamplerRule> rules_;
 
   DynamicConfig<std::shared_ptr<const SpanDefaults>> span_defaults_;
@@ -93,7 +96,7 @@ class ConfigManager : public remote_config::Listener {
   void on_post_process() override{};
 
   // Return the `TraceSampler` consistent with the most recent configuration.
-  std::shared_ptr<TraceSampler> trace_sampler();
+  std::shared_ptr<ErasedTraceSampler> trace_sampler();
 
   // Return the `SpanDefaults` consistent with the most recent configuration.
   std::shared_ptr<const SpanDefaults> span_defaults();

--- a/src/datadog/datadog_agent.cpp
+++ b/src/datadog/datadog_agent.cpp
@@ -157,7 +157,8 @@ DatadogAgent::DatadogAgent(
       flush_interval_(config.flush_interval),
       request_timeout_(config.request_timeout),
       shutdown_timeout_(config.shutdown_timeout),
-      remote_config_(tracer_signature, rc_listeners, logger) {
+      remote_config_(tracer_signature, rc_listeners, logger),
+      apm_tracing_enabled_(config.apm_tracing_enabled) {
   assert(logger_);
 
   // Set HTTP headers
@@ -211,7 +212,7 @@ DatadogAgent::~DatadogAgent() {
 
 Expected<void> DatadogAgent::send(
     std::vector<std::unique_ptr<SpanData>>&& spans,
-    const std::shared_ptr<TraceSampler>& response_handler) {
+    const std::shared_ptr<ErasedTraceSampler>& response_handler) {
   std::lock_guard<std::mutex> lock(mutex_);
   trace_chunks_.push_back(TraceChunk{std::move(spans), response_handler});
   return nullopt;
@@ -272,7 +273,7 @@ void DatadogAgent::flush() {
   // One HTTP request to the Agent could possibly involve trace chunks from
   // multiple tracers, and thus multiple trace samplers might need to have
   // their rates updated. Unlikely, but possible.
-  std::unordered_set<std::shared_ptr<TraceSampler>> response_handlers;
+  std::unordered_set<std::shared_ptr<ErasedTraceSampler>> response_handlers;
   for (auto& chunk : trace_chunks) {
     response_handlers.insert(std::move(chunk.response_handler));
   }
@@ -283,6 +284,9 @@ void DatadogAgent::flush() {
     writer.set("X-Datadog-Trace-Count", std::to_string(trace_chunks.size()));
     for (const auto& [key, value] : headers_) {
       writer.set(key, value);
+    }
+    if (!apm_tracing_enabled_) {
+      writer.set("Datadog-Client-Computed-Stats", "yes");
     }
   };
 

--- a/src/datadog/datadog_agent.h
+++ b/src/datadog/datadog_agent.h
@@ -21,17 +21,17 @@
 namespace datadog {
 namespace tracing {
 
+class ErasedTraceSampler;
 class FinalizedDatadogAgentConfig;
 class Logger;
 struct SpanData;
-class TraceSampler;
 struct TracerSignature;
 
 class DatadogAgent : public Collector {
  public:
   struct TraceChunk {
     std::vector<std::unique_ptr<SpanData>> spans;
-    std::shared_ptr<TraceSampler> response_handler;
+    std::shared_ptr<ErasedTraceSampler> response_handler;
   };
 
  private:
@@ -51,6 +51,7 @@ class DatadogAgent : public Collector {
   remote_config::Manager remote_config_;
 
   std::unordered_map<std::string, std::string> headers_;
+  bool apm_tracing_enabled_;
 
   void flush();
 
@@ -63,7 +64,7 @@ class DatadogAgent : public Collector {
 
   Expected<void> send(
       std::vector<std::unique_ptr<SpanData>>&& spans,
-      const std::shared_ptr<TraceSampler>& response_handler) override;
+      const std::shared_ptr<ErasedTraceSampler>& response_handler) override;
 
   void get_and_apply_remote_configuration_updates();
 

--- a/src/datadog/datadog_agent_config.cpp
+++ b/src/datadog/datadog_agent_config.cpp
@@ -31,6 +31,10 @@ Expected<DatadogAgentConfig> load_datadog_agent_env_config() {
     env_config.remote_configuration_poll_interval_seconds = *res;
   }
 
+  if (auto apm_enabled_env = lookup(environment::DD_APM_TRACING_ENABLED)) {
+    env_config.apm_tracing_enabled = !falsy(*apm_enabled_env);
+  }
+
   auto env_host = lookup(environment::DD_AGENT_HOST);
   auto env_port = lookup(environment::DD_TRACE_AGENT_PORT);
 
@@ -134,6 +138,9 @@ Expected<FinalizedDatadogAgentConfig> finalize_config(
   result.remote_configuration_enabled =
       value_or(env_config->remote_configuration_enabled,
                user_config.remote_configuration_enabled, true);
+
+  result.apm_tracing_enabled = value_or(env_config->apm_tracing_enabled,
+                                        user_config.apm_tracing_enabled, true);
 
   const auto [origin, url] =
       pick(env_config->url, user_config.url, "http://localhost:8126");

--- a/src/datadog/extraction_util.cpp
+++ b/src/datadog/extraction_util.cpp
@@ -34,7 +34,7 @@ void handle_trace_tags(StringView trace_tags, ExtractedData& result,
   }
 
   for (auto& [key, value] : *maybe_trace_tags) {
-    if (!starts_with(key, "_dd.p.")) {
+    if (!starts_with(key, "_dd.p.") && key != "_dd.p.ts") {
       continue;
     }
 

--- a/src/datadog/tags.cpp
+++ b/src/datadog/tags.cpp
@@ -31,6 +31,8 @@ const std::string language = "language";
 const std::string runtime_id = "runtime-id";
 const std::string sampling_decider = "_dd.is_sampling_decider";
 const std::string w3c_parent_id = "_dd.parent_id";
+const std::string trace_source = "_dd.p.ts";
+const std::string apm_enabled = "_dd.apm.enabled";
 
 }  // namespace internal
 

--- a/src/datadog/tags.h
+++ b/src/datadog/tags.h
@@ -39,6 +39,8 @@ extern const std::string language;
 extern const std::string runtime_id;
 extern const std::string sampling_decider;
 extern const std::string w3c_parent_id;
+extern const std::string trace_source;  // _dd.p.ts
+extern const std::string apm_enabled;   // _dd.apm.enabled
 }  // namespace internal
 
 // Return whether the specified `tag_name` is reserved for use internal to this

--- a/src/datadog/telemetry/telemetry_impl.cpp
+++ b/src/datadog/telemetry/telemetry_impl.cpp
@@ -107,6 +107,8 @@ std::string to_string(datadog::tracing::ConfigName name) {
       return "trace_baggage_max_bytes";
     case ConfigName::TRACE_BAGGAGE_MAX_ITEMS:
       return "trace_baggage_max_items";
+    case ConfigName::APM_TRACING_ENABLED:
+      return "apm_tracing_enabled";
   }
 
   std::abort();

--- a/src/datadog/trace_sampler.cpp
+++ b/src/datadog/trace_sampler.cpp
@@ -12,6 +12,7 @@
 #include "json_serializer.h"
 #include "sampling_util.h"
 #include "span_data.h"
+#include "tags.h"
 
 namespace datadog {
 namespace tracing {
@@ -122,6 +123,96 @@ nlohmann::json TraceSampler::config_json() const {
       {"rules", rules},
       {"max_per_second", limiter_max_per_second_},
   });
+}
+
+SamplingDecision ApmDisabledTraceSampler::decide(const SpanData& span_data) {
+  SamplingDecision decision;
+  decision.origin = SamplingDecision::Origin::LOCAL;
+
+  if (span_data.tags.find(tags::internal::trace_source) !=
+      span_data.tags.end()) {
+    decision.mechanism = static_cast<int>(SamplingMechanism::APP_SEC);
+    decision.priority = static_cast<int>(SamplingPriority::USER_KEEP);
+  } else {
+    auto now = clock_();
+    auto last_kept = last_kept_.load(std::memory_order_relaxed);
+    auto num_asked = num_asked_.fetch_add(1, std::memory_order_relaxed) + 1;
+    uint64_t num_allowed;
+    if (now.wall - last_kept >= INTERVAL) {
+      if (last_kept_.compare_exchange_strong(last_kept, now.wall)) {
+        decision.priority = static_cast<int>(SamplingPriority::USER_KEEP);
+        num_allowed = num_allowed_.fetch_add(1, std::memory_order_relaxed) + 1;
+      } else {
+        // another thread got to it first
+        decision.priority = static_cast<int>(SamplingPriority::USER_DROP);
+        num_allowed = num_allowed_.load(std::memory_order_relaxed);
+      }
+    } else {
+      decision.priority = static_cast<int>(SamplingPriority::USER_DROP);
+      num_allowed = num_allowed_.load(std::memory_order_relaxed);
+    }
+
+    decision.limiter_max_per_second = ALLOWED_PER_SECOND;
+    double effective_rate = static_cast<double>(num_allowed) / num_asked;
+    if (effective_rate > 1.0) {
+      // can happen due to the relaxed atomic operations
+      effective_rate = 1.0;
+    }
+    decision.limiter_effective_rate = Rate::from(effective_rate).value();
+  }
+
+  return decision;
+}
+
+void ApmDisabledTraceSampler::handle_collector_response(
+    const CollectorResponse&) {
+  // do nothing
+}
+
+nlohmann::json ApmDisabledTraceSampler::config_json() const {
+  return nlohmann::json::object({
+      {"max_per_second", ALLOWED_PER_SECOND},
+  });
+}
+
+template <typename Ptr>
+struct ErasedTraceSampler::Model : Concept {
+  Model(Ptr&& samplerImpl) : impl_(std::move(samplerImpl)) {}
+
+  SamplingDecision decide(const SpanData& span_data) override {
+    return impl_->decide(span_data);
+  }
+
+  void handle_collector_response(const CollectorResponse& response) override {
+    impl_->handle_collector_response(response);
+  }
+
+  nlohmann::json config_json() const override { return impl_->config_json(); }
+
+ private:
+  Ptr impl_;
+};
+
+template <typename Ptr>
+ErasedTraceSampler::ErasedTraceSampler(Ptr samplerImpl) {
+  impl_ = std::make_unique<Model<Ptr>>(std::move(samplerImpl));
+}
+
+template ErasedTraceSampler::ErasedTraceSampler(std::shared_ptr<TraceSampler>);
+template ErasedTraceSampler::ErasedTraceSampler(
+    std::unique_ptr<ApmDisabledTraceSampler>);
+
+SamplingDecision ErasedTraceSampler::decide(const SpanData& span_data) {
+  return impl_->decide(span_data);
+}
+
+void ErasedTraceSampler::handle_collector_response(
+    const CollectorResponse& response) {
+  impl_->handle_collector_response(response);
+}
+
+nlohmann::json ErasedTraceSampler::config_json() const {
+  return impl_->config_json();
 }
 
 }  // namespace tracing

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -350,8 +350,11 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
     return false;
   }
 
-  if (inj_opts.has_appsec_matches) {
-    trace_tags_.emplace_back(tags::internal::trace_source, "02");
+  if (inj_opts.trace_source) {
+    std::string trace_source = std::string(inj_opts.trace_source->begin(),
+                                           inj_opts.trace_source->end());
+    trace_tags_.emplace_back(tags::internal::trace_source,
+                             std::move(trace_source));
   }
 
   // The sampling priority can change (it can be overridden on another thread),

--- a/test/mocks/collectors.h
+++ b/test/mocks/collectors.h
@@ -22,7 +22,7 @@ struct MockCollector : public Collector {
   std::vector<std::vector<std::unique_ptr<SpanData>>> chunks;
 
   Expected<void> send(std::vector<std::unique_ptr<SpanData>>&& spans,
-                      const std::shared_ptr<TraceSampler>&) override {
+                      const std::shared_ptr<ErasedTraceSampler>&) override {
     chunks.emplace_back(std::move(spans));
     return {};
   }
@@ -51,7 +51,7 @@ struct MockCollectorWithResponse : public MockCollector {
 
   Expected<void> send(
       std::vector<std::unique_ptr<SpanData>>&& spans,
-      const std::shared_ptr<TraceSampler>& response_handler) override {
+      const std::shared_ptr<ErasedTraceSampler>& response_handler) override {
     MockCollector::send(std::move(spans), response_handler);
     response_handler->handle_collector_response(response);
     return {};
@@ -64,7 +64,7 @@ struct PriorityCountingCollector : public Collector {
   std::map<double, std::size_t> sampling_priority_count;
 
   Expected<void> send(std::vector<std::unique_ptr<SpanData>>&& spans,
-                      const std::shared_ptr<TraceSampler>&) override {
+                      const std::shared_ptr<ErasedTraceSampler>&) override {
     const SpanData& root = root_span(spans);
     const auto priority =
         root.numeric_tags.at(tags::internal::sampling_priority);
@@ -127,7 +127,7 @@ struct PriorityCountingCollectorWithResponse
 
   Expected<void> send(
       std::vector<std::unique_ptr<SpanData>>&& spans,
-      const std::shared_ptr<TraceSampler>& response_handler) override {
+      const std::shared_ptr<ErasedTraceSampler>& response_handler) override {
     PriorityCountingCollector::send(std::move(spans), response_handler);
     REQUIRE(response_handler);
     response_handler->handle_collector_response(response);
@@ -141,7 +141,7 @@ struct FailureCollector : public Collector {
   Error failure{Error::OTHER, "send(...) failed because I told it to."};
 
   Expected<void> send(std::vector<std::unique_ptr<SpanData>>&&,
-                      const std::shared_ptr<TraceSampler>&) override {
+                      const std::shared_ptr<ErasedTraceSampler>&) override {
     return failure;
   }
 

--- a/test/test_tracer_config.cpp
+++ b/test/test_tracer_config.cpp
@@ -272,6 +272,25 @@ TRACER_CONFIG_TEST("TracerConfig::log_on_startup") {
   }
 }
 
+TRACER_CONFIG_TEST("DD_APM_TRACING_ENABLED") {
+  TracerConfig config;
+  config.service = "testsvc";  // Required for finalize_config
+
+  SECTION("default is true") {
+    const EnvGuard guard{"DD_APM_TRACING_ENABLED", ""};
+    auto finalized = finalize_config(config);
+    REQUIRE(finalized);
+    REQUIRE(finalized->apm_tracing_enabled);
+  }
+
+  SECTION("can be set to false") {
+    const EnvGuard guard{"DD_APM_TRACING_ENABLED", "false"};
+    auto finalized = finalize_config(config);
+    REQUIRE(finalized);
+    REQUIRE(!finalized->apm_tracing_enabled);
+  }
+}
+
 TRACER_CONFIG_TEST("TracerConfig::report_traces") {
   TracerConfig config;
   config.service = "testsvc";


### PR DESCRIPTION
# Description

Implement DD_APM_TRACING_ENABLED=false, as described in the relevant RFC ("Configuration to Disable APM Tracing"). It also tries to keep at least about roughly 1 trace/second, so the application is deemed active.
