### PR TITLE
fix(telemetry): use tracer's service, env and runtime ID

### DIFF
--- a/include/datadog/telemetry/telemetry.h
+++ b/include/datadog/telemetry/telemetry.h
@@ -7,6 +7,7 @@
 #include <datadog/logger.h>
 #include <datadog/telemetry/configuration.h>
 #include <datadog/telemetry/metrics.h>
+#include <datadog/tracer_signature.h>
 
 #include <memory>
 #include <vector>
@@ -29,6 +30,14 @@ namespace datadog::telemetry {
 /// NOTE: Make sure to call `init` before calling any of the other telemetry
 /// functions.
 void init(FinalizedConfiguration configuration,
+          std::shared_ptr<tracing::Logger> logger,
+          std::shared_ptr<tracing::HTTPClient> client,
+          std::shared_ptr<tracing::EventScheduler> event_scheduler,
+          tracing::HTTPClient::URL agent_url,
+          tracing::Clock clock = tracing::default_clock);
+
+void init(FinalizedConfiguration configuration,
+          tracing::TracerSignature tracer_signature,
           std::shared_ptr<tracing::Logger> logger,
           std::shared_ptr<tracing::HTTPClient> client,
           std::shared_ptr<tracing::EventScheduler> event_scheduler,

--- a/src/datadog/telemetry/telemetry_impl.cpp
+++ b/src/datadog/telemetry/telemetry_impl.cpp
@@ -195,6 +195,7 @@ nlohmann::json encode_distributions(
 }  // namespace
 
 Telemetry::Telemetry(FinalizedConfiguration config,
+                     TracerSignature tracer_signature,
                      std::shared_ptr<tracing::Logger> logger,
                      std::shared_ptr<tracing::HTTPClient> client,
                      std::shared_ptr<tracing::EventScheduler> event_scheduler,
@@ -202,8 +203,7 @@ Telemetry::Telemetry(FinalizedConfiguration config,
     : config_(std::move(config)),
       logger_(std::move(logger)),
       telemetry_endpoint_(make_telemetry_endpoint(agent_url)),
-      tracer_signature_(tracing::RuntimeID::generate(),
-                        tracing::get_process_name(), ""),
+      tracer_signature_(tracer_signature),
       http_client_(client),
       clock_(std::move(clock)),
       scheduler_(event_scheduler),

--- a/src/datadog/telemetry/telemetry_impl.h
+++ b/src/datadog/telemetry/telemetry_impl.h
@@ -76,6 +76,7 @@ class Telemetry final {
   /// @param logger User logger instance.
   /// @param metrics A vector user metrics to report.
   Telemetry(FinalizedConfiguration configuration,
+            tracing::TracerSignature tracer_signature,
             std::shared_ptr<tracing::Logger> logger,
             std::shared_ptr<tracing::HTTPClient> client,
             std::shared_ptr<tracing::EventScheduler> event_scheduler,

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -59,7 +59,7 @@ Tracer::Tracer(const FinalizedTracerConfig& config,
       baggage_opts_(config.baggage_opts),
       baggage_injection_enabled_(false),
       baggage_extraction_enabled_(false) {
-  telemetry::init(config.telemetry, logger_, config.http_client,
+  telemetry::init(config.telemetry, signature_, logger_, config.http_client,
                   config.event_scheduler, config.agent_url);
   if (config.report_hostname) {
     hostname_ = get_hostname();

--- a/src/datadog/tracer_config.cpp
+++ b/src/datadog/tracer_config.cpp
@@ -371,15 +371,15 @@ Expected<FinalizedTracerConfig> finalize_config(const TracerConfig &user_config,
   // Baggage
   std::tie(origin, final_config.baggage_opts.max_items) =
       pick(env_config->baggage_max_items, user_config.baggage_max_items, 64);
-  final_config.metadata[ConfigName::TRACE_BAGGAGE_MAX_ITEMS] =
-      ConfigMetadata(ConfigName::TRACE_BAGGAGE_MAX_ITEMS,
-                     to_string(final_config.baggage_opts.max_items), origin);
+  final_config.metadata[ConfigName::TRACE_BAGGAGE_MAX_ITEMS] = ConfigMetadata(
+      ConfigName::TRACE_BAGGAGE_MAX_ITEMS,
+      std::to_string(final_config.baggage_opts.max_items), origin);
 
   std::tie(origin, final_config.baggage_opts.max_bytes) =
       pick(env_config->baggage_max_bytes, user_config.baggage_max_bytes, 8192);
-  final_config.metadata[ConfigName::TRACE_BAGGAGE_MAX_BYTES] =
-      ConfigMetadata(ConfigName::TRACE_BAGGAGE_MAX_BYTES,
-                     to_string(final_config.baggage_opts.max_bytes), origin);
+  final_config.metadata[ConfigName::TRACE_BAGGAGE_MAX_BYTES] = ConfigMetadata(
+      ConfigName::TRACE_BAGGAGE_MAX_BYTES,
+      std::to_string(final_config.baggage_opts.max_bytes), origin);
 
   if (final_config.baggage_opts.max_items <= 0 ||
       final_config.baggage_opts.max_bytes < 3) {

--- a/test/telemetry/test_telemetry.cpp
+++ b/test/telemetry/test_telemetry.cpp
@@ -98,7 +98,12 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry lifecycle") {
 
   SECTION("ctor send app-started message") {
     SECTION("Without a defined integration") {
-      Telemetry telemetry{*finalize_config(), logger, client, scheduler, *url};
+      Telemetry telemetry{*finalize_config(),
+                          tracer_signature,
+                          logger,
+                          client,
+                          scheduler,
+                          *url};
       /// By default the integration is `datadog` with the tracer version.
       /// TODO: remove the default because these datadog are already part of the
       /// request header.
@@ -118,7 +123,11 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry lifecycle") {
       Configuration cfg;
       cfg.integration_name = "nginx";
       cfg.integration_version = "1.25.2";
-      Telemetry telemetry2{*finalize_config(cfg), logger, client, scheduler,
+      Telemetry telemetry2{*finalize_config(cfg),
+                           tracer_signature,
+                           logger,
+                           client,
+                           scheduler,
                            *url};
 
       auto app_started = nlohmann::json::parse(client->request_body);
@@ -144,7 +153,12 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry lifecycle") {
       ddtest::EnvGuard install_time_env("DD_INSTRUMENTATION_INSTALL_TIME",
                                         "1703188212");
 
-      Telemetry telemetry4{*finalize_config(), logger, client, scheduler, *url};
+      Telemetry telemetry4{*finalize_config(),
+                           tracer_signature,
+                           logger,
+                           client,
+                           scheduler,
+                           *url};
 
       auto app_started = nlohmann::json::parse(client->request_body);
       REQUIRE(is_valid_telemetry_payload(app_started) == true);
@@ -186,7 +200,11 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry lifecycle") {
       Configuration cfg;
       cfg.products.emplace_back(std::move(product));
 
-      Telemetry telemetry3{*finalize_config(cfg), logger, client, scheduler,
+      Telemetry telemetry3{*finalize_config(cfg),
+                           tracer_signature,
+                           logger,
+                           client,
+                           scheduler,
                            *url};
 
       auto app_started = nlohmann::json::parse(client->request_body);
@@ -290,7 +308,12 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry lifecycle") {
 
   SECTION("dtor send app-closing message") {
     {
-      Telemetry telemetry{*finalize_config(), logger, client, scheduler, *url};
+      Telemetry telemetry{*finalize_config(),
+                          tracer_signature,
+                          logger,
+                          client,
+                          scheduler,
+                          *url};
       client->clear();
     }
 
@@ -322,8 +345,13 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry API") {
 
   auto url = HTTPClient::URL::parse("http://localhost:8000");
 
-  Telemetry telemetry{*finalize_config(), logger, client,
-                      scheduler,          *url,   clock};
+  Telemetry telemetry{*finalize_config(),
+                      tracer_signature,
+                      logger,
+                      client,
+                      scheduler,
+                      *url,
+                      clock};
 
   SECTION("generates a heartbeat message") {
     client->clear();
@@ -624,8 +652,13 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry API") {
       const Rate rps{"request", "rate-test", true};
       const Counter my_counter{"my_counter", "counter-test", true};
       {
-        Telemetry tmp_telemetry{*finalize_config(), logger, client,
-                                scheduler,          *url,   clock};
+        Telemetry tmp_telemetry{*finalize_config(),
+                                tracer_signature,
+                                logger,
+                                client,
+                                scheduler,
+                                *url,
+                                clock};
         tmp_telemetry.increment_counter(my_counter);  // = 1
         tmp_telemetry.add_datapoint(response_time, 128);
         tmp_telemetry.set_rate(rps, 1000);
@@ -772,8 +805,13 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry API") {
 
     SECTION("dtor sends logs in `app-closing` message") {
       {
-        Telemetry tmp_telemetry{*finalize_config(), logger, client,
-                                scheduler,          *url,   clock};
+        Telemetry tmp_telemetry{*finalize_config(),
+                                tracer_signature,
+                                logger,
+                                client,
+                                scheduler,
+                                *url,
+                                clock};
         tmp_telemetry.log_warning("Be careful!");
         client->clear();
       }
@@ -819,7 +857,8 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry configuration") {
     auto final_cfg = finalize_config(cfg);
     REQUIRE(final_cfg);
 
-    Telemetry telemetry(*final_cfg, logger, client, scheduler, *url);
+    Telemetry telemetry(*final_cfg, tracer_signature, logger, client, scheduler,
+                        *url);
     CHECK(scheduler->metrics_callback == nullptr);
     CHECK(scheduler->metrics_interval == nullopt);
   }
@@ -832,7 +871,8 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry configuration") {
     auto final_cfg = finalize_config(cfg);
     REQUIRE(final_cfg);
 
-    Telemetry telemetry(*final_cfg, logger, client, scheduler, *url);
+    Telemetry telemetry(*final_cfg, tracer_signature, logger, client, scheduler,
+                        *url);
     CHECK(scheduler->metrics_callback != nullptr);
     CHECK(scheduler->metrics_interval == 500ms);
 
@@ -849,7 +889,8 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry configuration") {
     auto final_cfg = finalize_config(cfg);
     REQUIRE(final_cfg);
 
-    Telemetry telemetry(*final_cfg, logger, client, scheduler, *url);
+    Telemetry telemetry(*final_cfg, tracer_signature, logger, client, scheduler,
+                        *url);
     telemetry.log_error("error");
 
     // NOTE(@dmehala): logs are sent with an heartbeat.


### PR DESCRIPTION
# Description
This fixes a regression introduced during the telemetry module refactoring. When the telemetry module is initialized in the tracer context, it now correctly uses the tracer's service name, environment, and runtime ID to ensure consistency.

Changes:
  - fix reported baggage configuration values.