### PR TITLE
chore(benchmarks): add PR performance quality gate

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 stages:
   - benchmarks
+  - benchmarks-gate
 
 include: ".gitlab/benchmarks.yml"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 stages:
   - benchmarks
-  - benchmarks-gate
+  - benchmarks-report
 
 include: ".gitlab/benchmarks.yml"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -11,12 +11,13 @@ benchmarks:
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
-    - git clone --branch dd-trace-cpp https://github.com/DataDog/benchmarking-platform /platform && cd /platform
-    - ./steps/capture-hardware-software-info.sh
-    - ./steps/run-benchmarks.sh
-    - ./steps/analyze-results.sh
-    - "./steps/upload-results-to-s3.sh || :"
-    - "./steps/post-pr-comment.sh || :"
+    - git clone --branch dd-trace-cpp https://github.com/DataDog/benchmarking-platform /platform
+    - export PATH="$PATH:/platform/steps"
+    - capture-hardware-software-info.sh
+    - run-benchmarks.sh
+    - analyze-results.sh
+    - "upload-results-to-s3.sh || :"
+    - "post-pr-comment.sh || :"
   artifacts:
     name: "reports"
     when: always
@@ -33,14 +34,21 @@ benchmarks:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
 check-big-regressions:
-  stage: benchmarks-gate
+  stage: benchmarks-report
   needs: [ benchmarks ]
   when: on_success
+  allow_failure: false
   tags: ["arch:amd64"]
   image: $BENCHMARKS_CI_IMAGE
-  script:
-    - export ARTIFACTS_DIR="$(pwd)/reports"
-    - cd reports && (git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-cpp)
-    - bp-runner bp-runner.fail-on-regression.yml --debug
+  script: |
+    export ARTIFACTS_DIR="$(pwd)/reports/"
+    if [[ -n "$CI_JOB_TOKEN" ]];
+    then
+      git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
+    fi
+    git clone --branch dd-trace-cpp https://github.com/DataDog/benchmarking-platform /platform
+    export PATH="$PATH:/platform/steps"
+
+    bp-runner /platform/bp-runner.fail-on-regression.yml --debug
   variables:
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-cpp

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -39,6 +39,7 @@ check-big-regressions:
   tags: ["arch:amd64"]
   image: $BENCHMARKS_CI_IMAGE
   script:
+    - export ARTIFACTS_DIR="$(pwd)/reports"
     - cd reports && (git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-cpp)
     - bp-runner bp-runner.fail-on-regression.yml --debug
   variables:

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -1,11 +1,11 @@
 variables:
-  BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-cpp
+  BENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-cpp
 
 benchmarks:
   stage: benchmarks
   when: on_success
   tags: ["runner:apm-k8s-tweaked-metal"]
-  image: $BASE_CI_IMAGE
+  image: $BENCHMARKS_CI_IMAGE
   interruptible: true
   timeout: 15m
   script:
@@ -19,6 +19,7 @@ benchmarks:
     - "./steps/post-pr-comment.sh || :"
   artifacts:
     name: "reports"
+    when: always
     paths:
       - reports/
     expire_in: 3 months
@@ -30,3 +31,28 @@ benchmarks:
 
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-cpp
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+
+benchmarks-pr-comment:
+  stage: benchmarks-gate
+  needs: [ benchmarks ]
+  when: on_success
+  tags: ["arch:amd64"]
+  image: $BENCHMARKS_CI_IMAGE
+  script:
+    - cd platform && (git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-cpp)
+    - bp-runner bp-runner.pr-comment.yml --debug
+  allow_failure: true
+  variables:
+    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-cpp
+
+check-big-regressions:
+  stage: benchmarks-gate
+  needs: [ benchmarks ]
+  when: on_success
+  tags: ["arch:amd64"]
+  image: $BENCHMARKS_CI_IMAGE
+  script:
+    - cd platform && (git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-cpp)
+    - bp-runner bp-runner.fail-on-regression.yml --debug
+  variables:
+    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-cpp

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -32,19 +32,6 @@ benchmarks:
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-cpp
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
-benchmarks-pr-comment:
-  stage: benchmarks-gate
-  needs: [ benchmarks ]
-  when: on_success
-  tags: ["arch:amd64"]
-  image: $BENCHMARKS_CI_IMAGE
-  script:
-    - cd platform && (git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-cpp)
-    - bp-runner bp-runner.pr-comment.yml --debug
-  allow_failure: true
-  variables:
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-cpp
-
 check-big-regressions:
   stage: benchmarks-gate
   needs: [ benchmarks ]
@@ -52,7 +39,7 @@ check-big-regressions:
   tags: ["arch:amd64"]
   image: $BENCHMARKS_CI_IMAGE
   script:
-    - cd platform && (git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-cpp)
+    - cd reports && (git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-cpp)
     - bp-runner bp-runner.fail-on-regression.yml --debug
   variables:
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-cpp


### PR DESCRIPTION
# Description

Adds performance quality gate to `dd-trace-cpp`. 
Now if a PR adds more than 20% overhead to microbenchmarks, a job called check-big-regressions will fail and will prevent the PR to be merged. 

# Motivation

Performance quality gates initiative.

# Additional Notes

Jira ticket: [APMSP-2048](https://datadoghq.atlassian.net/browse/APMSP-2048)


[APMSP-2048]: https://datadoghq.atlassian.net/browse/APMSP-2048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ