### PR TITLE
build: do not `FetchContent nlohmann_json` if already found by `find_package`

### DIFF
--- a/cmake/deps/json.cmake
+++ b/cmake/deps/json.cmake
@@ -3,8 +3,10 @@ include(FetchContent)
 set(JSON_BuildTests OFF)
 set(JSON_Install OFF)
 
-FetchContent_Declare(json
-  URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz
+FetchContent_Declare(nlohmann_json
+  URL https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.tar.gz
+  URL_HASH SHA256=4b92eb0c06d10683f7447ce9406cb97cd4b453be18d7279320f7b2f025c10187
+  FIND_PACKAGE_ARGS NAMES nlohmann_json
 )
 
-FetchContent_MakeAvailable(json)
+FetchContent_MakeAvailable(nlohmann_json)


### PR DESCRIPTION
# Description
This PR makes it possible to use `dd-trace-cpp` as a dependency when nlohmann_json has already been fetched content by a project.

It also renames `json` into `nlohmann_json` as it is more standard in other projects.

# Motivation

# Additional Notes
Bump version of `nlohmann_json` to 3.12.0.

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
