### PR TITLE
fix(system-tests): set end time when a span is closed

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -25,9 +25,10 @@
       "displayName": "Development",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "DD_TRACE_ENABLE_SANITIZE": "ON",
+        "DD_TRACE_ENABLE_SANITIZE": "OFF",
         "DD_TRACE_BUILD_TESTING": "ON",
-        "DD_TRACE_BUILD_EXAMPLES": "ON"
+        "DD_TRACE_BUILD_EXAMPLES": "ON",
+        "DD_TRACE_BUILD_FUZZERS": "OFF"
       }
     }
   ]

--- a/test/system-tests/request_handler.cpp
+++ b/test/system-tests/request_handler.cpp
@@ -154,6 +154,7 @@ void RequestHandler::on_span_start(const httplib::Request& req,
 
 void RequestHandler::on_span_end(const httplib::Request& req,
                                  httplib::Response& res) {
+  const auto now = std::chrono::steady_clock::now();
   const auto request_json = nlohmann::json::parse(req.body);
 
   auto span_id = utils::get_if_exists<uint64_t>(request_json, "span_id");
@@ -168,6 +169,7 @@ void RequestHandler::on_span_end(const httplib::Request& req,
     VALIDATION_ERROR(res, msg);
   }
 
+  span_it->second.set_end_time(now);
   res.status = 200;
 }
 

--- a/test/system-tests/request_handler.h
+++ b/test/system-tests/request_handler.h
@@ -10,7 +10,6 @@
 #include "developer_noise.h"
 #include "httplib.h"
 #include "manual_scheduler.h"
-#include "utils.h"
 
 class RequestHandler final {
  public:


### PR DESCRIPTION
# Description
Since #170, calls to `/trace/span/finish` have not been accurately reflecting the actual duration of spans. This commit ensures that when a span is closed, its duration is correctly set based on the time elapsed.

Changes:
  - Add `dev` preset.
  - Remove unecessary include.
  - Capture and set end time in `on_span_end`.