### PR TITLE
deps(nlohmann-json): `FetchContent` rely on `find_package`

### DIFF
--- a/cmake/deps/json.cmake
+++ b/cmake/deps/json.cmake
@@ -3,8 +3,10 @@ include(FetchContent)
 set(JSON_BuildTests OFF)
 set(JSON_Install OFF)
 
-FetchContent_Declare(json
-  URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz
+FetchContent_Declare(nlohmann_json
+  URL https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.tar.gz
+  URL_HASH SHA256=4b92eb0c06d10683f7447ce9406cb97cd4b453be18d7279320f7b2f025c10187
+  FIND_PACKAGE_ARGS NAMES nlohmann_json
 )
 
-FetchContent_MakeAvailable(json)
+FetchContent_MakeAvailable(nlohmann_json)


### PR DESCRIPTION
# Description
Add `FIND_PACKAGE_ARGS` will help `FetchContent_*` to satisfy the dependency with `find_package()`. If that dependency is not found, then it is built from source.

Supersede: #227 
Close #227 

# Additional Notes
Bump version of nlohmann_json to 3.12.0.
