### PR TITLE
fix(rc): improve trace sampling rules parsing

### DIFF
--- a/src/datadog/trace_sampler_config.cpp
+++ b/src/datadog/trace_sampler_config.cpp
@@ -209,7 +209,7 @@ Expected<FinalizedTraceSamplerConfig> finalize_config(
   }
 
   // If `sample_rate` was specified, then it translates to a "catch-all" rule
-  // appended to the end of `rules`.  First, though, we have to make sure the
+  // appended to the end of `rules`. First, though, we have to make sure the
   // sample rate is valid.
   if (sample_rate) {
     auto maybe_rate = Rate::from(*sample_rate);

--- a/test/test_config_manager.cpp
+++ b/test/test_config_manager.cpp
@@ -184,4 +184,41 @@ CONFIG_MANAGER_TEST("remote configuration handling") {
     const auto reverted_tracing_status = config_manager.report_traces();
     CHECK(old_tracing_status == reverted_tracing_status);
   }
+
+  SECTION("handling of `tracing_sampling_rules`") {
+    SECTION("valid input") {
+      config_update.content = R"({
+        "lib_config": {
+          "library_language": "all",
+          "library_version": "latest",
+          "service_name": "testsvc",
+          "env": "test",
+          "tracing_sampling_rules": [
+            {
+              "service": "foo",
+              "resource": "GET /hello",
+              "sample_rate": 0.1,
+              "provenance": "customer",
+              "name": "test",
+              "tags": [
+                { "key": "tag1", "value_glob": "value1" }
+              ]
+            }
+          ]
+        },
+        "service_target": {
+           "service": "testsvc",
+           "env": "test"
+        }
+      })";
+
+      const auto old_sampler_cfg =
+          config_manager.trace_sampler()->config_json();
+      const auto err = config_manager.on_update(config_update);
+      const auto new_sampler_cfg =
+          config_manager.trace_sampler()->config_json();
+
+      CHECK(old_sampler_cfg != new_sampler_cfg);
+    }
+  }
 }


### PR DESCRIPTION
Correctly parse `tags` from remote trace sampling rules and improves overall rule parsing reliability through stricter validation and clearer error reporting.

Changes:
  - Add support for `tags` in trace sampling rules.
  - Improve validation with explicit type checks and more descriptive error messages.
  - Update catch-all rule handling to replace an existing one instead of always prepending, ensuring consistent rule ordering.
  - Extended system test request handler to support `span_tags` from incoming requests.

[APMAPI-863]
[APMAPI-866]


[APMAPI-863]: https://datadoghq.atlassian.net/browse/APMAPI-863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMAPI-866]: https://datadoghq.atlassian.net/browse/APMAPI-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ