### PR TITLE
fix: edge cases parsing of `DD_TAGS`

### DIFF
--- a/src/datadog/parse_util.cpp
+++ b/src/datadog/parse_util.cpp
@@ -141,11 +141,10 @@ Expected<std::unordered_map<std::string, std::string>> parse_tags(
 
     if (separator == std::string::npos) {
       key = std::string{trim(token)};
+      if (key.empty()) continue;
     } else {
       key = std::string{trim(token.substr(0, separator))};
-      if (key.empty()) {
-        continue;
-      }
+      if (key.empty()) continue;
       value = std::string{trim(token.substr(separator + 1))};
     }
 
@@ -183,7 +182,6 @@ Expected<std::unordered_map<std::string, std::string>> parse_tags(
       break;
     } else if (input[i] == ' ') {
       separator = ' ';
-      break;
     }
   }
 
@@ -191,7 +189,7 @@ Expected<std::unordered_map<std::string, std::string>> parse_tags(
     goto capture_all;
   }
 
-  for (; i < end; ++i) {
+  for (i = beg; i < end; ++i) {
     if (input[i] == separator) {
       auto tag = input.substr(beg, i - beg);
       if (tag.size() > 0) {

--- a/test/test_parse_util.cpp
+++ b/test/test_parse_util.cpp
@@ -145,56 +145,72 @@ PARSE_UTIL_TEST("parse_tags") {
   };
 
   auto test_case = GENERATE(values<TestCase>({
+      {
+          __LINE__,
+          "space separated tags",
+          "env:test aKey:aVal bKey:bVal cKey:",
+          {
+              {"env", "test"},
+              {"aKey", "aVal"},
+              {"bKey", "bVal"},
+              {"cKey", ""},
+          },
+      },
+      {
+          __LINE__,
+          "comma separated tags",
+          "env:test,aKey:aVal,bKey:bVal,cKey:",
+          {
+              {"env", "test"},
+              {"aKey", "aVal"},
+              {"bKey", "bVal"},
+              {"cKey", ""},
+          },
+      },
+      {
+          __LINE__,
+          "mixed separator 1/3",
+          "env:test,aKey:aVal bKey:bVal cKey:",
+          {
+              {"env", "test"},
+              {"aKey", "aVal bKey:bVal cKey:"},
+          },
+      },
+      {
+          __LINE__,
+          "mixed separator 2/3",
+          "env:test     bKey :bVal, dKey: dVal cKey:",
+          {
+              {"env", "test     bKey :bVal"},
+              {"dKey", "dVal cKey:"},
+          },
+      },
+      {
+          __LINE__,
+          "mixed separator 3/3",
+          "env :test, aKey : aVal bKey:bVal cKey:",
+          {
+              {"env", "test"},
+              {"aKey", "aVal bKey:bVal cKey:"},
+          },
+      },
+      {
+          __LINE__,
+          "multiple semi-colons",
+          "env:keyWithA:Semicolon bKey:bVal cKey",
+          {
+              {"env", "keyWithA:Semicolon"},
+              {"bKey", "bVal"},
+              {"cKey", ""},
+          },
+      },
       {__LINE__,
-       "space separated tags",
-       "env:test aKey:aVal bKey:bVal cKey:",
+       "mixed separator edge case",
+       "env:keyWith:  , ,   Lots:Of:Semicolons ",
        {
-           {"env", "test"},
-           {"aKey", "aVal"},
-           {"bKey", "bVal"},
-           {"cKey", ""},
+           {"env", "keyWith:"},
+           {"Lots", "Of:Semicolons"},
        }},
-      {__LINE__,
-       "comma separated tags",
-       "env:test aKey:aVal bKey:bVal cKey:",
-       {
-           {"env", "test"},
-           {"aKey", "aVal"},
-           {"bKey", "bVal"},
-           {"cKey", ""},
-       }},
-      {__LINE__,
-       "mixed separator but comma first",
-       "env:test,aKey:aVal bKey:bVal cKey:",
-       {
-           {"env", "test"},
-           {"aKey", "aVal bKey:bVal cKey:"},
-       }},
-      {__LINE__,
-       "mixed separator but space first",
-       "env:test     bKey :bVal dKey: dVal cKey:",
-       {
-           {"env", "test"},
-           {"bKey", ""},
-           {"dKey", ""},
-           {"dVal", ""},
-           {"cKey", ""},
-       }},
-      {__LINE__,
-       "mixed separator but space first",
-       "env:keyWithA:Semicolon bKey:bVal cKey",
-       {
-           {"env", "keyWithA:Semicolon"},
-           {"bKey", "bVal"},
-           {"cKey", ""},
-       }},
-      // {__LINE__,
-      //  "mixed separator edge case",
-      //  "env:keyWith:  , ,   Lots:Of:Semicolons ",
-      //  {
-      //      {"env", "keyWith:"},
-      //      {"Lots", "Of:Semicolons"},
-      //  }},
       {__LINE__,
        "comma separated but some tags without value",
        "a:b,c,d",
@@ -210,19 +226,23 @@ PARSE_UTIL_TEST("parse_tags") {
            {"a", ""},
            {"1", ""},
        }},
-      {__LINE__,
-       "no separator",
-       "a:b:c:d",
-       {
-           {"a", "b:c:d"},
-       }},
-      {__LINE__,
-       "input is trimed",
-       "key1:val1, key2 : val2 ",
-       {
-           {"key1", "val1"},
-           {"key2", "val2"},
-       }},
+      {
+          __LINE__,
+          "no separator",
+          "a:b:c:d",
+          {
+              {"a", "b:c:d"},
+          },
+      },
+      {
+          __LINE__,
+          "input is trimed",
+          "key1:val1, key2 : val2 ",
+          {
+              {"key1", "val1"},
+              {"key2", "val2"},
+          },
+      },
   }));
 
   CAPTURE(test_case.line);


### PR DESCRIPTION
# Description
This pull request addresses a bug in the tag parsing logic where space-separated values were incorrectly considered even when comma separators were present in the `DD_TAGS` environment variable. According to the RFC:

"This is a (mostly) backwards-compatible change to DD_TAGS parsing where we use comma-separated tags if there are any commas present in the DD_TAGS variable, and use space-separation otherwise."

The fix ensures that the presence of commas takes precedence, aligning the parsing behavior with the intended specification.

## Motivation

The bug was identified during system tests, which rely on correct tag parsing to function as expected. This fix brings the implementation into compliance with the RFC and prevents inconsistent behavior in environments where mixed separators may be present.