### PR TITLE
fix(cmake): replace remaining targets depending on dd_trace_cpp-static

### DIFF
--- a/fuzz/base64/CMakeLists.txt
+++ b/fuzz/base64/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_executable(base64-fuzz main.cpp)
 
-add_dependencies(base64-fuzz dd_trace_cpp-static)
+add_dependencies(base64-fuzz dd-trace-cpp::static)
 
 target_include_directories(base64-fuzz
   PRIVATE
     ${CMAKE_SOURCE_DIR}/src
 )
 
-target_link_libraries(base64-fuzz dd_trace_cpp-static)
+target_link_libraries(base64-fuzz dd-trace-cpp::static)
 
 add_target_to_group(base64-fuzz dd_trace_cpp-fuzzers)

--- a/fuzz/remote-configuration/CMakeLists.txt
+++ b/fuzz/remote-configuration/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(remote-config-fuzz main.cpp)
 
-add_dependencies(remote-config-fuzz dd_trace_cpp-static)
+add_dependencies(remote-config-fuzz dd-trace-cpp::static)
 
 target_include_directories(remote-config-fuzz
   PRIVATE
@@ -8,6 +8,6 @@ target_include_directories(remote-config-fuzz
     ${CMAKE_SOURCE_DIR}/src/datadog
 )
 
-target_link_libraries(remote-config-fuzz dd_trace_cpp-static)
+target_link_libraries(remote-config-fuzz dd-trace-cpp::static)
 
 add_target_to_group(remote-config-fuzz dd_trace_cpp-fuzzers)

--- a/fuzz/tracing/CMakeLists.txt
+++ b/fuzz/tracing/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_executable(baggage-fuzz baggage.cpp)
 
-add_dependencies(baggage-fuzz dd_trace_cpp-static)
+add_dependencies(baggage-fuzz dd-trace-cpp::static)
 
 target_include_directories(baggage-fuzz
   PRIVATE
     ${CMAKE_SOURCE_DIR}/src
 )
 
-target_link_libraries(baggage-fuzz dd_trace_cpp-static)
+target_link_libraries(baggage-fuzz dd-trace-cpp::static)
 
 add_target_to_group(baggage-fuzz dd_trace_cpp-fuzzers)

--- a/fuzz/w3c-propagation/CMakeLists.txt
+++ b/fuzz/w3c-propagation/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_executable(w3c-propagation-fuzz fuzz.cpp)
 
-add_dependencies(w3c-propagation-fuzz dd_trace_cpp-static)
+add_dependencies(w3c-propagation-fuzz dd-trace-cpp::static)
 
 target_include_directories(w3c-propagation-fuzz
   PRIVATE
     ${CMAKE_SOURCE_DIR}/src
 )
-target_link_libraries(w3c-propagation-fuzz dd_trace_cpp-static)
+target_link_libraries(w3c-propagation-fuzz dd-trace-cpp::static)
 
 add_target_to_group(w3c-propagation-fuzz dd_trace_cpp-fuzzers)


### PR DESCRIPTION
# Description
Fix regression introduced in 6e5c32e35bf7ad5e7fc0ac951e7d8092295d67c1

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
