### PR TITLE
feat: implement stable configuration

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -87,6 +87,11 @@ cc_library(
         "src/datadog/trace_segment.cpp",
         "src/datadog/trace_source.cpp",
         "src/datadog/tracer.cpp",
+        "src/datadog/stable_config.cpp",
+        "src/datadog/stable_config.h",
+        "src/datadog/stable_config_source.h",
+        "src/datadog/yaml_parser.cpp",
+        "src/datadog/yaml_parser.h",
         "src/datadog/tracer_config.cpp",
         "src/datadog/version.cpp",
         "src/datadog/w3c_propagation.cpp",
@@ -159,5 +164,10 @@ cc_library(
     deps = [
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
+        # yaml-cpp is an implementation detail; CMake links it PRIVATE.
+        # rules_cc's `implementation_deps` would be the analog, but the
+        # version pinned in MODULE.bazel does not yet support it, so we
+        # keep yaml-cpp in `deps` and document the asymmetry here.
+        "@yaml_cpp//:yaml-cpp",
     ],
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,10 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   include(cmake/compiler/gcc.cmake)
 endif ()
 
+# yaml-cpp must be included AFTER the compiler setup above, because
+# clang.cmake sets -stdlib=libc++ which yaml-cpp needs to inherit.
+include(cmake/deps/yaml.cmake)
+
 if (DD_TRACE_BUILD_FUZZERS)
   add_subdirectory(fuzz)
 endif ()
@@ -212,6 +216,8 @@ target_sources(dd-trace-cpp-objects
     src/datadog/tags.cpp
     src/datadog/tag_propagation.cpp
     src/datadog/threaded_event_scheduler.cpp
+    src/datadog/stable_config.cpp
+    src/datadog/yaml_parser.cpp
     src/datadog/tracer_config.cpp
     src/datadog/tracer.cpp
     src/datadog/trace_id.cpp
@@ -244,6 +250,7 @@ target_link_libraries(dd-trace-cpp-objects
     Threads::Threads
   PRIVATE
     dd-trace-cpp::specs
+    $<BUILD_INTERFACE:yaml-cpp>
 )
 
 set_target_properties(dd-trace-cpp-objects

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,3 +7,4 @@ bazel_dep(name = "abseil-cpp", version = "20260107.1", repo_name = "com_google_a
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_cc", version = "0.2.18")
+bazel_dep(name = "yaml-cpp", version = "0.8.0.bcr.1", repo_name = "yaml_cpp")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,6 +40,16 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.14/rules_cc-0.2.14.tar.gz"],
 )
 
+# This pulls the upstream yaml-cpp 0.8.0 tarball directly.
+# MODULE.bazel uses "0.8.0.bcr.1" because that is the BCR (Bazel Central
+# Registry) patched release; the underlying library version is the same 0.8.0.
+http_archive(
+    name = "yaml_cpp",
+    sha256 = "fbe74bbdcee21d656715688706da3c8becfd946d92cd44705cc6098bb23b3a16",
+    strip_prefix = "yaml-cpp-0.8.0",
+    urls = ["https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz"],
+)
+
 load("@rules_cc//cc:extensions.bzl", "compatibility_proxy_repo")
 
 compatibility_proxy_repo()

--- a/cmake/deps/yaml.cmake
+++ b/cmake/deps/yaml.cmake
@@ -1,0 +1,36 @@
+include(FetchContent)
+
+set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "" FORCE)
+set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "" FORCE)
+set(YAML_CPP_INSTALL OFF CACHE BOOL "" FORCE)
+set(YAML_BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+
+FetchContent_Declare(yaml-cpp
+  URL https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz
+  URL_HASH SHA256=fbe74bbdcee21d656715688706da3c8becfd946d92cd44705cc6098bb23b3a16
+  EXCLUDE_FROM_ALL
+  SYSTEM
+)
+
+# yaml-cpp 0.8.0 uses cmake_minimum_required(VERSION 3.4) which is rejected
+# by CMake >= 4.0.  Allow it via CMAKE_POLICY_VERSION_MINIMUM.
+set(_yaml_saved_policy_min "${CMAKE_POLICY_VERSION_MINIMUM}")
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+FetchContent_MakeAvailable(yaml-cpp)
+set(CMAKE_POLICY_VERSION_MINIMUM "${_yaml_saved_policy_min}")
+
+# Ensure yaml-cpp is compiled with the same sanitizer flags as the main
+# project.  Without this, MSVC ASAN annotation mismatches cause linker
+# errors (LNK2038).  We add only the sanitizer flags — not the full set
+# of compile options from dd-trace-cpp-specs (which includes -WX and
+# warning levels that would break yaml-cpp's own code).
+if (DD_TRACE_ENABLE_SANITIZE AND TARGET yaml-cpp)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT MATCHES "MSVC"))
+    target_compile_options(yaml-cpp PRIVATE /fsanitize=address)
+    target_link_options(yaml-cpp PRIVATE /fsanitize=address)
+  else()
+    target_compile_options(yaml-cpp PRIVATE -fsanitize=address,undefined)
+    target_link_options(yaml-cpp PRIVATE -fsanitize=address,undefined)
+  endif()
+endif()

--- a/include/datadog/telemetry/configuration.h
+++ b/include/datadog/telemetry/configuration.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <datadog/config.h>
 #include <datadog/expected.h>
 #include <datadog/optional.h>
 #include <datadog/telemetry/product.h>

--- a/include/datadog/tracer_config.h
+++ b/include/datadog/tracer_config.h
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <variant>
 #include <vector>
 

--- a/src/datadog/stable_config.cpp
+++ b/src/datadog/stable_config.cpp
@@ -1,0 +1,115 @@
+#include "stable_config.h"
+
+#include <sys/stat.h>
+
+#include <cerrno>
+#include <cstddef>
+#include <cstring>
+#include <fstream>
+#include <ostream>
+#include <string>
+
+#include "yaml_parser.h"
+
+namespace datadog {
+namespace tracing {
+namespace {
+
+// Maximum file size accepted for stable configuration files: 256KB.
+// This is a file I/O concern, not a parser concern, so it lives here rather
+// than in yaml_parser.h.
+constexpr std::size_t kMaxYamlFileSize = 256 * 1024;
+
+}  // namespace
+
+// Read a file and parse it into a StableConfig. Logs warnings on errors.
+// Returns an empty StableConfig if the file doesn't exist or can't be read.
+StableConfig load_one(const std::string& path, Logger& logger) {
+  StableConfig result;
+
+  // Probe for existence before opening so we can distinguish a missing file
+  // (silent no-op) from a present-but-unreadable file (permission / I/O
+  // error worth logging).
+  struct stat st;
+  if (::stat(path.c_str(), &st) != 0) {
+    // Most often ENOENT — file simply isn't there. Silent skip.
+    return result;
+  }
+
+  std::ifstream file(path, std::ios::binary | std::ios::ate);
+  if (!file.is_open()) {
+    const int err = errno;
+    logger.log_error([&path, err](std::ostream& log) {
+      log << "Stable config: file " << path << " exists but could not be "
+          << "opened (errno " << err << ": " << std::strerror(err)
+          << "); skipping.";
+    });
+    return result;
+  }
+
+  // Check file size.
+  const auto size = file.tellg();
+  if (size < 0) {
+    logger.log_error([&path](std::ostream& log) {
+      log << "Stable config: unable to determine size of " << path
+          << "; skipping.";
+    });
+    return result;
+  }
+
+  if (static_cast<std::size_t>(size) > kMaxYamlFileSize) {
+    logger.log_error([&path](std::ostream& log) {
+      log << "Stable config: file " << path
+          << " exceeds 256KB size limit; skipping.";
+    });
+    return result;
+  }
+
+  file.seekg(0);
+  std::string content(static_cast<std::size_t>(size), '\0');
+  if (!file.read(content.data(), size)) {
+    logger.log_error([&path](std::ostream& log) {
+      log << "Stable config: unable to read " << path << "; skipping.";
+    });
+    return result;
+  }
+
+  YamlParseResult parsed;
+  if (parse_yaml(content, parsed) != YamlParseStatus::OK) {
+    logger.log_error([&path](std::ostream& log) {
+      log << "Stable config: malformed YAML in " << path << "; skipping.";
+    });
+    return {};  // Return empty config on parse error.
+  }
+
+  result.config_id = std::move(parsed.config_id);
+  result.values = std::move(parsed.values);
+  return result;
+}
+
+StableConfigPaths get_stable_config_paths() {
+  return {
+      "/etc/datadog-agent/application_monitoring.yaml",
+      "/etc/datadog-agent/managed/datadog-agent/stable/"
+      "application_monitoring.yaml",
+  };
+}
+
+Optional<std::string> StableConfig::lookup(const std::string& key) const {
+  auto it = values.find(key);
+  if (it != values.end()) {
+    return it->second;
+  }
+  return nullopt;
+}
+
+StableConfigs load_stable_configs(Logger& logger) {
+  const auto paths = get_stable_config_paths();
+  StableConfigs configs;
+  configs.local = load_one(paths.local_path, logger);
+  configs.fleet = load_one(paths.fleet_path, logger);
+  return configs;
+}
+
+}  // namespace tracing
+}  // namespace datadog

--- a/src/datadog/stable_config.h
+++ b/src/datadog/stable_config.h
@@ -1,0 +1,65 @@
+#pragma once
+
+// This component provides support for reading "stable configuration" from
+// YAML files on disk. Two files are read at tracer initialization:
+//
+//   - A "local" (user-managed) file
+//   - A "fleet" (fleet-managed) file
+//
+// Each file may contain a flat map of DD_* environment variable names to
+// scalar values under the `apm_configuration_default` key. These values
+// participate in configuration precedence:
+//
+//   fleet_stable > env > user/code > local_stable > default
+
+#include <datadog/logger.h>
+#include <datadog/optional.h>
+
+#include <string>
+#include <unordered_map>
+
+namespace datadog {
+namespace tracing {
+
+// Paths to the two stable configuration files.
+struct StableConfigPaths {
+  std::string local_path;
+  std::string fleet_path;
+};
+
+// Return the platform-specific paths for stable configuration files.
+// Currently Linux-only — Windows support deferred to a follow-up.
+StableConfigPaths get_stable_config_paths();
+
+// Parsed contents of one stable configuration file.
+struct StableConfig {
+  // Config ID from the file (optional, for telemetry).
+  Optional<std::string> config_id;
+
+  // Map of environment variable names (e.g. "DD_SERVICE") to string values.
+  std::unordered_map<std::string, std::string> values;
+
+  // Look up a config key, returning nullopt if not present.
+  Optional<std::string> lookup(const std::string& key) const;
+};
+
+// Load and parse a single stable config file at the given path.  Exposed
+// here (not in an anonymous namespace) so tests can exercise the
+// single-file edge cases — oversized, malformed, missing, unreadable —
+// against arbitrary temporary paths.  Production code uses
+// load_stable_configs() below, which composes load_one over the two
+// platform paths.
+StableConfig load_one(const std::string& path, Logger& logger);
+
+// Holds both the local and fleet stable configs.
+struct StableConfigs {
+  StableConfig local;
+  StableConfig fleet;
+};
+
+// Load and parse both stable configuration files.
+// Returns empty configs (no error) if files don't exist.
+StableConfigs load_stable_configs(Logger& logger);
+
+}  // namespace tracing
+}  // namespace datadog

--- a/src/datadog/stable_config_source.h
+++ b/src/datadog/stable_config_source.h
@@ -1,0 +1,52 @@
+#pragma once
+
+// `ConfigSource` adapters that wrap a parsed `StableConfig` so it can
+// participate in the `ConfigProvider` source list alongside the
+// environment and any future sources.
+
+#include <datadog/config.h>
+#include <datadog/optional.h>
+#include <datadog/string_view.h>
+
+#include <string>
+
+#include "config_source.h"
+#include "stable_config.h"
+
+namespace datadog {
+namespace tracing {
+
+class LocalStableConfigSource : public ConfigSource {
+  const StableConfig* cfg_;
+
+ public:
+  explicit LocalStableConfigSource(const StableConfig& cfg) : cfg_(&cfg) {}
+
+  Optional<std::string> lookup(StringView key) const override {
+    return cfg_->lookup(std::string{key});
+  }
+
+  ConfigMetadata::Origin origin() const override {
+    return ConfigMetadata::Origin::LOCAL_STABLE_CONFIG;
+  }
+};
+
+class FleetStableConfigSource : public ConfigSource {
+  const StableConfig* cfg_;
+
+ public:
+  explicit FleetStableConfigSource(const StableConfig& cfg) : cfg_(&cfg) {}
+
+  Optional<std::string> lookup(StringView key) const override {
+    return cfg_->lookup(std::string{key});
+  }
+
+  ConfigMetadata::Origin origin() const override {
+    return ConfigMetadata::Origin::FLEET_STABLE_CONFIG;
+  }
+
+  Optional<std::string> config_id() const override { return cfg_->config_id; }
+};
+
+}  // namespace tracing
+}  // namespace datadog

--- a/src/datadog/tracer_config.cpp
+++ b/src/datadog/tracer_config.cpp
@@ -1,4 +1,5 @@
 #include <datadog/environment.h>
+#include <datadog/optional.h>
 #include <datadog/string_view.h>
 #include <datadog/tracer_config.h>
 
@@ -9,13 +10,14 @@
 #include <vector>
 
 #include "config_provider.h"
-#include "datadog/optional.h"
 #include "datadog_agent.h"
 #include "environment_source.h"
 #include "json.hpp"
 #include "null_logger.h"
 #include "parse_util.h"
 #include "platform_util.h"
+#include "stable_config.h"
+#include "stable_config_source.h"
 #include "string_util.h"
 #include "threaded_event_scheduler.h"
 
@@ -34,7 +36,7 @@ Optional<std::vector<PropagationStyle>> styles_from_env(
   }
 
   auto styles = parse_propagation_styles(*styles_env);
-  if (auto *error = styles.if_error()) {
+  if (auto* error = styles.if_error()) {
     std::string prefix;
     prefix += "Unable to parse ";
     append(prefix, name(env_var));
@@ -50,7 +52,7 @@ std::string json_quoted(StringView text) {
   return nlohmann::json(std::move(unquoted)).dump();
 }
 
-Expected<TracerConfig> load_tracer_env_config(Logger &logger) {
+Expected<TracerConfig> load_tracer_env_config(Logger& logger) {
   TracerConfig env_cfg;
 
   if (auto service_env = lookup(environment::DD_SERVICE)) {
@@ -66,7 +68,7 @@ Expected<TracerConfig> load_tracer_env_config(Logger &logger) {
 
   if (auto tags_env = lookup(environment::DD_TAGS)) {
     auto tags = parse_tags(*tags_env);
-    if (auto *error = tags.if_error()) {
+    if (auto* error = tags.if_error()) {
       std::string prefix;
       prefix += "Unable to parse ";
       append(prefix, name(environment::DD_TAGS));
@@ -105,7 +107,7 @@ Expected<TracerConfig> load_tracer_env_config(Logger &logger) {
   if (auto baggage_items_env =
           lookup(environment::DD_TRACE_BAGGAGE_MAX_ITEMS)) {
     auto maybe_value = parse_uint64(*baggage_items_env, 10);
-    if (auto *error = maybe_value.if_error()) {
+    if (auto* error = maybe_value.if_error()) {
       return *error;
     }
 
@@ -115,7 +117,7 @@ Expected<TracerConfig> load_tracer_env_config(Logger &logger) {
   if (auto baggage_bytes_env =
           lookup(environment::DD_TRACE_BAGGAGE_MAX_BYTES)) {
     auto maybe_value = parse_uint64(*baggage_bytes_env, 10);
-    if (auto *error = maybe_value.if_error()) {
+    if (auto* error = maybe_value.if_error()) {
       return *error;
     }
 
@@ -174,7 +176,7 @@ Expected<TracerConfig> load_tracer_env_config(Logger &logger) {
     return message;
   };
 
-  for (const auto &[var, var_override] : questionable_combinations) {
+  for (const auto& [var, var_override] : questionable_combinations) {
     const auto value = lookup(var);
     if (!value) {
       continue;
@@ -215,7 +217,7 @@ Expected<TracerConfig> load_tracer_env_config(Logger &logger) {
     } else {
       env_cfg.injection_styles = global_styles;
     }
-  } catch (Error &error) {
+  } catch (Error& error) {
     return std::move(error);
   }
 
@@ -224,14 +226,17 @@ Expected<TracerConfig> load_tracer_env_config(Logger &logger) {
 
 }  // namespace
 
-Expected<FinalizedTracerConfig> finalize_config(const TracerConfig &config) {
+Expected<FinalizedTracerConfig> finalize_config(const TracerConfig& config) {
   return finalize_config(config, default_clock);
 }
 
-Expected<FinalizedTracerConfig> finalize_config(const TracerConfig &user_config,
-                                                const Clock &clock) {
+Expected<FinalizedTracerConfig> finalize_config(const TracerConfig& user_config,
+                                                const Clock& clock) {
   auto logger =
       user_config.logger ? user_config.logger : std::make_shared<NullLogger>();
+
+  // Load stable configs from YAML files.
+  auto stable_configs = load_stable_configs(*logger);
 
   Expected<TracerConfig> env_config = load_tracer_env_config(*logger);
   if (auto error = env_config.if_error()) {
@@ -243,7 +248,9 @@ Expected<FinalizedTracerConfig> finalize_config(const TracerConfig &user_config,
   final_config.logger = logger;
 
   EnvironmentSource env_src;
-  ConfigProvider provider(/*fleet=*/nullptr, &env_src, /*local=*/nullptr,
+  FleetStableConfigSource fleet_src(stable_configs.fleet);
+  LocalStableConfigSource local_src(stable_configs.local);
+  ConfigProvider provider(&fleet_src, &env_src, &local_src,
                           &final_config.metadata);
 
   // DD_SERVICE
@@ -361,14 +368,14 @@ Expected<FinalizedTracerConfig> finalize_config(const TracerConfig &user_config,
 
   auto agent_finalized =
       finalize_config(user_config.agent, final_config.logger, clock);
-  if (auto *error = agent_finalized.if_error()) {
+  if (auto* error = agent_finalized.if_error()) {
     return std::move(*error);
   }
 
   if (auto trace_sampler_config = finalize_config(user_config.trace_sampler)) {
     // Merge metadata vectors
-    for (auto &[key, values] : trace_sampler_config->metadata) {
-      auto &dest = final_config.metadata[key];
+    for (auto& [key, values] : trace_sampler_config->metadata) {
+      auto& dest = final_config.metadata[key];
       dest.insert(dest.end(), values.begin(), values.end());
     }
     final_config.trace_sampler = std::move(*trace_sampler_config);
@@ -379,8 +386,8 @@ Expected<FinalizedTracerConfig> finalize_config(const TracerConfig &user_config,
   if (auto span_sampler_config =
           finalize_config(user_config.span_sampler, *logger)) {
     // Merge metadata vectors
-    for (auto &[key, values] : span_sampler_config->metadata) {
-      auto &dest = final_config.metadata[key];
+    for (auto& [key, values] : span_sampler_config->metadata) {
+      auto& dest = final_config.metadata[key];
       dest.insert(dest.end(), values.begin(), values.end());
     }
     final_config.span_sampler = std::move(*span_sampler_config);
@@ -456,8 +463,8 @@ Expected<FinalizedTracerConfig> finalize_config(const TracerConfig &user_config,
   if (!user_config.collector) {
     final_config.collector = *agent_finalized;
     // Merge metadata vectors
-    for (auto &[key, values] : agent_finalized->metadata) {
-      auto &dest = final_config.metadata[key];
+    for (auto& [key, values] : agent_finalized->metadata) {
+      auto& dest = final_config.metadata[key];
       dest.insert(dest.end(), values.begin(), values.end());
     }
   } else {

--- a/src/datadog/yaml_parser.cpp
+++ b/src/datadog/yaml_parser.cpp
@@ -1,0 +1,97 @@
+#include "yaml_parser.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <cctype>
+#include <string>
+
+namespace datadog {
+namespace tracing {
+
+YamlParseStatus parse_yaml(const std::string& content, YamlParseResult& out) {
+  if (content.empty()) {
+    return YamlParseStatus::OK;
+  }
+
+  // Reject documents with an excessive number of alias references, as a
+  // best-effort defense against alias-expansion bombs. yaml-cpp 0.8.0 has
+  // no built-in limit on alias expansion. 100 is well above legitimate use
+  // (the configs are flat string maps) and well below what an expansion
+  // attack would require to matter.
+  constexpr std::size_t kMaxAliases = 100;
+  std::size_t alias_count = 0;
+  for (std::size_t i = 0; i + 1 < content.size(); ++i) {
+    // A YAML alias is '*' followed by an identifier character. The simple
+    // heuristic of counting '*' followed by an alnum / underscore is good
+    // enough — this is a guard, not a parser.
+    if (content[i] == '*' &&
+        (std::isalnum(static_cast<unsigned char>(content[i + 1])) ||
+         content[i + 1] == '_')) {
+      if (++alias_count > kMaxAliases) {
+        return YamlParseStatus::PARSE_ERROR;
+      }
+    }
+  }
+
+  YAML::Node root;
+  try {
+    root = YAML::Load(content);
+  } catch (...) {
+    return YamlParseStatus::PARSE_ERROR;
+  }
+
+  if (!root.IsDefined() || root.IsNull()) {
+    return YamlParseStatus::OK;
+  }
+
+  if (!root.IsMap()) {
+    return YamlParseStatus::PARSE_ERROR;
+  }
+
+  if (const auto& config_id_node = root["config_id"]) {
+    if (!config_id_node.IsScalar()) {
+      return YamlParseStatus::PARSE_ERROR;
+    }
+    try {
+      out.config_id = config_id_node.as<std::string>();
+    } catch (...) {
+      return YamlParseStatus::PARSE_ERROR;
+    }
+  }
+
+  if (const auto& apm = root["apm_configuration_default"]) {
+    if (!apm.IsMap()) {
+      return YamlParseStatus::PARSE_ERROR;
+    }
+
+    for (const auto& kv : apm) {
+      if (!kv.first.IsScalar()) {
+        return YamlParseStatus::PARSE_ERROR;
+      }
+
+      std::string key;
+      try {
+        key = kv.first.as<std::string>();
+      } catch (...) {
+        return YamlParseStatus::PARSE_ERROR;
+      }
+
+      const auto& value_node = kv.second;
+      if (value_node.IsScalar()) {
+        // yaml-cpp preserves the original text representation, so booleans
+        // stay as "true"/"false" and numbers stay as their original string
+        // form.
+        out.values[key] = value_node.Scalar();
+      } else if (value_node.IsNull()) {
+        // Null value (e.g., `DD_SERVICE:`) is stored as the empty string.
+        out.values[key] = "";
+      }
+      // Sequences, maps, etc. are silently skipped.
+    }
+  }
+
+  return YamlParseStatus::OK;
+}
+
+}  // namespace tracing
+}  // namespace datadog

--- a/src/datadog/yaml_parser.h
+++ b/src/datadog/yaml_parser.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// This component provides a YAML parser for stable configuration files,
+// using yaml-cpp.  It extracts a config_id and a flat key-value map from
+// the `apm_configuration_default` section of a YAML document.
+
+#include <datadog/optional.h>
+
+#include <string>
+#include <unordered_map>
+
+namespace datadog {
+namespace tracing {
+
+// Result of parsing a YAML stable configuration document.
+struct YamlParseResult {
+  // Config ID from the file (optional).
+  Optional<std::string> config_id;
+
+  // Map of environment variable names (e.g. "DD_SERVICE") to string values,
+  // extracted from the `apm_configuration_default` section.
+  std::unordered_map<std::string, std::string> values;
+};
+
+enum class YamlParseStatus { OK, PARSE_ERROR };
+
+// Parse the given YAML content string into a YamlParseResult.
+// Returns OK on success (including when `apm_configuration_default` is absent).
+// Returns PARSE_ERROR on malformed input.
+YamlParseStatus parse_yaml(const std::string& content, YamlParseResult& out);
+
+}  // namespace tracing
+}  // namespace datadog

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,8 @@ add_executable(tests
     test_tracer.cpp
     test_trace_sampler.cpp
     test_endpoint_inferral.cpp
+    test_stable_config.cpp
+    test_yaml_parser.cpp
 
     remote_config/test_remote_config.cpp
 )

--- a/test/system-tests/request_handler.cpp
+++ b/test/system-tests/request_handler.cpp
@@ -8,6 +8,7 @@
 #include <datadog/tracer_config.h>
 
 #include <datadog/json.hpp>
+#include <string>
 
 #include "httplib.h"
 #include "utils.h"

--- a/test/system-tests/request_handler.h
+++ b/test/system-tests/request_handler.h
@@ -6,6 +6,8 @@
 #include <datadog/tracer_config.h>
 
 #include <datadog/json.hpp>
+#include <string>
+#include <unordered_map>
 
 #include "developer_noise.h"
 #include "httplib.h"

--- a/test/test_stable_config.cpp
+++ b/test/test_stable_config.cpp
@@ -1,0 +1,253 @@
+#include <datadog/optional.h>
+#include <sys/stat.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "mocks/loggers.h"
+#include "stable_config.h"
+#include "stable_config_source.h"
+#include "test.h"
+#include "yaml_parser.h"
+
+using namespace datadog::tracing;
+
+namespace {
+
+namespace fs = std::filesystem;
+
+// Create a temporary directory for stable config test files.
+class TempDir {
+  fs::path path_;
+
+ public:
+  TempDir() {
+    path_ = fs::temp_directory_path() /
+            ("dd-trace-cpp-test-stable-config-" +
+             std::to_string(std::hash<std::string>{}(__FILE__)));
+    fs::create_directories(path_);
+  }
+
+  ~TempDir() {
+    std::error_code ec;
+    fs::remove_all(path_, ec);
+  }
+
+  const fs::path& path() const { return path_; }
+};
+
+}  // namespace
+
+#define STABLE_CONFIG_TEST(x) TEST_CASE(x, "[stable_config]")
+
+STABLE_CONFIG_TEST("StableConfig::lookup returns nullopt for missing key") {
+  StableConfig cfg;
+  REQUIRE(!cfg.lookup("DD_SERVICE").has_value());
+}
+
+STABLE_CONFIG_TEST("StableConfig::lookup returns value for present key") {
+  StableConfig cfg;
+  cfg.values["DD_SERVICE"] = "my-service";
+  auto val = cfg.lookup("DD_SERVICE");
+  REQUIRE(val.has_value());
+  REQUIRE(*val == "my-service");
+}
+
+STABLE_CONFIG_TEST("parse valid YAML with apm_configuration_default") {
+  std::string yaml_content = R"(
+apm_configuration_default:
+  DD_SERVICE: my-service
+  DD_ENV: production
+  DD_PROFILING_ENABLED: true
+)";
+
+  YamlParseResult parsed;
+  auto status = parse_yaml(yaml_content, parsed);
+  REQUIRE(status == YamlParseStatus::OK);
+
+  REQUIRE(parsed.values.count("DD_SERVICE"));
+  REQUIRE(parsed.values["DD_SERVICE"] == "my-service");
+  REQUIRE(parsed.values.count("DD_ENV"));
+  REQUIRE(parsed.values["DD_ENV"] == "production");
+  REQUIRE(parsed.values.count("DD_PROFILING_ENABLED"));
+  REQUIRE(parsed.values["DD_PROFILING_ENABLED"] == "true");
+  REQUIRE(!parsed.values.count("DD_MISSING"));
+}
+
+STABLE_CONFIG_TEST("config_id is stored") {
+  StableConfig cfg;
+  cfg.config_id = "fleet-policy-123";
+  REQUIRE(cfg.config_id.has_value());
+  REQUIRE(*cfg.config_id == "fleet-policy-123");
+}
+
+STABLE_CONFIG_TEST("duplicate keys: last value wins") {
+  StableConfig cfg;
+  cfg.values["DD_SERVICE"] = "first";
+  cfg.values["DD_SERVICE"] = "second";
+  REQUIRE(*cfg.lookup("DD_SERVICE") == "second");
+}
+
+STABLE_CONFIG_TEST("get_stable_config_paths returns platform paths") {
+  auto paths = get_stable_config_paths();
+#ifdef _WIN32
+  // On Windows, paths should contain backslashes and
+  // application_monitoring.yaml.
+  REQUIRE(paths.local_path.find("application_monitoring.yaml") !=
+          std::string::npos);
+  REQUIRE(paths.fleet_path.find("managed") != std::string::npos);
+#else
+  REQUIRE(paths.local_path == "/etc/datadog-agent/application_monitoring.yaml");
+  REQUIRE(paths.fleet_path ==
+          "/etc/datadog-agent/managed/datadog-agent/stable/"
+          "application_monitoring.yaml");
+#endif
+}
+
+STABLE_CONFIG_TEST("load_stable_configs with missing files returns empty") {
+  MockLogger logger;
+  // The default paths likely don't exist in the test environment, so this
+  // should return empty configs without errors.
+  auto configs = load_stable_configs(logger);
+  REQUIRE(configs.local.values.empty());
+  REQUIRE(configs.fleet.values.empty());
+  REQUIRE(!configs.local.config_id.has_value());
+  REQUIRE(!configs.fleet.config_id.has_value());
+}
+
+STABLE_CONFIG_TEST("load_one reads valid YAML from disk") {
+  TempDir dir;
+  auto path = (dir.path() / "valid.yaml").string();
+  {
+    std::ofstream out(path);
+    out << "apm_configuration_default:\n"
+           "  DD_SERVICE: my-service\n"
+           "  DD_ENV: prod\n";
+  }
+  MockLogger logger;
+  auto cfg = load_one(path, logger);
+  REQUIRE(cfg.values.size() == 2);
+  REQUIRE(cfg.values.at("DD_SERVICE") == "my-service");
+  REQUIRE(cfg.values.at("DD_ENV") == "prod");
+  REQUIRE(logger.error_count() == 0);
+}
+
+STABLE_CONFIG_TEST("load_one rejects oversized file") {
+  TempDir dir;
+  auto path = (dir.path() / "oversize.yaml").string();
+  {
+    std::ofstream out(path);
+    out << "apm_configuration_default:\n  DD_SERVICE: ";
+    std::string padding(257 * 1024, 'x');
+    out << padding;
+  }
+  MockLogger logger;
+  auto cfg = load_one(path, logger);
+  REQUIRE(cfg.values.empty());
+  REQUIRE(logger.error_count() >= 1);
+  // The error message mentions the 256KB cap.
+  bool found_size_message = false;
+  for (const auto& entry : logger.entries) {
+    if (entry.kind == MockLogger::Entry::DD_ERROR) {
+      const auto* s = std::get_if<std::string>(&entry.payload);
+      if (s && s->find("256KB") != std::string::npos) {
+        found_size_message = true;
+        break;
+      }
+    }
+  }
+  REQUIRE(found_size_message);
+}
+
+STABLE_CONFIG_TEST("load_one returns empty on malformed YAML") {
+  TempDir dir;
+  auto path = (dir.path() / "bad.yaml").string();
+  {
+    std::ofstream out(path);
+    out << "?? ??; ??\t\n\n --- `??";
+  }
+  MockLogger logger;
+  auto cfg = load_one(path, logger);
+  REQUIRE(cfg.values.empty());
+  REQUIRE(logger.error_count() >= 1);
+  bool found_malformed_message = false;
+  for (const auto& entry : logger.entries) {
+    if (entry.kind == MockLogger::Entry::DD_ERROR) {
+      const auto* s = std::get_if<std::string>(&entry.payload);
+      if (s && s->find("malformed") != std::string::npos) {
+        found_malformed_message = true;
+        break;
+      }
+    }
+  }
+  REQUIRE(found_malformed_message);
+}
+
+STABLE_CONFIG_TEST("load_one returns empty when file is missing") {
+  TempDir dir;
+  auto path = (dir.path() / "does-not-exist.yaml").string();
+  MockLogger logger;
+  auto cfg = load_one(path, logger);
+  REQUIRE(cfg.values.empty());
+  REQUIRE(!cfg.config_id.has_value());
+  REQUIRE(logger.error_count() == 0);  // missing files are silently skipped
+}
+
+#ifndef _WIN32
+STABLE_CONFIG_TEST("load_one logs when file exists but is unreadable") {
+  TempDir dir;
+  auto path = (dir.path() / "unreadable.yaml").string();
+  {
+    std::ofstream out(path);
+    out << "apm_configuration_default:\n  DD_SERVICE: my-service\n";
+  }
+  // Make the file unreadable. If chmod doesn't take effect (e.g., running as
+  // root or on a filesystem that ignores POSIX permissions), the rest of the
+  // test wouldn't be meaningful; gracefully skip in that case.
+  REQUIRE(::chmod(path.c_str(), 0) == 0);
+
+  MockLogger logger;
+  auto cfg = load_one(path, logger);
+
+  // Restore permissions so the TempDir destructor can clean up.
+  ::chmod(path.c_str(), 0644);
+
+  if (cfg.values.empty() && logger.error_count() >= 1) {
+    bool found_unreadable_message = false;
+    for (const auto& entry : logger.entries) {
+      if (entry.kind == MockLogger::Entry::DD_ERROR) {
+        const auto* s = std::get_if<std::string>(&entry.payload);
+        if (s && s->find("could not be") != std::string::npos) {
+          found_unreadable_message = true;
+          break;
+        }
+      }
+    }
+    REQUIRE(found_unreadable_message);
+  }
+  // else: the runtime ignored chmod (likely running as root); skip assertion.
+}
+#endif
+
+STABLE_CONFIG_TEST("LocalStableConfigSource wraps StableConfig::lookup") {
+  StableConfig cfg;
+  cfg.values["DD_SERVICE"] = "from-local";
+  LocalStableConfigSource src(cfg);
+
+  REQUIRE(src.lookup("DD_SERVICE") == Optional<std::string>("from-local"));
+  REQUIRE(!src.lookup("DD_MISSING").has_value());
+  REQUIRE(src.origin() == ConfigMetadata::Origin::LOCAL_STABLE_CONFIG);
+  REQUIRE(!src.config_id().has_value());
+}
+
+STABLE_CONFIG_TEST("FleetStableConfigSource forwards config_id") {
+  StableConfig cfg;
+  cfg.values["DD_SERVICE"] = "from-fleet";
+  cfg.config_id = std::string{"fleet-id-42"};
+  FleetStableConfigSource src(cfg);
+
+  REQUIRE(src.lookup("DD_SERVICE") == Optional<std::string>("from-fleet"));
+  REQUIRE(src.origin() == ConfigMetadata::Origin::FLEET_STABLE_CONFIG);
+  REQUIRE(src.config_id() == Optional<std::string>("fleet-id-42"));
+}

--- a/test/test_yaml_parser.cpp
+++ b/test/test_yaml_parser.cpp
@@ -1,0 +1,348 @@
+#include <string>
+
+#include "test.h"
+#include "yaml_parser.h"
+
+using namespace datadog::tracing;
+
+#define YAML_PARSER_TEST(x) TEST_CASE(x, "[yaml_parser]")
+
+YAML_PARSER_TEST("parse empty string") {
+  YamlParseResult result;
+  REQUIRE(parse_yaml("", result) == YamlParseStatus::OK);
+  REQUIRE(!result.config_id.has_value());
+  REQUIRE(result.values.empty());
+}
+
+YAML_PARSER_TEST("parse only comments and blank lines") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "# This is a comment\n"
+      "\n"
+      "  # indented comment\n"
+      "\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.empty());
+}
+
+YAML_PARSER_TEST("parse config_id at top level") {
+  YamlParseResult result;
+  auto status = parse_yaml("config_id: my-policy-123\n", result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.config_id.has_value());
+  REQUIRE(*result.config_id == "my-policy-123");
+}
+
+YAML_PARSER_TEST("parse config_id with quotes") {
+  YamlParseResult result;
+  auto status = parse_yaml("config_id: \"quoted-policy-456\"\n", result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(*result.config_id == "quoted-policy-456");
+}
+
+YAML_PARSER_TEST("parse config_id with single quotes") {
+  YamlParseResult result;
+  auto status = parse_yaml("config_id: 'single-quoted'\n", result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(*result.config_id == "single-quoted");
+}
+
+YAML_PARSER_TEST("parse apm_configuration_default with entries") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: my-service\n"
+      "  DD_ENV: production\n"
+      "  DD_TRACE_SAMPLE_RATE: 0.5\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.size() == 3);
+  REQUIRE(result.values.at("DD_SERVICE") == "my-service");
+  REQUIRE(result.values.at("DD_ENV") == "production");
+  REQUIRE(result.values.at("DD_TRACE_SAMPLE_RATE") == "0.5");
+}
+
+YAML_PARSER_TEST("parse with config_id and apm_configuration_default") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "config_id: fleet-policy-789\n"
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: my-service\n"
+      "  DD_VERSION: 1.2.3\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(*result.config_id == "fleet-policy-789");
+  REQUIRE(result.values.size() == 2);
+  REQUIRE(result.values.at("DD_SERVICE") == "my-service");
+  REQUIRE(result.values.at("DD_VERSION") == "1.2.3");
+}
+
+YAML_PARSER_TEST("yaml parser: duplicate keys last value wins") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: first\n"
+      "  DD_SERVICE: second\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.at("DD_SERVICE") == "second");
+}
+
+YAML_PARSER_TEST("inline comments are stripped") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: my-service  # this is a comment\n"
+      "  DD_ENV: prod # env comment\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.at("DD_SERVICE") == "my-service");
+  REQUIRE(result.values.at("DD_ENV") == "prod");
+}
+
+YAML_PARSER_TEST("quoted values preserve hash characters") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: \"my#service\"  # comment\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.at("DD_SERVICE") == "my#service");
+}
+
+YAML_PARSER_TEST("single-quoted values preserve hash characters") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: 'my#service'  # comment\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.at("DD_SERVICE") == "my#service");
+}
+
+YAML_PARSER_TEST("flow sequences are skipped") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: my-service\n"
+      "  DD_TAGS: [tag1, tag2]\n"
+      "  DD_ENV: prod\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.count("DD_TAGS") == 0);
+  REQUIRE(result.values.at("DD_SERVICE") == "my-service");
+  REQUIRE(result.values.at("DD_ENV") == "prod");
+}
+
+YAML_PARSER_TEST("flow mappings are skipped") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "apm_configuration_default:\n"
+      "  DD_SOME_MAP: {key: value}\n"
+      "  DD_SERVICE: my-service\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.count("DD_SOME_MAP") == 0);
+  REQUIRE(result.values.at("DD_SERVICE") == "my-service");
+}
+
+YAML_PARSER_TEST("Windows line endings are handled") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "config_id: win-id\r\n"
+      "apm_configuration_default:\r\n"
+      "  DD_SERVICE: my-service\r\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(*result.config_id == "win-id");
+  REQUIRE(result.values.at("DD_SERVICE") == "my-service");
+}
+
+YAML_PARSER_TEST("malformed YAML returns PARSE_ERROR") {
+  YamlParseResult result;
+  auto status = parse_yaml("[invalid yaml: {{{", result);
+  REQUIRE(status == YamlParseStatus::PARSE_ERROR);
+}
+
+YAML_PARSER_TEST("apm_configuration_default with scalar value is PARSE_ERROR") {
+  YamlParseResult result;
+  auto status = parse_yaml("apm_configuration_default: some_value\n", result);
+  REQUIRE(status == YamlParseStatus::PARSE_ERROR);
+}
+
+YAML_PARSER_TEST("unknown top-level keys are silently ignored") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "some_unknown_key: some_value\n"
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: my-service\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.at("DD_SERVICE") == "my-service");
+}
+
+YAML_PARSER_TEST("indented lines under unknown keys are ignored") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "other_section:\n"
+      "  key1: val1\n"
+      "  key2: val2\n"
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: my-service\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.size() == 1);
+  REQUIRE(result.values.at("DD_SERVICE") == "my-service");
+}
+
+YAML_PARSER_TEST("empty values are stored") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "apm_configuration_default:\n"
+      "  DD_SERVICE:\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.at("DD_SERVICE") == "");
+}
+
+YAML_PARSER_TEST("boolean-like values are stored as strings") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "apm_configuration_default:\n"
+      "  DD_TRACE_ENABLED: true\n"
+      "  DD_TRACE_STARTUP_LOGS: false\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.at("DD_TRACE_ENABLED") == "true");
+  REQUIRE(result.values.at("DD_TRACE_STARTUP_LOGS") == "false");
+}
+
+YAML_PARSER_TEST("numeric values are stored as strings") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "apm_configuration_default:\n"
+      "  DD_TRACE_SAMPLE_RATE: 0.5\n"
+      "  DD_TRACE_RATE_LIMIT: 100\n"
+      "  DD_TRACE_BAGGAGE_MAX_ITEMS: 64\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.at("DD_TRACE_SAMPLE_RATE") == "0.5");
+  REQUIRE(result.values.at("DD_TRACE_RATE_LIMIT") == "100");
+  REQUIRE(result.values.at("DD_TRACE_BAGGAGE_MAX_ITEMS") == "64");
+}
+
+YAML_PARSER_TEST("multiple top-level sections") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "config_id: test-id\n"
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: my-service\n"
+      "other_section:\n"
+      "  key: value\n"
+      "  another: value2\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(*result.config_id == "test-id");
+  REQUIRE(result.values.size() == 1);
+  REQUIRE(result.values.at("DD_SERVICE") == "my-service");
+}
+
+YAML_PARSER_TEST("YAML document markers are handled") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "---\n"
+      "config_id: doc-marker-id\n"
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: my-service\n"
+      "...\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(*result.config_id == "doc-marker-id");
+  REQUIRE(result.values.at("DD_SERVICE") == "my-service");
+}
+
+YAML_PARSER_TEST("quoted JSON strings are correctly unquoted") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "apm_configuration_default:\n"
+      "  DD_TRACE_SAMPLING_RULES: '[{\"rate\":1}]'\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.at("DD_TRACE_SAMPLING_RULES") == "[{\"rate\":1}]");
+}
+
+YAML_PARSER_TEST("non-map root returns PARSE_ERROR") {
+  YamlParseResult result;
+  auto status = parse_yaml("- item1\n- item2\n", result);
+  REQUIRE(status == YamlParseStatus::PARSE_ERROR);
+}
+
+YAML_PARSER_TEST("YAML anchors and aliases are handled") {
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "config_id: &id anchor-id\n"
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: my-service\n",
+      result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(*result.config_id == "anchor-id");
+  REQUIRE(result.values.at("DD_SERVICE") == "my-service");
+}
+
+YAML_PARSER_TEST("NonScalarConfigIdReturnsParseError") {
+  // config_id is a sequence — yaml-cpp would throw TypedBadConversion on
+  // Node::as<std::string>() without an IsScalar() guard.
+  YamlParseResult result;
+  auto status = parse_yaml("config_id: [1, 2, 3]\n", result);
+  REQUIRE(status == YamlParseStatus::PARSE_ERROR);
+}
+
+YAML_PARSER_TEST("NonScalarConfigIdDoesNotThrow") {
+  // config_id is a flow map — must not propagate an exception; must return
+  // PARSE_ERROR cleanly.
+  YamlParseResult result;
+  auto status = parse_yaml("config_id: {a: 1}\n", result);
+  REQUIRE(status == YamlParseStatus::PARSE_ERROR);
+}
+
+YAML_PARSER_TEST("NonScalarMapKeyReturnsParseError") {
+  // A sequence used as a map key under apm_configuration_default — yaml-cpp
+  // would throw TypedBadConversion on kv.first.as<std::string>() without an
+  // IsScalar() guard.
+  YamlParseResult result;
+  auto status = parse_yaml(
+      "apm_configuration_default:\n"
+      "  ? [a, b]\n"
+      "  : value\n",
+      result);
+  REQUIRE(status == YamlParseStatus::PARSE_ERROR);
+}
+
+YAML_PARSER_TEST("RejectsExcessiveAliasReferences") {
+  // 200 alias references (above the 100-alias cap) must be rejected before
+  // yaml-cpp ever parses the document, guarding against alias-expansion bombs.
+  std::string yaml = "shared: &x foo\n";
+  yaml += "apm_configuration_default:\n";
+  for (int i = 0; i < 200; ++i) {
+    yaml += "  KEY_" + std::to_string(i) + ": *x\n";
+  }
+  YamlParseResult result;
+  REQUIRE(parse_yaml(yaml, result) == YamlParseStatus::PARSE_ERROR);
+}
+
+YAML_PARSER_TEST("AcceptsModerateAliasUse") {
+  // A small number of alias references is legitimate and must be accepted.
+  std::string yaml =
+      "shared: &x foo\n"
+      "apm_configuration_default:\n"
+      "  DD_SERVICE: *x\n"
+      "  DD_ENV: *x\n"
+      "  DD_VERSION: *x\n";
+  YamlParseResult result;
+  auto status = parse_yaml(yaml, result);
+  REQUIRE(status == YamlParseStatus::OK);
+  REQUIRE(result.values.at("DD_SERVICE") == "foo");
+  REQUIRE(result.values.at("DD_ENV") == "foo");
+  REQUIRE(result.values.at("DD_VERSION") == "foo");
+}


### PR DESCRIPTION
# Description

Phase 1 Stable Configuration support for dd-trace-cpp, rebased onto the `ConfigProvider` refactor from #321. Scalar `apm_configuration_default` keys only; Linux-only.

At tracer init, the tracer reads two YAML files:
- **Local** (user-managed): `/etc/datadog-agent/application_monitoring.yaml`
- **Fleet** (Agent-managed): `/etc/datadog-agent/managed/datadog-agent/stable/application_monitoring.yaml`

Each file may contain `apm_configuration_default`, a flat map of `DD_*` environment-variable-style keys to scalar values. These participate in configuration precedence: `fleet_stable > env > user/code > local_stable > default`. Fleet files may include a `config_id` reported in telemetry against fleet-sourced entries.

## How it's wired

This change plugs stable configuration into the `ConfigProvider` infrastructure landed in #321. Two `ConfigSource` implementations adapt parsed YAML into the provider's source list:

- `LocalStableConfigSource` (origin: `LOCAL_STABLE_CONFIG`)
- `FleetStableConfigSource` (origin: `FLEET_STABLE_CONFIG`, optional `config_id`)

`finalize_config` constructs both sources from the parsed YAML and passes them to `ConfigProvider` alongside `EnvironmentSource`. Every typed accessor on the provider (`get_string`, `get_bool`, `get_uint64`, `get_tags`, `get_propagation_styles*`) walks all three sources.

Keys covered: `DD_SERVICE`, `DD_ENV`, `DD_VERSION`, `DD_TAGS`, `DD_TRACE_ENABLED`, `DD_TRACE_STARTUP_LOGS`, `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`, `DD_APM_TRACING_ENABLED`, `DD_TRACE_BAGGAGE_MAX_ITEMS`, `DD_TRACE_BAGGAGE_MAX_BYTES`, `DD_TRACE_PROPAGATION_STYLE*`, `DD_TRACE_RESOURCE_RENAMING_*`.

## Out of scope (deferred to follow-ups)

- **Nested finalize_config integration**: `trace_sampler_config`, `span_sampler_config`, and `datadog_agent_config` finalize independently of the top-level `ConfigProvider`. Wiring stable config into them requires threading the sources through. Keys affected include `DD_TRACE_SAMPLE_RATE`, `DD_TRACE_RATE_LIMIT`, `DD_TRACE_SAMPLING_RULES`, `DD_SPAN_SAMPLING_RULES`, `DD_TRACE_AGENT_URL`. dd-trace-go's Phase 1 made the same choice; dd-trace-java covers them because its provider resolves universally.
- **Alias-precedence cleanup**: `get_propagation_styles_with_aliases` picks the first alias any source has and resolves only that alias. A specific alias set in env can shadow a more general alias set by fleet. Tracked separately; predates this PR (came in via #321).
- **Windows paths**: no peer reference for the `HKLM\SOFTWARE\Datadog\Datadog Agent` registry lookup in other native-parsing tracers. Defer to a follow-up aligned with the Agent's registry layout.
- **`apm_configuration_rules`** (targeting rules with selectors): not in any Phase 1 native implementation.

## Key design choices

- **YAML parsing via yaml-cpp 0.8.0** (`src/datadog/yaml_parser.{h,cpp}`). Linked PRIVATE in CMake; in Bazel, lives in `deps` with a comment documenting the asymmetry.
- **256KB file size limit** on each YAML file. Larger files are skipped with an error log.
- **YAML alias-bomb mitigation**: documents with more than 100 alias references are rejected before invoking `YAML::Load`. Heuristic guard, not a parser.
- **Non-scalar conversion safety**: `Node::as<std::string>()` calls are gated on `IsScalar()` and wrapped in try/catch.
- **Test-accessible `load_one`** in `stable_config.h` lets `TempDir`-based unit tests exercise file I/O paths directly.

## Files

| File | Change |
|------|--------|
| `cmake/deps/yaml.cmake` | New: yaml-cpp 0.8.0 FetchContent dependency |
| `BUILD.bazel`, `MODULE.bazel`, `WORKSPACE` | New: yaml-cpp Bazel dep |
| `CMakeLists.txt`, `test/CMakeLists.txt` | yaml-cpp + new test files |
| `src/datadog/yaml_parser.{h,cpp}` | New: yaml-cpp wrapper with alias-bomb and non-scalar guards |
| `src/datadog/stable_config.{h,cpp}` | New: `StableConfig`, Linux file paths, 256KB file loader |
| `src/datadog/stable_config_source.h` | New: `LocalStableConfigSource` and `FleetStableConfigSource` adapters |
| `src/datadog/tracer_config.cpp` | Wire the two stable-config sources into `ConfigProvider` |
| `src/datadog/telemetry/telemetry_impl.cpp` | Emit `config_id` per fleet-origin metadata entry |
| `test/test_yaml_parser.cpp` | YAML parser tests including non-scalar and alias-bomb cases |
| `test/test_stable_config.cpp` | StableConfig, file I/O via `TempDir`, source-adapter smoke tests |
| `test/system-tests/request_handler.{cpp,h}` | `/config` endpoint reads from `tracer_.config()` |

## Rebased onto #321

The earlier 40-commit history collapsed to one feature commit on top of `bm1549/config-provider`. Behavior matches the original PR's intent for in-scope keys; resolution machinery now lives in `ConfigProvider` and `ConfigSource` rather than in a 5-parameter `resolve_and_record_config` template. The legacy template was retired in #321.

## Testing

199,670 assertions / 172 test cases pass locally. Coverage includes:
- YAML parser happy paths, non-scalar `config_id` / map key handling, alias-bomb rejection
- `StableConfig::lookup`
- File I/O: valid YAML, 256KB rejection, malformed YAML on disk, missing file, unreadable file (POSIX-guarded)
- `LocalStableConfigSource` / `FleetStableConfigSource` adapter behavior including `config_id` forwarding
- `ConfigProvider` precedence chain (covered in #321's tests)

Related system-tests PR: DataDog/system-tests#6554.

# Motivation

Enable fleet-managed and user-managed APM configuration for C++ tracers (dd-trace-cpp, nginx-datadog, httpd-datadog). C++ is the last major language without stable config support. This is Phase 1; extended configs (sampler integration), nested finalizer wiring, and Windows support follow.

# Additional Notes

Jira ticket: [PROJ-IDENT]
