### PR TITLE
Add backfilled option to config registry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ validate_supported_configurations_v2_local_file:
   extends: .validate_supported_configurations_v2_local_file
   variables:
     LOCAL_JSON_PATH: "supported-configurations.json"
-    BACKFILLED: false
+    BACKFILLED: true
 
 update_central_configurations_version_range_v2:
   stage: config-validation

--- a/.gitlab/config-registry.yml
+++ b/.gitlab/config-registry.yml
@@ -19,7 +19,7 @@ variables:
     - when: on_success
   variables:
     LOCAL_JSON_PATH: ""
-    BACKFILLED: ""
+    BACKFILLED: "true"
   before_script:
     - *download-scripts-from-template
   script:

--- a/include/datadog/environment.h
+++ b/include/datadog/environment.h
@@ -35,6 +35,9 @@ namespace environment {
 //       The runtime default is resolved in C++ configuration finalization
 //       logic. The description is emitted as the "default" field in
 //       metadata/supported-configurations.json.
+//   - nullptr
+//       There is no default value. This is emitted as JSON null in
+//       metadata/supported-configurations.json.
 #define DD_LIST_ENVIRONMENT_VARIABLES(MACRO)                                   \
   MACRO(DD_AGENT_HOST, STRING, "localhost")                                    \
   MACRO(DD_ENV, STRING, "")                                                    \
@@ -60,29 +63,29 @@ namespace environment {
             "then defaults to http://localhost:8126."))                        \
   MACRO(DD_TRACE_DEBUG, BOOLEAN, false)                                        \
   MACRO(DD_TRACE_ENABLED, BOOLEAN, true)                                       \
-  MACRO(DD_TRACE_RATE_LIMIT, DECIMAL, 100.0)                                   \
+  MACRO(DD_TRACE_RATE_LIMIT, INT, 100)                                         \
   MACRO(DD_TRACE_REPORT_HOSTNAME, BOOLEAN, false)                              \
-  MACRO(DD_TRACE_SAMPLE_RATE, DECIMAL, 1.0)                                    \
+  MACRO(DD_TRACE_SAMPLE_RATE, DECIMAL, 1)                                      \
   MACRO(DD_TRACE_SAMPLING_RULES, ARRAY, "[]")                                  \
   MACRO(DD_TRACE_STARTUP_LOGS, BOOLEAN, true)                                  \
   MACRO(DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH, INT, 512)                        \
   MACRO(DD_VERSION, STRING, "")                                                \
   MACRO(DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED, BOOLEAN, true)            \
   MACRO(DD_TELEMETRY_HEARTBEAT_INTERVAL, DECIMAL, 10)                          \
-  MACRO(DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL, DECIMAL, 86400.0)            \
+  MACRO(DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL, INT, 86400)                  \
   MACRO(DD_TELEMETRY_METRICS_ENABLED, BOOLEAN, true)                           \
   MACRO(DD_TELEMETRY_METRICS_INTERVAL_SECONDS, DECIMAL, 60)                    \
   MACRO(DD_TELEMETRY_DEBUG, BOOLEAN, false)                                    \
   MACRO(DD_TRACE_BAGGAGE_MAX_ITEMS, INT, 64)                                   \
   MACRO(DD_TRACE_BAGGAGE_MAX_BYTES, INT, 8192)                                 \
   MACRO(DD_TELEMETRY_LOG_COLLECTION_ENABLED, BOOLEAN, true)                    \
-  MACRO(DD_INSTRUMENTATION_INSTALL_ID, STRING, "")                             \
-  MACRO(DD_INSTRUMENTATION_INSTALL_TYPE, STRING, "")                           \
-  MACRO(DD_INSTRUMENTATION_INSTALL_TIME, STRING, "")                           \
+  MACRO(DD_INSTRUMENTATION_INSTALL_ID, STRING, nullptr)                        \
+  MACRO(DD_INSTRUMENTATION_INSTALL_TYPE, STRING, nullptr)                      \
+  MACRO(DD_INSTRUMENTATION_INSTALL_TIME, STRING, nullptr)                      \
   MACRO(DD_APM_TRACING_ENABLED, BOOLEAN, true)                                 \
   MACRO(DD_TRACE_RESOURCE_RENAMING_ENABLED, BOOLEAN, false)                    \
   MACRO(DD_TRACE_RESOURCE_RENAMING_ALWAYS_SIMPLIFIED_ENDPOINT, BOOLEAN, false) \
-  MACRO(DD_EXTERNAL_ENV, STRING, "")
+  MACRO(DD_EXTERNAL_ENV, STRING, nullptr)
 
 #define ENV_DEFAULT_RESOLVED_IN_CODE(X) X
 #define WITH_COMMA(ARG, TYPE, DEFAULT_VALUE) ARG,

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -4,287 +4,287 @@
       {
         "default": "localhost",
         "implementation": "A",
-        "type": "STRING"
+        "type": "string"
       }
     ],
     "DD_APM_TRACING_ENABLED": [
       {
-        "default": "1",
+        "default": "true",
         "implementation": "A",
-        "type": "BOOLEAN"
+        "type": "boolean"
       }
     ],
     "DD_ENV": [
       {
         "default": "",
         "implementation": "A",
-        "type": "STRING"
+        "type": "string"
       }
     ],
     "DD_EXTERNAL_ENV": [
       {
-        "default": "",
+        "default": null,
         "implementation": "A",
-        "type": "STRING"
+        "type": "string"
       }
     ],
     "DD_INSTRUMENTATION_INSTALL_ID": [
       {
-        "default": "",
+        "default": null,
         "implementation": "A",
-        "type": "STRING"
+        "type": "string"
       }
     ],
     "DD_INSTRUMENTATION_INSTALL_TIME": [
       {
-        "default": "",
+        "default": null,
         "implementation": "A",
-        "type": "STRING"
+        "type": "string"
       }
     ],
     "DD_INSTRUMENTATION_INSTALL_TYPE": [
       {
-        "default": "",
+        "default": null,
         "implementation": "A",
-        "type": "STRING"
+        "type": "string"
       }
     ],
     "DD_INSTRUMENTATION_TELEMETRY_ENABLED": [
       {
-        "default": "1",
+        "default": "true",
         "implementation": "A",
-        "type": "BOOLEAN"
+        "type": "boolean"
       }
     ],
     "DD_PROPAGATION_STYLE_EXTRACT": [
       {
         "default": "datadog,tracecontext,baggage",
-        "implementation": "A",
-        "type": "ARRAY"
+        "implementation": "C",
+        "type": "array"
       }
     ],
     "DD_PROPAGATION_STYLE_INJECT": [
       {
         "default": "datadog,tracecontext,baggage",
-        "implementation": "A",
-        "type": "ARRAY"
+        "implementation": "C",
+        "type": "array"
       }
     ],
     "DD_REMOTE_CONFIGURATION_ENABLED": [
       {
-        "default": "1",
+        "default": "true",
         "implementation": "A",
-        "type": "BOOLEAN"
+        "type": "boolean"
       }
     ],
     "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": [
       {
-        "default": "5",
+        "default": "5.0",
         "implementation": "A",
-        "type": "DECIMAL"
+        "type": "decimal"
       }
     ],
     "DD_SERVICE": [
       {
         "default": "",
-        "implementation": "A",
-        "type": "STRING"
+        "implementation": "F",
+        "type": "string"
       }
     ],
     "DD_SPAN_SAMPLING_RULES": [
       {
         "default": "[]",
         "implementation": "A",
-        "type": "ARRAY"
+        "type": "array"
       }
     ],
     "DD_SPAN_SAMPLING_RULES_FILE": [
       {
         "default": "",
-        "implementation": "A",
-        "type": "STRING"
+        "implementation": "B",
+        "type": "string"
       }
     ],
     "DD_TAGS": [
       {
         "default": "",
         "implementation": "A",
-        "type": "MAP"
+        "type": "map"
       }
     ],
     "DD_TELEMETRY_DEBUG": [
       {
-        "default": "0",
+        "default": "false",
         "implementation": "A",
-        "type": "BOOLEAN"
+        "type": "boolean"
       }
     ],
     "DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL": [
       {
         "default": "86400",
         "implementation": "A",
-        "type": "DECIMAL"
+        "type": "int"
       }
     ],
     "DD_TELEMETRY_HEARTBEAT_INTERVAL": [
       {
         "default": "10",
-        "implementation": "A",
-        "type": "DECIMAL"
+        "implementation": "D",
+        "type": "decimal"
       }
     ],
     "DD_TELEMETRY_LOG_COLLECTION_ENABLED": [
       {
-        "default": "1",
+        "default": "true",
         "implementation": "A",
-        "type": "BOOLEAN"
+        "type": "boolean"
       }
     ],
     "DD_TELEMETRY_METRICS_ENABLED": [
       {
-        "default": "1",
+        "default": "true",
         "implementation": "A",
-        "type": "BOOLEAN"
+        "type": "boolean"
       }
     ],
     "DD_TELEMETRY_METRICS_INTERVAL_SECONDS": [
       {
         "default": "60",
         "implementation": "A",
-        "type": "DECIMAL"
+        "type": "decimal"
       }
     ],
     "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": [
       {
-        "default": "1",
+        "default": "true",
         "implementation": "A",
-        "type": "BOOLEAN"
+        "type": "boolean"
       }
     ],
     "DD_TRACE_AGENT_PORT": [
       {
         "default": "8126",
         "implementation": "A",
-        "type": "INT"
+        "type": "int"
       }
     ],
     "DD_TRACE_AGENT_URL": [
       {
         "default": "",
         "implementation": "A",
-        "type": "STRING"
+        "type": "string"
       }
     ],
     "DD_TRACE_BAGGAGE_MAX_BYTES": [
       {
         "default": "8192",
         "implementation": "A",
-        "type": "INT"
+        "type": "int"
       }
     ],
     "DD_TRACE_BAGGAGE_MAX_ITEMS": [
       {
         "default": "64",
         "implementation": "A",
-        "type": "INT"
+        "type": "int"
       }
     ],
     "DD_TRACE_DEBUG": [
       {
-        "default": "0",
-        "implementation": "A",
-        "type": "BOOLEAN"
+        "default": "false",
+        "implementation": "B",
+        "type": "boolean"
       }
     ],
     "DD_TRACE_ENABLED": [
       {
-        "default": "1",
+        "default": "true",
         "implementation": "A",
-        "type": "BOOLEAN"
+        "type": "boolean"
       }
     ],
     "DD_TRACE_PROPAGATION_STYLE": [
       {
         "default": "datadog,tracecontext,baggage",
-        "implementation": "A",
-        "type": "ARRAY"
+        "implementation": "D",
+        "type": "array"
       }
     ],
     "DD_TRACE_PROPAGATION_STYLE_EXTRACT": [
       {
         "default": "datadog,tracecontext,baggage",
-        "implementation": "A",
-        "type": "ARRAY"
+        "implementation": "D",
+        "type": "array"
       }
     ],
     "DD_TRACE_PROPAGATION_STYLE_INJECT": [
       {
         "default": "datadog,tracecontext,baggage",
-        "implementation": "A",
-        "type": "ARRAY"
+        "implementation": "D",
+        "type": "array"
       }
     ],
     "DD_TRACE_RATE_LIMIT": [
       {
         "default": "100",
         "implementation": "A",
-        "type": "DECIMAL"
+        "type": "int"
       }
     ],
     "DD_TRACE_REPORT_HOSTNAME": [
       {
-        "default": "0",
+        "default": "false",
         "implementation": "A",
-        "type": "BOOLEAN"
+        "type": "boolean"
       }
     ],
     "DD_TRACE_RESOURCE_RENAMING_ALWAYS_SIMPLIFIED_ENDPOINT": [
       {
-        "default": "0",
+        "default": "false",
         "implementation": "A",
-        "type": "BOOLEAN"
+        "type": "boolean"
       }
     ],
     "DD_TRACE_RESOURCE_RENAMING_ENABLED": [
       {
-        "default": "0",
+        "default": "false",
         "implementation": "A",
-        "type": "BOOLEAN"
+        "type": "boolean"
       }
     ],
     "DD_TRACE_SAMPLE_RATE": [
       {
         "default": "1",
-        "implementation": "A",
-        "type": "DECIMAL"
+        "implementation": "C",
+        "type": "decimal"
       }
     ],
     "DD_TRACE_SAMPLING_RULES": [
       {
         "default": "[]",
-        "implementation": "A",
-        "type": "ARRAY"
+        "implementation": "D",
+        "type": "array"
       }
     ],
     "DD_TRACE_STARTUP_LOGS": [
       {
-        "default": "1",
-        "implementation": "A",
-        "type": "BOOLEAN"
+        "default": "true",
+        "implementation": "C",
+        "type": "boolean"
       }
     ],
     "DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH": [
       {
         "default": "512",
         "implementation": "A",
-        "type": "INT"
+        "type": "int"
       }
     ],
     "DD_VERSION": [
       {
         "default": "",
         "implementation": "A",
-        "type": "STRING"
+        "type": "string"
       }
     ]
   },

--- a/tools/config-inversion/main.cpp
+++ b/tools/config-inversion/main.cpp
@@ -1,49 +1,93 @@
 #include <cxxopts.hpp>
-#include <filesystem>
+#include <cctype>
 #include <fstream>
 #include <iostream>
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <string>
+#include <type_traits>
 
 #include "datadog/environment.h"
 
-namespace fs = std::filesystem;
-namespace env = datadog::tracing::environment;
+std::string lowercase(std::string value) {
+  for (char& ch : value) {
+    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  }
+  return value;
+}
 
 template <typename T>
-std::string to_string_any(const T& value) {
+nlohmann::json json_default_value(const std::string& type, const char* raw_token,
+                                  const T& value) {
+  using Value = std::decay_t<T>;
+
+  if constexpr (std::is_same_v<Value, std::nullptr_t>) {
+    return nullptr;
+  }
+
+  if (type == "decimal") {
+    return raw_token;
+  }
+
+  if constexpr (std::is_same_v<Value, bool>) {
+    return value ? "true" : "false";
+  }
+
   std::ostringstream oss;
   oss << value;
   return oss.str();
 }
 
+nlohmann::json load_existing_supported_configurations() {
+  std::ifstream file("supported-configurations.json", std::ios::binary);
+  nlohmann::json json;
+  file >> json;
+  const auto it = json.find("supportedConfigurations");
+  return it != json.end() && it->is_object() ? *it : nlohmann::json::object();
+}
+
+std::string preserved_implementation(
+    const nlohmann::json& supported_configurations, const char* name) {
+  const auto it = supported_configurations.find(name);
+  if (it == supported_configurations.end() || !it->is_array() || it->empty() ||
+      !(*it)[0].is_object()) {
+    return "A";
+  }
+
+  return (*it)[0].value("implementation", "A");
+}
+
 nlohmann::json build_configuration() {
-  nlohmann::json j;
-  j["version"] = "2";
+  const auto existing_supported_configurations =
+      load_existing_supported_configurations();
 
   auto supported_configurations = nlohmann::json::object();
 
 #define QUOTED_IMPL(ARG) #ARG
 #define QUOTED(ARG) QUOTED_IMPL(ARG)
+#define RAW_QUOTED(ARG) #ARG
 
 #define ENV_DEFAULT_RESOLVED_IN_CODE(X) ""
 
-#define X(NAME, TYPE, DEFAULT_VALUE)                                       \
-  do {                                                                     \
-    auto obj = nlohmann::json::object();                                   \
-    obj["default"] = to_string_any(DEFAULT_VALUE);                         \
-    obj["implementation"] = "A";                                           \
-    obj["type"] = QUOTED(TYPE);                                            \
-    supported_configurations[QUOTED(NAME)] = nlohmann::json::array({obj}); \
+#define X(NAME, TYPE, DEFAULT_VALUE)                                           \
+  do {                                                                         \
+    const auto type = lowercase(QUOTED(TYPE));                                 \
+    supported_configurations[QUOTED(NAME)] = nlohmann::json::array({           \
+        {{"default",                                                           \
+          json_default_value(type, RAW_QUOTED(DEFAULT_VALUE), DEFAULT_VALUE)}, \
+         {"implementation",                                                    \
+          preserved_implementation(existing_supported_configurations,          \
+                                   QUOTED(NAME))},                             \
+         {"type", type}}});                                                    \
   } while (0);
 
   DD_LIST_ENVIRONMENT_VARIABLES(X)
 #undef X
 #undef ENV_DEFAULT_RESOLVED_IN_CODE
+#undef RAW_QUOTED
 
-  j["supportedConfigurations"] = supported_configurations;
-
-  return j;
+  return {{"supportedConfigurations", std::move(supported_configurations)},
+          {"version", "2"}};
 }
 
 int main(int argc, char** argv) {
@@ -55,22 +99,19 @@ int main(int argc, char** argv) {
                         "Location where the JSON file will be written",
                         cxxopts::value<std::string>())("h,help", "Print usage");
 
-  auto result = options.parse(argc, argv);
-
+  const auto result = options.parse(argc, argv);
   if (result.count("output-file") == 0 || result.count("help")) {
     std::cout << options.help() << std::endl;
     return 0;
   }
 
-  const fs::path output_file = result["output-file"].as<std::string>();
-
-  const auto j = build_configuration();
-  std::ofstream file(output_file, std::ios::binary);
+  const auto output = build_configuration().dump(2);
+  std::ofstream file(result["output-file"].as<std::string>(), std::ios::binary);
   if (!file) {
     std::cerr << "Unable to write configuration file";
     return 1;
   }
 
-  file << j.dump(2);
+  file << output;
   return 0;
 }


### PR DESCRIPTION
The backfilled option showed some issue with the current state of
the supported-configurations.json. This is fixed by this PR by
adding setting backfilled to true as well as updating the generation
script to:
- lower case types
- use true and false as boolean
- use exact decimal values as defined in the macro

In addition, change DD_TRACE_RATE_LIMIT and
DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL decimal types to integers.

Some default values were changed from an empty string to `nullptr`, since
that seemed more suitable for these entries.

The script now also preserves the former implementation used.