### PR TITLE
chore(ci): use dd-sts for system-tests test optimization

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -210,4 +210,3 @@ jobs:
       parametric_job_count: 8  # dedicated parameter to speed up parametric job
       scenarios: PARAMETRIC
       push_to_test_optimization: true
-      dd_sts_policy: dd-trace-cpp-system-tests

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -197,7 +197,7 @@ jobs:
 
   system-tests:
     needs: build-system-tests-artifact
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
     secrets:
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY }}
     permissions:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -201,9 +201,7 @@ jobs:
     secrets:
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY }}
     permissions:
-      contents: read
       id-token: write
-      packages: write
     with:
       library: cpp
       binaries_artifact: system_tests_binaries

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -202,6 +202,7 @@ jobs:
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY }}
     permissions:
       contents: read
+      id-token: write
       packages: write
     with:
       library: cpp
@@ -209,3 +210,4 @@ jobs:
       parametric_job_count: 8  # dedicated parameter to speed up parametric job
       scenarios: PARAMETRIC
       push_to_test_optimization: true
+      dd_sts_policy: dd-trace-cpp-system-tests

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -205,6 +205,7 @@ jobs:
       id-token: write
     with:
       library: cpp
+      ref: 1e5d6b7096279ca43ce4826fda3cc805635b63c1
       binaries_artifact: system_tests_binaries
       parametric_job_count: 8  # dedicated parameter to speed up parametric job
       scenarios: PARAMETRIC

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -201,6 +201,7 @@ jobs:
     secrets:
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY }}
     permissions:
+      contents: read
       id-token: write
     with:
       library: cpp


### PR DESCRIPTION
## Summary

Migrates system-tests CI to use [dd-sts](https://github.com/DataDog/dd-sts-action) for Datadog Test Optimization instead of long-lived API keys.

All repositories now share a single `system-tests` policy (see [dd-source#408172](https://github.com/DataDog/dd-source/pull/408172)) — no per-repo policy is needed.

Depends on [DataDog/system-tests#6726](https://github.com/DataDog/system-tests/pull/6726).

### Changes
- Add `id-token: write` permission to the system-tests reusable workflow call so it can obtain short-lived credentials via OIDC
- Pin system-tests to `1e5d6b709` (current `main`, pre-migration) to allow a controlled rollout: repos stay on the pre-migration workflow until their pin is explicitly updated to the post-merge SHA

## How to review

The only functional change is adding `id-token: write`. It has no effect at the pinned SHA (dd-sts is not yet used there) but will be required once each repo's pin is updated after [DataDog/system-tests#6726](https://github.com/DataDog/system-tests/pull/6726) merges.