### PR TITLE
fix: use parentheses for signature_ init to match existing style

### DIFF
--- a/include/datadog/tracer_config.h
+++ b/include/datadog/tracer_config.h
@@ -141,6 +141,11 @@ struct TracerConfig {
   // specify the same `runtime_id` for all tracer instances in the same run.
   Optional<RuntimeID> runtime_id;
 
+  // Root session ID for stable telemetry correlation across forked workers.
+  // Integrations (nginx, httpd, kong) should set this in the master process
+  // before workers fork so all Tracers share the same root.
+  Optional<std::string> root_session_id;
+
   // `integration_name` is the name of the product integrating this library.
   // Example: "nginx", "envoy" or "istio".
   Optional<std::string> integration_name;
@@ -188,11 +193,6 @@ struct TracerConfig {
   // present. This is disabled by default.
   // This option is ignored if `resource_renaming_enabled` is not `true`.
   Optional<bool> resource_renaming_always_simplified_endpoint;
-
-  // Root session ID for stable telemetry correlation across forked workers.
-  // Integrations (nginx, httpd, kong) should set this in the master process
-  // before workers fork so all Tracers share the same root.
-  Optional<std::string> root_session_id;
 
   /// A mapping of process-specific tags used to uniquely identify processes.
   ///

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -49,10 +49,10 @@ Tracer::Tracer(const FinalizedTracerConfig& config,
     : logger_(config.logger),
       runtime_id_(config.runtime_id ? *config.runtime_id
                                     : RuntimeID::generate()),
-      signature_{runtime_id_,
+      signature_(runtime_id_,
                  root_session_id::get_or_init(
                      config.root_session_id.value_or(runtime_id_.string())),
-                 config.defaults.service, config.defaults.environment},
+                 config.defaults.service, config.defaults.environment),
       config_manager_(std::make_shared<ConfigManager>(config)),
       collector_(/* see constructor body */),
       span_sampler_(


### PR DESCRIPTION
Followup from #295 review feedback.

Changes `signature_{...}` to `signature_(...)` in the Tracer constructor member init list to match the parentheses style used by all other members (`logger_(...)`, `runtime_id_(...)`, etc.) & moves up root_session_id to be after runtime_id in tracer config

Ref: https://github.com/DataDog/dd-trace-cpp/pull/295#discussion_r3046662390