### PR TITLE
ci: unpin system-tests (back to @main)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -197,7 +197,7 @@ jobs:
 
   system-tests:
     needs: build-system-tests-artifact
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
     secrets:
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY }}
     permissions:
@@ -205,7 +205,6 @@ jobs:
       id-token: write
     with:
       library: cpp
-      ref: 1e5d6b7096279ca43ce4826fda3cc805635b63c1
       binaries_artifact: system_tests_binaries
       parametric_job_count: 8  # dedicated parameter to speed up parametric job
       scenarios: PARAMETRIC


### PR DESCRIPTION
Remove temporary system-tests pin (1e5d6b7 → @main) to activate dd-sts test optimization.