### PR TITLE
Bump version to 2.1.0, and fix ksr formatting

### DIFF
--- a/include/datadog/version.h
+++ b/include/datadog/version.h
@@ -2,8 +2,7 @@
 
 // This component provides the release version of this library.
 
-namespace datadog {
-namespace tracing {
+namespace datadog::tracing {
 
 // The release version at or before this code revision, e.g. "v0.1.12".
 // That is, this code is at least as recent as `tracer_version`, but may be
@@ -15,5 +14,4 @@ extern const char *const tracer_version;
 // version v0.1.12]".
 extern const char *const tracer_version_string;
 
-}  // namespace tracing
-}  // namespace datadog
+}  // namespace datadog::tracing

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -31,8 +31,8 @@
 #include "trace_sampler.h"
 #include "w3c_propagation.h"
 
-namespace datadog {
-namespace tracing {
+namespace datadog::tracing {
+
 namespace {
 
 struct Cache {
@@ -109,7 +109,37 @@ void maybe_calculate_http_endpoint(HttpEndpointCalculationMode renaming_mode,
     }
   }
 }
-}  // namespace
+
+// Convert rate to a fixed-point string with 6 decimal digits,
+// stripping trailing zeros and a decimal point. Examples:
+//   0.100000 -> "0.1"
+//   0.123456789 -> "0.123456"
+//   1.0 -> "1"
+Optional<std::string> format_rate(double rate, Logger& logger) {
+  constexpr int nb_decimal_digits = 6;
+  std::array<char, nb_decimal_digits + 2> buf;
+  char* const begin = buf.data();
+  auto [end, error_code] =
+      std::to_chars(begin, begin + buf.size(), rate, std::chars_format::fixed,
+                    nb_decimal_digits);
+  if (error_code != std::errc()) {
+    logger.log_error("rate to string conversion failed: " +
+                     std::make_error_code(error_code).message());
+    return nullopt;
+  }
+  // strip trailing zeros and possibly the decimal point
+  if (std::find(begin, end, '.') != end) {
+    while ((end > begin) && (*(end - 1) == '0')) {
+      --end;
+    }
+    if ((end > begin) && (*(end - 1) == '.')) {
+      --end;
+    }
+  }
+  return std::string(begin, end);
+}
+
+}  // anonymous namespace
 
 TraceSegment::TraceSegment(
     const std::shared_ptr<Logger>& logger,
@@ -322,22 +352,17 @@ void TraceSegment::make_sampling_decision_if_null() {
 
   update_decision_maker_trace_tag();
 
-  // Only set ksr when the sampling mechanism is explicit (agent rate, rule, or
-  // remote rule).  The DEFAULT mechanism means we haven't received any
-  // configuration from the agent yet, so ksr would be meaningless.
+  // Only set ksr when the sampling mechanism is explicit.
+  // The DEFAULT mechanism means we haven't received any configuration from the
+  // agent yet, so ksr would be meaningless.
   if (sampling_decision_->mechanism &&
-      *sampling_decision_->mechanism != int(SamplingMechanism::DEFAULT)) {
-    std::array<char, 8> buf;
-    const auto [ptr, ec] = std::to_chars(buf.data(), buf.data() + buf.size(),
-                                         *sampling_decision_->configured_rate,
-                                         std::chars_format::general, 6);
-    if (ec != std::errc()) {
-      std::string error{"string conversion failed: "};
-      error += std::make_error_code(ec).message();
-      logger_->log_error(error);
+      (*sampling_decision_->mechanism != int(SamplingMechanism::DEFAULT))) {
+    const Optional<std::string> rate_string =
+        format_rate(*sampling_decision_->configured_rate, *logger_);
+    if (!rate_string) {
       return;
     }
-    trace_tags_.emplace_back(tags::internal::ksr, std::string(buf.data(), ptr));
+    trace_tags_.emplace_back(tags::internal::ksr, *rate_string);
   }
 }
 
@@ -481,5 +506,4 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
 
 SpanData& TraceSegment::local_root() const { return *spans_.front(); }
 
-}  // namespace tracing
-}  // namespace datadog
+}  // namespace datadog::tracing

--- a/src/datadog/version.cpp
+++ b/src/datadog/version.cpp
@@ -1,13 +1,11 @@
 #include <datadog/version.h>
 
-namespace datadog {
-namespace tracing {
+namespace datadog::tracing {
 
-#define DD_TRACE_VERSION "v2.0.1"
+#define DD_TRACE_VERSION "v2.1.0"
 
 const char* const tracer_version = DD_TRACE_VERSION;
 const char* const tracer_version_string =
     "[dd-trace-cpp version " DD_TRACE_VERSION "]";
 
-}  // namespace tracing
-}  // namespace datadog
+}  // namespace datadog::tracing

--- a/test/test_trace_segment.cpp
+++ b/test/test_trace_segment.cpp
@@ -401,11 +401,8 @@ TEST_CASE("TraceSegment finalization of spans") {
         const auto& span = collector->first_span();
         REQUIRE(span.numeric_tags.at(tags::internal::rule_sample_rate) ==
                 sample_rate);
-        {
-          char buf[32];
-          std::snprintf(buf, sizeof(buf), "%.6g", sample_rate);
-          CHECK(span.tags.at(tags::internal::ksr) == std::string(buf));
-        }
+        CHECK(span.tags.at(tags::internal::ksr) ==
+              (sample_rate == 0.0 ? "0" : "1"));
         if (sample_rate == 1.0) {
           REQUIRE(span.numeric_tags.at(
                       tags::internal::rule_limiter_sample_rate) == 1.0);


### PR DESCRIPTION
In order to prepare a delivery, bump version to `2.1.0`, because there are functional changes since the latest release, https://github.com/DataDog/dd-trace-cpp/releases/tag/v2.0.0 (from October 14th, 2025).


By the way, I had to fix the formatting of the Knuth sampling rate (`_dd.p.ksr`) to fixed, with maximum 6 decimal digits and no trailing decimal zeros.
This was recently (on March 12th) modified by https://github.com/DataDog/dd-trace-cpp/pull/288.
But we just got new failures from system tests. See [this failed CI job](https://github.com/DataDog/dd-trace-cpp/actions/runs/25376293971/job/74416829164?pr=314):
```
Expected _dd.p.ksr='0.000001', got: 1e-06
Expected _dd.p.ksr='0', got: 1e-07
Expected _dd.p.ksr='0.000001', got: 5.1e-07
```