### PR TITLE
ci: adding scheduled runs for system-tests

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -200,8 +200,6 @@ jobs:
   system-tests:
     needs: build-system-tests-artifact
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
-    secrets:
-      TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
 name: "Main"
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,15 +45,3 @@ jobs:
         with:
           binary: ./.build/fuzz/remote-configuration/remote-config-fuzz
           duration_seconds: ${DURATION_SEC}
-
-  system-tests:
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
-    permissions:
-      contents: read
-      id-token: write
-    with:
-      library: cpp
-      parametric_job_count: 8  # dedicated parameter to speed up parametric job
-      scenarios: PARAMETRIC
-      _system_tests_dev_mode: true
-      push_to_test_optimization: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: "Main"
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,3 +45,14 @@ jobs:
           binary: ./.build/fuzz/remote-configuration/remote-config-fuzz
           duration_seconds: ${DURATION_SEC}
 
+  system-tests:
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      library: cpp
+      parametric_job_count: 8  # dedicated parameter to speed up parametric job
+      scenarios: PARAMETRIC
+      _system_tests_dev_mode: true
+      push_to_test_optimization: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,3 +44,4 @@ jobs:
         with:
           binary: ./.build/fuzz/remote-configuration/remote-config-fuzz
           duration_seconds: ${DURATION_SEC}
+


### PR DESCRIPTION
# Description

The system-tests workflow now handles all the authentification with the datadog backend using dd-sts. The relevant policy can be found [here](https://github.com/DataDog/dd-source/blob/main/domains/seceng/sit/apps/apis/dd-sts/config/policies/us1.ddbuild.io/system-tests.yaml).

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
