### PR TITLE
Fix call-dev-workflow CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
   fuzz-testing:
     needs: call-dev-workflow


### PR DESCRIPTION
Since April 14th, the `call-dev-workflow` GitHub CI job [fails with the following error](https://github.com/DataDog/dd-trace-cpp/actions/runs/24435680988):
```
[Invalid workflow file: .github/workflows/main.yml#L11](https://github.com/DataDog/dd-trace-cpp/actions/runs/[…]]/workflow)
The workflow is not valid. .github/workflows/main.yml (Line: 11, Col: 3):
Error calling workflow 'DataDog/dd-trace-cpp/.github/workflows/dev.yml@[…]'.
The nested job 'system-tests' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

This comes from #306, which switched system-tests from `packages: write` to `id-token: write` for [dd-sts](https://github.com/DataDog/dd-sts-action) OIDC authentication.

PR pipelines were unaffected because `dev.yml` has no top-level permissions and inherits the default `GITHUB_TOKEN` scopes, but `main.yml` explicitly lists permissions on its `call-dev-workflow` job, so any unlisted scope defaults to none. This PR adds `id-token: write` for `call-dev-workflow`.