### PR TITLE
Bump version following delivery of v2.1.0

### DIFF
--- a/src/datadog/version.cpp
+++ b/src/datadog/version.cpp
@@ -2,7 +2,7 @@
 
 namespace datadog::tracing {
 
-#define DD_TRACE_VERSION "v2.1.0"
+#define DD_TRACE_VERSION "v2.1.1"
 
 const char* const tracer_version = DD_TRACE_VERSION;
 const char* const tracer_version_string =


### PR DESCRIPTION
Following the [delivery of v2.1.0](https://github.com/DataDog/dd-trace-cpp/releases/tag/v2.1.0), bump the version.