### PR TITLE
Don't use metal runners for non-benchmarking jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ include:
 validate_supported_configurations_v2_local_file:
   stage: config-validation
   image: registry.ddbuild.io/ci/libdatadog-build/packaging:100425777
-  tags: ["runner:amd/arch64"]
+  tags: ["arch:amd64"]
   rules:
     - when: on_success
   extends: .validate_supported_configurations_v2_local_file
@@ -26,7 +26,7 @@ validate_supported_configurations_v2_local_file:
 update_central_configurations_version_range_v2:
   stage: config-validation
   image: registry.ddbuild.io/ci/libdatadog-build/packaging:100425777
-  tags: ["runner:amd/arch64"]
+  tags: ["arch:amd64"]
   extends: .update_central_configurations_version_range_v2
   variables:
     LOCAL_REPO_NAME: "dd-trace-cpp"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ include:
 validate_supported_configurations_v2_local_file:
   stage: config-validation
   image: registry.ddbuild.io/ci/libdatadog-build/packaging:100425777
-  tags: ["runner:apm-k8s-tweaked-metal"]
+  tags: ["runner:amd/arch64"]
   rules:
     - when: on_success
   extends: .validate_supported_configurations_v2_local_file
@@ -26,7 +26,7 @@ validate_supported_configurations_v2_local_file:
 update_central_configurations_version_range_v2:
   stage: config-validation
   image: registry.ddbuild.io/ci/libdatadog-build/packaging:100425777
-  tags: ["runner:apm-k8s-tweaked-metal"]
+  tags: ["runner:amd/arch64"]
   extends: .update_central_configurations_version_range_v2
   variables:
     LOCAL_REPO_NAME: "dd-trace-cpp"


### PR DESCRIPTION
We should not use metal runners for non-benchmarking jobs.

[APMSP-2972 Ensure non-benchmarking dd-trace-cpp jobs don't use metal runners](https://datadoghq.atlassian.net/browse/APMSP-2972)