### PR TITLE
Get dd_trace_agent_url from Tracer configuration for meaningful System Tests

### DIFF
--- a/test/system-tests/request_handler.cpp
+++ b/test/system-tests/request_handler.cpp
@@ -69,7 +69,7 @@ void RequestHandler::on_trace_config(const httplib::Request& /* req */,
     {"config", {
       {"dd_service", tracer_cfg["defaults"]["service"]},
       {"dd_env", tracer_cfg["defaults"]["environment"]},
-      {"dd_version", tracer_cfg["environment_variables"]["version"]},
+      {"dd_version", tracer_cfg["defaults"]["version"]},
       {"dd_trace_enabled", tracer_cfg["environment_variables"]["report_traces"]},
       {"dd_trace_agent_url", agent_url}
     }}

--- a/test/system-tests/request_handler.cpp
+++ b/test/system-tests/request_handler.cpp
@@ -12,6 +12,21 @@
 #include "httplib.h"
 #include "utils.h"
 
+namespace {
+
+std::string get_agent_url_from_traces_url(std::string traces_url) {
+  // Strip the API path from the traces URL to get the agent URL
+  constexpr std::string_view traces_api_path = "/v0.4/traces";
+  if (traces_url.size() >= traces_api_path.size() &&
+      traces_url.compare(traces_url.size() - traces_api_path.size(),
+                         traces_api_path.size(), traces_api_path) == 0) {
+    traces_url.resize(traces_url.size() - traces_api_path.size());
+  }
+  return traces_url;
+}
+
+} // namespace
+
 RequestHandler::RequestHandler(
     datadog::tracing::FinalizedTracerConfig& tracerConfig,
     std::shared_ptr<ManualScheduler> scheduler,
@@ -47,17 +62,18 @@ void RequestHandler::on_trace_config(const httplib::Request& /* req */,
                                      httplib::Response& res) {
   auto tracer_cfg = nlohmann::json::parse(tracer_.config());
 
+  const std::string agent_url = get_agent_url_from_traces_url(tracer_cfg["collector"]["config"]["traces_url"]);
+
   // clang-format off
-    auto response_body = nlohmann::json{
-      { "config", {
-          { "dd_service", tracer_cfg["defaults"]["service"]},
-          { "dd_env", tracer_cfg["defaults"]["environment"]},
-          { "dd_version", tracer_cfg["environment_variables"]["version"]},
-          { "dd_trace_enabled", tracer_cfg["environment_variables"]["report_traces"]},
-          { "dd_trace_agent_url", tracer_cfg["environment_variables"]["DD_TRACE_AGENT_URL"]}
-        }
-      }
-    };
+  auto response_body = nlohmann::json{
+    {"config", {
+      {"dd_service", tracer_cfg["defaults"]["service"]},
+      {"dd_env", tracer_cfg["defaults"]["environment"]},
+      {"dd_version", tracer_cfg["environment_variables"]["version"]},
+      {"dd_trace_enabled", tracer_cfg["environment_variables"]["report_traces"]},
+      {"dd_trace_agent_url", agent_url}
+    }}
+  };
   // clang-format on
 
   if (tracer_cfg.contains("trace_sampler")) {

--- a/test/system-tests/request_handler.cpp
+++ b/test/system-tests/request_handler.cpp
@@ -16,6 +16,7 @@ namespace {
 
 std::string get_agent_url_from_traces_url(std::string traces_url) {
   // Strip the API path from the traces URL to get the agent URL
+  // This API path is defined in src/datadog/datadog_agent.cpp.
   constexpr std::string_view traces_api_path = "/v0.4/traces";
   if (traces_url.size() >= traces_api_path.size() &&
       traces_url.compare(traces_url.size() - traces_api_path.size(),
@@ -25,7 +26,7 @@ std::string get_agent_url_from_traces_url(std::string traces_url) {
   return traces_url;
 }
 
-} // namespace
+}  // namespace
 
 RequestHandler::RequestHandler(
     datadog::tracing::FinalizedTracerConfig& tracerConfig,
@@ -62,7 +63,8 @@ void RequestHandler::on_trace_config(const httplib::Request& /* req */,
                                      httplib::Response& res) {
   auto tracer_cfg = nlohmann::json::parse(tracer_.config());
 
-  const std::string agent_url = get_agent_url_from_traces_url(tracer_cfg["collector"]["config"]["traces_url"]);
+  const std::string agent_url = get_agent_url_from_traces_url(
+      tracer_cfg["collector"]["config"]["traces_url"]);
 
   // clang-format off
   auto response_body = nlohmann::json{

--- a/test/system-tests/request_handler.cpp
+++ b/test/system-tests/request_handler.cpp
@@ -70,7 +70,7 @@ void RequestHandler::on_trace_config(const httplib::Request& /* req */,
       {"dd_service", tracer_cfg["defaults"]["service"]},
       {"dd_env", tracer_cfg["defaults"]["environment"]},
       {"dd_version", tracer_cfg["defaults"]["version"]},
-      {"dd_trace_enabled", tracer_cfg["environment_variables"]["report_traces"]},
+      {"dd_trace_enabled", tracer_cfg["report_traces"]},
       {"dd_trace_agent_url", agent_url}
     }}
   };


### PR DESCRIPTION
# Motivation

The `dd_trace_agent_url`, `dd_version` and `dd_trace_enabled` values checked by System Tests used to be simply read from the environment variables, so leading to quite dummy tests! Now they are read from the Tracer configuration, to really test if it behaves as expected.

# Additional Notes

Jira ticket: [IDMPL-380 Really test agent URL parsing](https://datadoghq.atlassian.net/browse/IDMPL-380).
