### PR TITLE
Place _dd.apm.enabled:0 in every span

### DIFF
--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -332,11 +332,6 @@ void TraceSegment::span_finished() {
   for (const auto& span_ptr : spans_) {
     SpanData& span = *span_ptr;
     if (!tracing_enabled_) {
-      // RFC seems to only mandate that this be set if the trace is kept.
-      // However, system-tests expect this to always be set.
-      // Add it all the time; can't hurt
-      // Following incident-57980, go beyond the RFC and add it to every span so
-      // that every trace chunk is marked.
       span.numeric_tags[tags::internal::apm_enabled] = 0;
     }
     if (origin_) {

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -328,16 +328,17 @@ void TraceSegment::span_finished() {
     }
   }
 
-  // RFC seems to only mandate that this be set if the trace is kept.
-  // However, system-tests expect this to always be set.
-  // Add it all the time; can't hurt
-  if (!tracing_enabled_) {
-    local_root.numeric_tags[tags::internal::apm_enabled] = 0;
-  }
-
   // Some tags are repeated on all spans.
   for (const auto& span_ptr : spans_) {
     SpanData& span = *span_ptr;
+    if (!tracing_enabled_) {
+      // RFC seems to only mandate that this be set if the trace is kept.
+      // However, system-tests expect this to always be set.
+      // Add it all the time; can't hurt
+      // Following incident-57980, go beyond the RFC and add it to every span so
+      // that every trace chunk is marked.
+      span.numeric_tags[tags::internal::apm_enabled] = 0;
+    }
     if (origin_) {
       span.tags[tags::internal::origin] = *origin_;
     }

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -2118,6 +2118,29 @@ TEST_TRACER("move semantics") {
   (void)tracer2;
 }
 
+TEST_TRACER("APM tracing enabled") {
+  TracerConfig config;
+  config.service = "testsvc";
+  config.name = "test.op";
+  const std::shared_ptr<MockCollector> collector =
+      std::make_shared<MockCollector>();
+  config.collector = collector;
+  config.logger = std::make_shared<NullLogger>();
+  config.tracing_enabled = true;
+
+  Expected<FinalizedTracerConfig> finalized_config = finalize_config(config);
+  REQUIRE(finalized_config);
+  Tracer tracer{*finalized_config};
+
+  tracer.create_span();
+
+  REQUIRE(collector->chunks.size() == 1);
+  REQUIRE(collector->chunks.front().size() == 1);
+  const SpanData& span = *collector->chunks.front().front();
+  // tracing needs to be disabled for this tag to be set
+  CHECK(span.numeric_tags.count(tags::internal::apm_enabled) == 0);
+}
+
 TEST_TRACER("APM tracing disabled") {
   TracerConfig config;
   config.service = "testsvc";
@@ -2131,7 +2154,8 @@ TEST_TRACER("APM tracing disabled") {
   auto clock = [&current_time]() { return current_time; };
 
   SECTION("_dd.apm.enabled is added to every span") {
-    auto finalized_config = finalize_config(config, clock);
+    Expected<FinalizedTracerConfig> finalized_config =
+        finalize_config(config, clock);
     REQUIRE(finalized_config);
     Tracer tracer{*finalized_config};
 
@@ -2139,11 +2163,9 @@ TEST_TRACER("APM tracing disabled") {
     service_entry_config.service = "child-service";
 
     {
-      auto root = tracer.create_span();
-      auto child = root.create_child();
-      auto service_entry = root.create_child(service_entry_config);
-      (void)child;
-      (void)service_entry;
+      Span root = tracer.create_span();
+      root.create_child();
+      root.create_child(service_entry_config);
     }
 
     REQUIRE(collector->chunks.size() == 1);

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -2130,6 +2130,30 @@ TEST_TRACER("APM tracing disabled") {
   TimePoint current_time = default_clock();
   auto clock = [&current_time]() { return current_time; };
 
+  SECTION("_dd.apm.enabled is added to every span") {
+    auto finalized_config = finalize_config(config, clock);
+    REQUIRE(finalized_config);
+    Tracer tracer{*finalized_config};
+
+    SpanConfig service_entry_config;
+    service_entry_config.service = "child-service";
+
+    {
+      auto root = tracer.create_span();
+      auto child = root.create_child();
+      auto service_entry = root.create_child(service_entry_config);
+      (void)child;
+      (void)service_entry;
+    }
+
+    REQUIRE(collector->chunks.size() == 1);
+    const auto& chunk = collector->chunks.front();
+    REQUIRE(chunk.size() == 3);
+    for (const auto& span : chunk) {
+      CHECK(span->numeric_tags.at(tags::internal::apm_enabled) == 0);
+    }
+  }
+
   SECTION("sampling behaviour") {
     SECTION("span with _dd.p.ts is kept") {
       auto finalized_config = finalize_config(config, clock);


### PR DESCRIPTION
# Description

Although the RFC says otherwise (only to place it on the first span in the chunk), this is the safest way to ensure `_dd.apm.enabled` is encountered during processing and was the consensus decision following an incident.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
