### PR TITLE
Fix README shared-library link flag (-ldd_trace_cpp -> -ldd-trace-cpp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ c++ -I/path/to/dd-trace-cpp/.install/include -c -o my_app.o my_app.cpp
 ```
 
 When linking an executable that uses `dd-trace-cpp`, specify linkage to the
-built library using the `-ldd_trace_cpp` option and an appropriate `-L` option.
+built library using the `-ldd-trace-cpp` option and an appropriate `-L` option.
 If the library was installed into the default system directories, then the `-L`
-options is not needed. The `-ldd_trace_cpp` option is always needed.
+options is not needed. The `-ldd-trace-cpp` option is always needed.
 
 ```shell
-c++ -o my_app my_app.o -L/path/to/dd-trace-cpp/.install/lib -ldd_trace_cpp
+c++ -o my_app my_app.o -L/path/to/dd-trace-cpp/.install/lib -ldd-trace-cpp
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary
- The Dynamic Linking section of the README instructs linking with `-ldd_trace_cpp` (underscore), but `CMakeLists.txt` sets `OUTPUT_NAME "dd-trace-cpp"` (hyphen) for both the shared and static library targets.
- The installed file is actually `libdd-trace-cpp.so`/`libdd-trace-cpp.a`, so following the README's `-ldd_trace_cpp` instruction as written fails at link time (`ld: cannot find -ldd_trace_cpp`) / `find_library` can't locate it under that name.
- Updated the two link-flag mentions and the example command to use `-ldd-trace-cpp`.

## Test plan
- Docs-only change; verified the corrected flag matches `OUTPUT_NAME "dd-trace-cpp"` in `CMakeLists.txt` and manually confirmed `cmake --install` produces `libdd-trace-cpp.so` on a fresh build.

Recreates #340 from a branch on this repository (instead of a fork) at @xlamorlette-datadog's request, so CI runs correctly.

Made with [Cursor](https://cursor.com)