### PR TITLE
Fix cmake install missing http_endpoint_calculation_mode.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ target_sources(dd-trace-cpp-objects
       include/datadog/event_scheduler.h
       include/datadog/expected.h
       include/datadog/http_client.h
+      include/datadog/http_endpoint_calculation_mode.h
       include/datadog/id_generator.h
       include/datadog/injection_options.h
       include/datadog/logger.h


### PR DESCRIPTION
## Summary

- `tracer_config.h` (a public header) includes `http_endpoint_calculation_mode.h`, but that file is missing from the `public_headers` `FILE_SET` list in `CMakeLists.txt`.
- As a result, `cmake --install` never copies `http_endpoint_calculation_mode.h` to the install prefix's `include/datadog/` directory, even though the file exists in the source tree.
- Anyone building from source and installing per the README's manual build instructions gets a fatal compile error on anything that includes `tracer.h`/`tracer_config.h`:
  ```
  fatal error: http_endpoint_calculation_mode.h: No such file or directory
  ```
- Added the missing entry to the `FILE_SET` list, alphabetically placed next to the other `http_*` header.

Recreated from #341, which was opened from a fork; this one is opened from a branch on the main repo instead.

## Test plan

- Confirmed by diffing the `FILES` list in `CMakeLists.txt` against the actual contents of `include/datadog/` in the source tree — this was the only header present in the tree but absent from the list.
- Hit this exact error downstream while building a lab exercise against a manually-built/installed v2.1.1: `cmake -B build . && cmake --build build -j && cmake --install build`, then compiling a file that includes `<datadog/tracer.h>` failed with the error above.

Made with [Cursor](https://cursor.com)