### PR TITLE
fixing dependabot PR CI

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -55,7 +55,7 @@ jobs:
       packages: read
     env:
       BUILD_DIR: .build
-      DD_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY }}
+      HAS_DD_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Configure
@@ -67,7 +67,9 @@ jobs:
         env:
           ASAN_OPTIONS: alloc_dealloc_mismatch=0
       - name: Upload test report to Datadog
-        if: success() || failure()
+        if: (success() || failure()) && env.HAS_DD_API_KEY == 'true'
+        env:
+          DD_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-${{ matrix.arch }}" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
           datadog-ci junit upload --service dd-trace-cpp --tags test.source.file:test/*.cpp .build/report.xml
@@ -137,7 +139,7 @@ jobs:
       contents: read
       packages: read
     env:
-      DD_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY }}
+      HAS_DD_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Dependency Manager (scoop)
@@ -157,7 +159,9 @@ jobs:
           & 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\Tools\\Launch-VsDevShell.ps1' -arch ${{ matrix.arch }}
           .\build\test\tests.exe -r junit -o report.xml
       - name: Upload test report to Datadog
-        if: success() || failure()
+        if: (success() || failure()) && env.HAS_DD_API_KEY == 'true'
+        env:
+          DD_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY }}
         run: |
           Invoke-WebRequest -Uri "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_win-x64" -OutFile "datadog-ci.exe"
           ./datadog-ci.exe junit upload --service dd-trace-cpp --tags test.source.file:test/*.cpp report.xml
@@ -172,10 +176,13 @@ jobs:
     permissions:
       contents: read
       packages: read
+    env:
+      HAS_DD_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: bin/test --coverage --verbose
       - name: Upload code coverage report to Datadog
+        if: success() && env.HAS_DD_API_KEY == 'true'
         # See https://github.com/DataDog/coverage-upload-github-action/releases
         uses: DataDog/coverage-upload-github-action@2ba057033351887422f8eb0203d1990c3acbc8c5 # v1.0.4
         with:


### PR DESCRIPTION
# Description

Skips Datadog test-report and coverage uploads when `DD_CI_VIS_API_KEY` is unavailable. Builds and tests still run, and JUnit uploads still run after a test failure when the key exists. The key itself is scoped to the upload steps.

# Motivation

GitHub does not expose Actions secrets to Dependabot or fork pull requests, and reusable workflows may be called without inherited secrets. These runs were failing after successful builds and tests because upload steps ran with an empty key.

# Additional Notes

Validated with actionlint and credential-condition checks.

Jira ticket: N/A