### PR TITLE
Bump version to v2.2.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "dd-trace-cpp",
-    version = "2.1.2",
+    version = "2.2.0",
 )
 
 bazel_dep(name = "abseil-cpp", version = "20260526.0", repo_name = "com_google_absl")

--- a/src/datadog/version.cpp
+++ b/src/datadog/version.cpp
@@ -3,7 +3,7 @@
 namespace datadog::tracing {
 
 #define DD_TRACE_LIBRARY_NAME "dd-trace-cpp"
-#define DD_TRACE_VERSION "v2.1.2"
+#define DD_TRACE_VERSION "v2.2.0"
 
 const char* const tracer_library_name = DD_TRACE_LIBRARY_NAME;
 const char* const tracer_version = DD_TRACE_VERSION;


### PR DESCRIPTION
# Description

As per title, bump version to `v2.2.0`.

# Motivation

Latest delivery, [v2.1.1](https://github.com/DataDog/dd-trace-cpp/releases/tag/v2.1.1), dates from June 19. Several features have been implemented since then.

# Additional Notes

Jira ticket: [IDMPL-758 [C++ Tracer] [Delivery] Deliver C++ Tracer v2.2.0](https://datadoghq.atlassian.net/browse/IDMPL-758).