### PR TITLE
Bump version to 2.2.1, following delivery of 2.2.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "dd-trace-cpp",
-    version = "2.2.0",
+    version = "2.2.1",
 )
 
 bazel_dep(name = "abseil-cpp", version = "20260526.0", repo_name = "com_google_absl")

--- a/src/datadog/version.cpp
+++ b/src/datadog/version.cpp
@@ -3,7 +3,7 @@
 namespace datadog::tracing {
 
 #define DD_TRACE_LIBRARY_NAME "dd-trace-cpp"
-#define DD_TRACE_VERSION "v2.2.0"
+#define DD_TRACE_VERSION "v2.2.1"
 
 const char* const tracer_library_name = DD_TRACE_LIBRARY_NAME;
 const char* const tracer_version = DD_TRACE_VERSION;


### PR DESCRIPTION
# Description

Following delivery of v2.2.0, bump the version to `v2.2.1`.

# Additional Notes

Jira ticket: [IDML-563 [C++ Tracer] [Delivery] Deliver C++ Tracer v2.2.0](https://datadoghq.atlassian.net/browse/IDMPL-758)
