### PR TITLE
For agent URL configuration, consider empty environment variables as unset

### DIFF
--- a/src/datadog/datadog_agent_config.cpp
+++ b/src/datadog/datadog_agent_config.cpp
@@ -10,12 +10,15 @@ namespace datadog::tracing {
 namespace {
 
 Optional<std::string> build_agent_url_from_environment_variables() {
-  if (Optional<StringView> url_env = lookup(environment::DD_TRACE_AGENT_URL)) {
+  Optional<StringView> url_env = lookup(environment::DD_TRACE_AGENT_URL);
+  if (url_env && !url_env->empty()) {
     return std::string{*url_env};
   }
 
   Optional<StringView> env_host = lookup(environment::DD_AGENT_HOST);
+  if (env_host && env_host->empty()) env_host = nullopt;
   Optional<StringView> env_port = lookup(environment::DD_TRACE_AGENT_PORT);
+  if (env_port && env_port->empty()) env_port = nullopt;
   if (env_host || env_port) {
     std::string agent_url = "http://";
     const StringView host = env_host.value_or("localhost");

--- a/test/test_tracer_config.cpp
+++ b/test/test_tracer_config.cpp
@@ -504,18 +504,18 @@ TRACER_CONFIG_TEST("TracerConfig::agent") {
       };
 
       auto test_case = GENERATE(values<TestCase>({
-          {"override host with default port", "dd-agent", nullopt, nullopt,
-           "http", "dd-agent:8126"},
-          {"override port and host", "dd-agent", "8080", nullopt, "http",
+          {"all defaults", nullopt, nullopt, nullopt, "http", "localhost:8126"},
+          {"override host", "dd-agent", nullopt, nullopt, "http",
+           "dd-agent:8126"},
+          {"override port", nullopt, "8080", nullopt, "http", "localhost:8080"},
+          {"override host and port", "dd-agent", "8080", nullopt, "http",
            "dd-agent:8080"},
-          {"override port with default host", nullopt, "8080", nullopt, "http",
-           "localhost:8080"},
+          {"empty URL", "dd-agent", "8080", "", "http", "dd-agent:8080"},
+          {"empty host", "", nullopt, nullopt, "http", "localhost:8126"},
+          {"empty port", nullopt, "", nullopt, "http", "localhost:8126"},
           {"IPv6 host", "::1", nullopt, nullopt, "http", "[::1]:8126"},
           {"IPv6 host with brackets", "[::1]", nullopt, nullopt, "http",
            "[::1]:8126"},
-          // A bogus port number will cause an error in the TCPClient, not
-          // during configuration. For the purposes of configuration, any
-          // value is accepted.
           {"we don't parse port", nullopt, "bogus", nullopt, "http",
            "localhost:bogus"},
           {"URL", nullopt, nullopt, "http://dd-agent:8080", "http",


### PR DESCRIPTION
# Description

When reading the `DD_TRACE_AGENT_URL`, `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` environment variables for the configuration of the agent, consider empty values as unset.

# Motivation

This was discovered when [activating the handling of IPv6 agent host addresses in System Tests](https://github.com/DataDog/system-tests/pull/7497). See [the error](https://github.com/DataDog/system-tests/actions/runs/31600651293/job/94132117349?pr=7497):
```
unable to initialize tracer:Datadog Agent URL is missing the "://" separator: ""
```

Actually, this does not come from the newly implemented handling of IPv6 agent host addresses, this was a bug already present before.
 
# Additional Notes

Jira ticket: [IDMPL-760 [C++ Tracer] Bug: empty environment variables for agent configuration not handled correctly](https://datadoghq.atlassian.net/browse/IDMPL-760)

`performance/ignore-performance-regression`: We get [very often](https://mosaic.us1.ddbuild.io/change-request/3490251447569031727?owner=datadog&repository=dd-trace-cpp&taskId=gitlab&taskExecutionId=1947786219) high values for `BM_TraceID_ParseHex` whereas the relative code has not been touched:
```
[STDERR] Fail on regression  | FAIL! Metric MetricName.EXECUTION_TIME in scenario:BM_TraceID_ParseHex/64bit has regression +32.48%, larger than threshold 5.00%.
[STDERR] Fail on regression  | FAIL! Metric MetricName.EXECUTION_TIME in scenario:BM_TraceID_ParseHex/128bit has regression +40.50%, larger than threshold 5.00%.
```