### PR TITLE
feat(tracing): add OpenTelemetry tracestate sampling

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -127,6 +127,7 @@ cc_library(
         "include/datadog/logger.h",
         "include/datadog/null_collector.h",
         "include/datadog/optional.h",
+        "include/datadog/otel_tracestate.h",
         "include/datadog/propagation_behavior_extract.h",
         "include/datadog/propagation_style.h",
         "include/datadog/rate.h",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ target_sources(dd-trace-cpp-objects
       include/datadog/logger.h
       include/datadog/null_collector.h
       include/datadog/optional.h
+      include/datadog/otel_tracestate.h
       include/datadog/propagation_behavior_extract.h
       include/datadog/propagation_style.h
       include/datadog/rate.h

--- a/include/datadog/otel_tracestate.h
+++ b/include/datadog/otel_tracestate.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+namespace datadog {
+namespace tracing {
+
+struct OtelTraceState {
+  // Raw value of the `ot` tracestate member.
+  std::string value;
+  // Number of other-vendor members to emit before `ot`.
+  std::size_t position;
+};
+
+}  // namespace tracing
+}  // namespace datadog

--- a/include/datadog/sampling_decision.h
+++ b/include/datadog/sampling_decision.h
@@ -39,8 +39,9 @@ struct SamplingDecision {
   // The per-second maximum allowed number of "keeps" configured for the limiter
   // consulted in this decision, if any.
   Optional<double> limiter_max_per_second;
-  // The outcome of the probability comparison before rate limiting, if any.
-  Optional<bool> probability_sampled;
+  // Whether the sample rate alone, before the rate limiter, would keep this
+  // trace.
+  Optional<bool> was_probability_sampled;
   // The provenance of this decision.
   Origin origin;
 };

--- a/include/datadog/sampling_decision.h
+++ b/include/datadog/sampling_decision.h
@@ -39,6 +39,8 @@ struct SamplingDecision {
   // The per-second maximum allowed number of "keeps" configured for the limiter
   // consulted in this decision, if any.
   Optional<double> limiter_max_per_second;
+  // The outcome of the probability comparison before rate limiting, if any.
+  Optional<bool> probability_sampled;
   // The provenance of this decision.
   Origin origin;
 };

--- a/include/datadog/trace_segment.h
+++ b/include/datadog/trace_segment.h
@@ -77,6 +77,7 @@ class TraceSegment {
   std::vector<std::unique_ptr<SpanData>> spans_;
   std::size_t num_finished_spans_;
   Optional<SamplingDecision> sampling_decision_;
+  const Optional<std::string> otel_w3c_tracestate_;
   const Optional<std::string> additional_w3c_tracestate_;
   const Optional<std::string> additional_datadog_w3c_tracestate_;
 
@@ -99,6 +100,7 @@ class TraceSegment {
                Optional<std::string> origin, std::size_t tags_header_max_size,
                std::vector<std::pair<std::string, std::string>> trace_tags,
                Optional<SamplingDecision> sampling_decision,
+               Optional<std::string> otel_w3c_tracestate,
                Optional<std::string> additional_w3c_tracestate,
                Optional<std::string> additional_datadog_w3c_tracestate,
                std::unique_ptr<SpanData> local_root,

--- a/include/datadog/trace_segment.h
+++ b/include/datadog/trace_segment.h
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include "optional.h"
+#include "otel_tracestate.h"
 #include "propagation_style.h"
 #include "runtime_id.h"
 #include "sampling_decision.h"
@@ -77,7 +78,7 @@ class TraceSegment {
   std::vector<std::unique_ptr<SpanData>> spans_;
   std::size_t num_finished_spans_;
   Optional<SamplingDecision> sampling_decision_;
-  const Optional<std::string> otel_w3c_tracestate_;
+  const Optional<OtelTraceState> otel_w3c_tracestate_;
   const Optional<std::string> additional_w3c_tracestate_;
   const Optional<std::string> additional_datadog_w3c_tracestate_;
 
@@ -100,7 +101,7 @@ class TraceSegment {
                Optional<std::string> origin, std::size_t tags_header_max_size,
                std::vector<std::pair<std::string, std::string>> trace_tags,
                Optional<SamplingDecision> sampling_decision,
-               Optional<std::string> otel_w3c_tracestate,
+               Optional<OtelTraceState> otel_w3c_tracestate,
                Optional<std::string> additional_w3c_tracestate,
                Optional<std::string> additional_datadog_w3c_tracestate,
                std::unique_ptr<SpanData> local_root,

--- a/src/datadog/extracted_data.h
+++ b/src/datadog/extracted_data.h
@@ -31,6 +31,8 @@ struct ExtractedData {
   // then `additional_w3c_tracestate` is null.
   // `additional_w3c_tracestate` is used for the `W3C` injection style.
   Optional<std::string> additional_w3c_tracestate;
+  // The raw value of the OpenTelemetry `ot` tracestate member, if present.
+  Optional<std::string> otel_w3c_tracestate;
   // If this `ExtractedData` was created on account of `PropagationStyle::W3C`,
   // and if the "tracestate" header contained a "dd" (Datadog) entry, then
   // `additional_datadog_w3c_tracestate` contains fields from within the "dd"

--- a/src/datadog/extracted_data.h
+++ b/src/datadog/extracted_data.h
@@ -26,9 +26,9 @@ struct ExtractedData {
   // refering to the latest datadog parent ID.
   Optional<std::string> datadog_w3c_parent_id;
   // If this `ExtractedData` was created on account of `PropagationStyle::W3C`,
-  // then `additional_w3c_tracestate` contains the parts of the "tracestate"
-  // header that are not the "dd" (Datadog) entry. If there are no other parts,
-  // then `additional_w3c_tracestate` is null.
+  // then `additional_w3c_tracestate` contains the entries of the "tracestate"
+  // header other than the "dd" (Datadog) and "ot" (OpenTelemetry) entries.
+  // If there are no such entries, then `additional_w3c_tracestate` is null.
   // `additional_w3c_tracestate` is used for the `W3C` injection style.
   Optional<std::string> additional_w3c_tracestate;
   // The raw value of the OpenTelemetry `ot` tracestate member, if present.

--- a/src/datadog/extracted_data.h
+++ b/src/datadog/extracted_data.h
@@ -4,6 +4,7 @@
 // extracted from trace context. It's an implementation detail of this library.
 
 #include <datadog/optional.h>
+#include <datadog/otel_tracestate.h>
 #include <datadog/propagation_style.h>
 #include <datadog/trace_id.h>
 
@@ -31,8 +32,8 @@ struct ExtractedData {
   // If there are no such entries, then `additional_w3c_tracestate` is null.
   // `additional_w3c_tracestate` is used for the `W3C` injection style.
   Optional<std::string> additional_w3c_tracestate;
-  // The raw value of the OpenTelemetry `ot` tracestate member, if present.
-  Optional<std::string> otel_w3c_tracestate;
+  // The retained OpenTelemetry `ot` tracestate member, if present.
+  Optional<OtelTraceState> otel_w3c_tracestate;
   // If this `ExtractedData` was created on account of `PropagationStyle::W3C`,
   // and if the "tracestate" header contained a "dd" (Datadog) entry, then
   // `additional_datadog_w3c_tracestate` contains fields from within the "dd"

--- a/src/datadog/extraction_util.cpp
+++ b/src/datadog/extraction_util.cpp
@@ -283,6 +283,7 @@ ExtractedData merge(
 
   if (w3c != contexts.end() && w3c->second.trace_id == result.trace_id) {
     result.additional_w3c_tracestate = w3c->second.additional_w3c_tracestate;
+    result.otel_w3c_tracestate = w3c->second.otel_w3c_tracestate;
     result.additional_datadog_w3c_tracestate =
         w3c->second.additional_datadog_w3c_tracestate;
     result.headers_examined.insert(result.headers_examined.end(),

--- a/src/datadog/sampling_util.h
+++ b/src/datadog/sampling_util.h
@@ -4,12 +4,29 @@
 // `TraceSampler` and `SpanSampler`.
 
 #include <datadog/rate.h>
+#include <datadog/sampling_mechanism.h>
 
 #include <cstdint>
 #include <limits>
 
 namespace datadog {
 namespace tracing {
+
+inline bool is_probability_mechanism(int mechanism) {
+  switch (static_cast<SamplingMechanism>(mechanism)) {
+    case SamplingMechanism::DEFAULT:
+    case SamplingMechanism::AGENT_RATE:
+    case SamplingMechanism::REMOTE_RATE_AUTO:
+    case SamplingMechanism::RULE:
+    case SamplingMechanism::REMOTE_RATE_USER_DEFINED:
+    case SamplingMechanism::REMOTE_RATE_EMERGENCY:
+    case SamplingMechanism::REMOTE_RULE:
+    case SamplingMechanism::REMOTE_ADAPTIVE_RULE:
+      return true;
+    default:
+      return false;
+  }
+}
 
 // Return a hash value for the specified `value`. `value` is one of the
 // following:

--- a/src/datadog/trace_sampler.cpp
+++ b/src/datadog/trace_sampler.cpp
@@ -50,9 +50,10 @@ SamplingDecision TraceSampler::decide(const SpanData& span) {
     decision.mechanism = int(rule.mechanism);
     decision.limiter_max_per_second = limiter_max_per_second_;
     decision.configured_rate = rule.rate;
-    const std::uint64_t threshold = max_id_from_rate(rule.rate);
-    decision.probability_sampled = knuth_hash(span.trace_id.low) <= threshold;
-    if (*decision.probability_sampled) {
+    const std::uint64_t threshold = max_id_from_rate(*decision.configured_rate);
+    decision.was_probability_sampled =
+        knuth_hash(span.trace_id.low) <= threshold;
+    if (*decision.was_probability_sampled) {
       if (rule.bypass_limiter) {
         decision.priority = int(SamplingPriority::USER_KEEP);
         return decision;
@@ -92,8 +93,8 @@ SamplingDecision TraceSampler::decide(const SpanData& span) {
   }
 
   const std::uint64_t threshold = max_id_from_rate(*decision.configured_rate);
-  decision.probability_sampled = knuth_hash(span.trace_id.low) <= threshold;
-  if (*decision.probability_sampled) {
+  decision.was_probability_sampled = knuth_hash(span.trace_id.low) <= threshold;
+  if (*decision.was_probability_sampled) {
     decision.priority = int(SamplingPriority::AUTO_KEEP);
   } else {
     decision.priority = int(SamplingPriority::AUTO_DROP);

--- a/src/datadog/trace_sampler.cpp
+++ b/src/datadog/trace_sampler.cpp
@@ -51,7 +51,8 @@ SamplingDecision TraceSampler::decide(const SpanData& span) {
     decision.limiter_max_per_second = limiter_max_per_second_;
     decision.configured_rate = rule.rate;
     const std::uint64_t threshold = max_id_from_rate(rule.rate);
-    if (knuth_hash(span.trace_id.low) <= threshold) {
+    decision.probability_sampled = knuth_hash(span.trace_id.low) <= threshold;
+    if (*decision.probability_sampled) {
       if (rule.bypass_limiter) {
         decision.priority = int(SamplingPriority::USER_KEEP);
         return decision;
@@ -91,7 +92,8 @@ SamplingDecision TraceSampler::decide(const SpanData& span) {
   }
 
   const std::uint64_t threshold = max_id_from_rate(*decision.configured_rate);
-  if (knuth_hash(span.trace_id.low) <= threshold) {
+  decision.probability_sampled = knuth_hash(span.trace_id.low) <= threshold;
+  if (*decision.probability_sampled) {
     decision.priority = int(SamplingPriority::AUTO_KEEP);
   } else {
     decision.priority = int(SamplingPriority::AUTO_DROP);

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -162,9 +162,9 @@ Optional<std::string> resolve_otel_tracestate(
   }
 
   if (!decision.mechanism || !decision.configured_rate ||
-      !decision.probability_sampled ||
+      !decision.was_probability_sampled ||
       !is_probability_mechanism(*decision.mechanism) ||
-      (*decision.probability_sampled && decision.priority <= 0)) {
+      (*decision.was_probability_sampled && decision.priority <= 0)) {
     return rewrite_otel_tracestate(raw, extract_otel_random_value(raw),
                                    nullopt);
   }
@@ -176,9 +176,9 @@ Optional<std::string> resolve_otel_tracestate(
   threshold = std::min(threshold, max_value - 1);
 
   std::uint64_t random_value = (~knuth_hash(trace_id.low)) >> 8;
-  if (*decision.probability_sampled && random_value < threshold) {
+  if (*decision.was_probability_sampled && random_value < threshold) {
     random_value = threshold;
-  } else if (!*decision.probability_sampled && random_value >= threshold) {
+  } else if (!*decision.was_probability_sampled && random_value >= threshold) {
     random_value = threshold == 0 ? 0 : threshold - 1;
   }
 

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -6,7 +6,6 @@
 #include <datadog/injection_options.h>
 #include <datadog/logger.h>
 #include <datadog/optional.h>
-#include <datadog/sampling_mechanism.h>
 #include <datadog/span_defaults.h>
 #include <datadog/telemetry/metrics.h>
 #include <datadog/telemetry/telemetry.h>
@@ -16,7 +15,6 @@
 #include <cassert>
 #include <charconv>
 #include <cmath>
-#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -186,7 +186,7 @@ Optional<std::string> resolve_otel_tracestate(
   }
 
   constexpr std::uint64_t max_value = UINT64_C(1) << 56;
-  auto threshold = static_cast<std::uint64_t>(
+  std::uint64_t threshold = static_cast<std::uint64_t>(
       std::round((1.0 - decision.configured_rate->value()) *
                  static_cast<double>(max_value)));
   threshold = std::min(threshold, max_value - 1);

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -162,10 +162,12 @@ Optional<std::string> resolve_otel_tracestate(
   }
 
   const StringView raw = inherited ? StringView(*inherited) : StringView{};
-  if (!decision.mechanism || !decision.configured_rate ||
+  const bool probability_sampling_is_unavailable_or_dropped =
       !decision.was_probability_sampled ||
+      (*decision.was_probability_sampled && decision.priority <= 0);
+  if (!decision.mechanism || !decision.configured_rate ||
       !is_probability_mechanism(*decision.mechanism) ||
-      (*decision.was_probability_sampled && decision.priority <= 0)) {
+      probability_sampling_is_unavailable_or_dropped) {
     return rewrite_otel_tracestate(raw, extract_otel_random_value(raw),
                                    nullopt);
   }

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -250,7 +250,7 @@ Optional<SamplingDecision> TraceSegment::sampling_decision() const {
   return sampling_decision_;
 }
 
-Optional<std::pair<std::string, std::uint32_t>> TraceSegment::w3c_link_context(
+Optional<W3CLinkContext> TraceSegment::w3c_link_context(
     const SpanData& span) const {
   SamplingDecision sampling_decision;
   std::vector<std::pair<std::string, std::string>> trace_tags;

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -153,22 +153,6 @@ Optional<std::string> format_rate(double rate, Logger& logger) {
   return std::string(begin, end);
 }
 
-bool is_probability_mechanism(int mechanism) {
-  switch (static_cast<SamplingMechanism>(mechanism)) {
-    case SamplingMechanism::DEFAULT:
-    case SamplingMechanism::AGENT_RATE:
-    case SamplingMechanism::REMOTE_RATE_AUTO:
-    case SamplingMechanism::RULE:
-    case SamplingMechanism::REMOTE_RATE_USER_DEFINED:
-    case SamplingMechanism::REMOTE_RATE_EMERGENCY:
-    case SamplingMechanism::REMOTE_RULE:
-    case SamplingMechanism::REMOTE_ADAPTIVE_RULE:
-      return true;
-    default:
-      return false;
-  }
-}
-
 Optional<std::string> resolve_otel_tracestate(
     TraceID trace_id, const SamplingDecision& decision,
     const Optional<std::string>& inherited) {

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -57,15 +57,12 @@ Cache cache_singleton;
 
 // Encode the specified `trace_tags`. If the encoded value is not longer than
 // the specified `tags_header_max_size`, then set it as the "x-datadog-tags"
-// header using the specified `writer`. If the encoded value is oversized, then
-// write a diagnostic to the specified `logger` and set a propagation error tag
-// on the specified `local_root_tags`.
-void inject_trace_tags(
+// header using the specified `writer`. Return true if the encoded value is
+// oversized.
+bool inject_trace_tags(
     DictWriter& writer,
     const std::vector<std::pair<std::string, std::string>>& trace_tags,
-    std::size_t tags_header_max_size,
-    std::unordered_map<std::string, std::string>& local_root_tags,
-    Logger& logger) {
+    std::size_t tags_header_max_size, Logger& logger) {
   const std::string encoded_trace_tags = encode_tags(trace_tags);
 
   if (encoded_trace_tags.size() > tags_header_max_size) {
@@ -78,10 +75,13 @@ void inject_trace_tags(
     message += std::to_string(encoded_trace_tags.size());
     message += " bytes.";
     logger.log_error(message);
-    local_root_tags[tags::internal::propagation_error] = "inject_max_size";
-  } else if (!encoded_trace_tags.empty()) {
+    return true;
+  }
+
+  if (!encoded_trace_tags.empty()) {
     writer.set("x-datadog-tags", encoded_trace_tags);
   }
+  return false;
 }
 
 void maybe_calculate_http_endpoint(HttpEndpointCalculationMode renaming_mode,
@@ -487,19 +487,16 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
   // decision and trace tags before unlocking.
   SamplingDecision sampling_decision;
   std::vector<std::pair<std::string, std::string>> trace_tags;
+  Optional<std::string> trace_source_tag;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     make_sampling_decision_if_null();
     assert(sampling_decision_);
     sampling_decision = *sampling_decision_;
     trace_tags = trace_tags_;
+
+    trace_source_tag = find_trace_source_tag(spans_.front()->tags);
   }
-
-  std::unordered_map<std::string, std::string>& local_root_tags =
-      spans_.front()->tags;
-
-  const Optional<std::string> trace_source_tag =
-      find_trace_source_tag(local_root_tags);
 
   // When tracing (the product) is disabled, skip tracing context propagation
   // when:
@@ -528,6 +525,7 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
     trace_tags.emplace_back(tags::internal::trace_source, *trace_source_tag);
   }
 
+  bool trace_tags_too_large = false;
   for (const auto style : injection_styles_) {
     switch (style) {
       case PropagationStyle::DATADOG:
@@ -538,8 +536,10 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
         if (origin_) {
           writer.set("x-datadog-origin", *origin_);
         }
-        inject_trace_tags(writer, trace_tags, tags_header_max_size_,
-                          local_root_tags, *logger_);
+        if (inject_trace_tags(writer, trace_tags, tags_header_max_size_,
+                              *logger_)) {
+          trace_tags_too_large = true;
+        }
 
         telemetry::counter::increment(metrics::tracer::trace_context::injected,
                                       {"header_style:datadog"});
@@ -556,8 +556,10 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
         if (origin_) {
           writer.set("x-datadog-origin", *origin_);
         }
-        inject_trace_tags(writer, trace_tags, tags_header_max_size_,
-                          local_root_tags, *logger_);
+        if (inject_trace_tags(writer, trace_tags, tags_header_max_size_,
+                              *logger_)) {
+          trace_tags_too_large = true;
+        }
         telemetry::counter::increment(metrics::tracer::trace_context::injected,
                                       {"header_style:b3multi"});
         break;
@@ -578,6 +580,13 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
       default:
         break;
     }
+  }
+
+  if (trace_tags_too_large) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::unordered_map<std::string, std::string>& local_root_tags =
+        spans_.front()->tags;
+    local_root_tags[tags::internal::propagation_error] = "inject_max_size";
   }
 
   return true;

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -156,11 +156,12 @@ Optional<std::string> format_rate(double rate, Logger& logger) {
 Optional<std::string> resolve_otel_tracestate(
     TraceID trace_id, const SamplingDecision& decision,
     const Optional<std::string>& inherited) {
-  const StringView raw = inherited ? StringView(*inherited) : StringView{};
   if (decision.origin != SamplingDecision::Origin::LOCAL) {
-    return inherited ? sanitize_otel_tracestate(raw) : nullopt;
+    return inherited ? sanitize_otel_tracestate(StringView(*inherited))
+                     : nullopt;
   }
 
+  const StringView raw = inherited ? StringView(*inherited) : StringView{};
   if (!decision.mechanism || !decision.configured_rate ||
       !decision.was_probability_sampled ||
       !is_probability_mechanism(*decision.mechanism) ||

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -6,6 +6,7 @@
 #include <datadog/injection_options.h>
 #include <datadog/logger.h>
 #include <datadog/optional.h>
+#include <datadog/sampling_mechanism.h>
 #include <datadog/span_defaults.h>
 #include <datadog/telemetry/metrics.h>
 #include <datadog/telemetry/telemetry.h>
@@ -14,6 +15,8 @@
 #include <array>
 #include <cassert>
 #include <charconv>
+#include <cmath>
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -23,6 +26,7 @@
 #include "endpoint_inferral.h"
 #include "hex.h"
 #include "platform_util.h"
+#include "sampling_util.h"
 #include "span_data.h"
 #include "span_sampler.h"
 #include "tag_propagation.h"
@@ -151,6 +155,54 @@ Optional<std::string> format_rate(double rate, Logger& logger) {
   return std::string(begin, end);
 }
 
+bool is_probability_mechanism(int mechanism) {
+  switch (static_cast<SamplingMechanism>(mechanism)) {
+    case SamplingMechanism::DEFAULT:
+    case SamplingMechanism::AGENT_RATE:
+    case SamplingMechanism::REMOTE_RATE_AUTO:
+    case SamplingMechanism::RULE:
+    case SamplingMechanism::REMOTE_RATE_USER_DEFINED:
+    case SamplingMechanism::REMOTE_RATE_EMERGENCY:
+    case SamplingMechanism::REMOTE_RULE:
+    case SamplingMechanism::REMOTE_ADAPTIVE_RULE:
+      return true;
+    default:
+      return false;
+  }
+}
+
+Optional<std::string> resolve_otel_tracestate(
+    TraceID trace_id, const SamplingDecision& decision,
+    const Optional<std::string>& inherited) {
+  const StringView raw = inherited ? StringView(*inherited) : StringView{};
+  if (decision.origin != SamplingDecision::Origin::LOCAL) {
+    return inherited ? sanitize_otel_tracestate(raw) : nullopt;
+  }
+
+  if (!decision.mechanism || !decision.configured_rate ||
+      !decision.probability_sampled ||
+      !is_probability_mechanism(*decision.mechanism) ||
+      (*decision.probability_sampled && decision.priority <= 0)) {
+    return rewrite_otel_tracestate(raw, extract_otel_random_value(raw),
+                                   nullopt);
+  }
+
+  constexpr std::uint64_t max_value = UINT64_C(1) << 56;
+  auto threshold = static_cast<std::uint64_t>(
+      std::round((1.0 - decision.configured_rate->value()) *
+                 static_cast<double>(max_value)));
+  threshold = std::min(threshold, max_value - 1);
+
+  std::uint64_t random_value = (~knuth_hash(trace_id.low)) >> 8;
+  if (*decision.probability_sampled && random_value < threshold) {
+    random_value = threshold;
+  } else if (!*decision.probability_sampled && random_value >= threshold) {
+    random_value = threshold == 0 ? 0 : threshold - 1;
+  }
+
+  return rewrite_otel_tracestate(raw, random_value, threshold);
+}
+
 }  // anonymous namespace
 
 TraceSegment::TraceSegment(
@@ -166,6 +218,7 @@ TraceSegment::TraceSegment(
     std::size_t tags_header_max_size,
     std::vector<std::pair<std::string, std::string>> trace_tags,
     Optional<SamplingDecision> sampling_decision,
+    Optional<std::string> otel_w3c_tracestate,
     Optional<std::string> additional_w3c_tracestate,
     Optional<std::string> additional_datadog_w3c_tracestate,
     std::unique_ptr<SpanData> local_root,
@@ -184,6 +237,7 @@ TraceSegment::TraceSegment(
       trace_tags_(std::move(trace_tags)),
       num_finished_spans_(0),
       sampling_decision_(std::move(sampling_decision)),
+      otel_w3c_tracestate_(std::move(otel_w3c_tracestate)),
       additional_w3c_tracestate_(std::move(additional_w3c_tracestate)),
       additional_datadog_w3c_tracestate_(
           std::move(additional_datadog_w3c_tracestate)),
@@ -216,14 +270,14 @@ Optional<SamplingDecision> TraceSegment::sampling_decision() const {
 
 Optional<std::pair<std::string, std::uint32_t>> TraceSegment::w3c_link_context(
     const SpanData& span) const {
-  int sampling_priority;
+  SamplingDecision sampling_decision;
   std::vector<std::pair<std::string, std::string>> trace_tags;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     if (!sampling_decision_) {
       return nullopt;
     }
-    sampling_priority = sampling_decision_->priority;
+    sampling_decision = *sampling_decision_;
     trace_tags = trace_tags_;
 
     const Optional<std::string> trace_source_tag =
@@ -234,10 +288,13 @@ Optional<std::pair<std::string, std::uint32_t>> TraceSegment::w3c_link_context(
   }
 
   return std::make_pair(
-      encode_tracestate(span.span_id, sampling_priority, origin_, trace_tags,
-                        additional_datadog_w3c_tracestate_,
-                        additional_w3c_tracestate_),
-      sampling_priority > 0 ? 1u : 0u);
+      encode_tracestate(
+          span.span_id, sampling_decision.priority, origin_, trace_tags,
+          additional_datadog_w3c_tracestate_,
+          resolve_otel_tracestate(span.trace_id, sampling_decision,
+                                  otel_w3c_tracestate_),
+          additional_w3c_tracestate_),
+      sampling_decision.priority > 0 ? 1u : 0u);
 }
 
 Logger& TraceSegment::logger() const { return *logger_; }
@@ -443,13 +500,13 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
   // and trace tags might change when that happens ("_dd.p.dm").
   // So, we lock here, make a sampling decision if necessary, and then copy the
   // decision and trace tags before unlocking.
-  int sampling_priority;
+  SamplingDecision sampling_decision;
   std::vector<std::pair<std::string, std::string>> trace_tags;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     make_sampling_decision_if_null();
     assert(sampling_decision_);
-    sampling_priority = sampling_decision_->priority;
+    sampling_decision = *sampling_decision_;
     trace_tags = trace_tags_;
   }
 
@@ -464,7 +521,7 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
   //  - the local root span is NOT created by another product (no `_dd.p.ts`)
   //  - sampling priority is DROP
   if (!tracing_enabled_) {
-    if (!trace_source_tag && sampling_priority <= 0) {
+    if (!trace_source_tag && sampling_decision.priority <= 0) {
       writer.erase("x-datadog-trace-id");
       writer.erase("x-datadog-parent-id");
       writer.erase("x-datadog-sampling-priority");
@@ -492,7 +549,7 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
         writer.set("x-datadog-trace-id", std::to_string(span.trace_id.low));
         writer.set("x-datadog-parent-id", std::to_string(span.span_id));
         writer.set("x-datadog-sampling-priority",
-                   std::to_string(sampling_priority));
+                   std::to_string(sampling_decision.priority));
         if (origin_) {
           writer.set("x-datadog-origin", *origin_);
         }
@@ -509,7 +566,8 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
           writer.set("x-b3-traceid", hex_padded(span.trace_id.low));
         }
         writer.set("x-b3-spanid", hex_padded(span.span_id));
-        writer.set("x-b3-sampled", std::to_string(int(sampling_priority > 0)));
+        writer.set("x-b3-sampled",
+                   std::to_string(int(sampling_decision.priority > 0)));
         if (origin_) {
           writer.set("x-datadog-origin", *origin_);
         }
@@ -519,14 +577,16 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
                                       {"header_style:b3multi"});
         break;
       case PropagationStyle::W3C:
-        writer.set(
-            "traceparent",
-            encode_traceparent(span.trace_id, span.span_id, sampling_priority));
-        writer.set(
-            "tracestate",
-            encode_tracestate(span.span_id, sampling_priority, origin_,
-                              trace_tags, additional_datadog_w3c_tracestate_,
-                              additional_w3c_tracestate_));
+        writer.set("traceparent",
+                   encode_traceparent(span.trace_id, span.span_id,
+                                      sampling_decision.priority));
+        writer.set("tracestate",
+                   encode_tracestate(
+                       span.span_id, sampling_decision.priority, origin_,
+                       trace_tags, additional_datadog_w3c_tracestate_,
+                       resolve_otel_tracestate(span.trace_id, sampling_decision,
+                                               otel_w3c_tracestate_),
+                       additional_w3c_tracestate_));
         telemetry::counter::increment(metrics::tracer::trace_context::injected,
                                       {"header_style:tracecontext"});
         break;

--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -153,15 +153,15 @@ Optional<std::string> format_rate(double rate, Logger& logger) {
   return std::string(begin, end);
 }
 
-Optional<std::string> resolve_otel_tracestate(
+Optional<std::string> resolve_otel_tracestate_value(
     TraceID trace_id, const SamplingDecision& decision,
-    const Optional<std::string>& inherited) {
+    const Optional<OtelTraceState>& inherited) {
   if (decision.origin != SamplingDecision::Origin::LOCAL) {
-    return inherited ? sanitize_otel_tracestate(StringView(*inherited))
-                     : nullopt;
+    return inherited ? sanitize_otel_tracestate(inherited->value) : nullopt;
   }
 
-  const StringView raw = inherited ? StringView(*inherited) : StringView{};
+  const StringView raw =
+      inherited ? StringView(inherited->value) : StringView{};
   const bool probability_sampling_is_unavailable_or_dropped =
       !decision.was_probability_sampled ||
       (*decision.was_probability_sampled && decision.priority <= 0);
@@ -188,6 +188,24 @@ Optional<std::string> resolve_otel_tracestate(
   return rewrite_otel_tracestate(raw, random_value, threshold);
 }
 
+Optional<OtelTraceState> resolve_otel_tracestate(
+    TraceID trace_id, const SamplingDecision& decision,
+    const Optional<OtelTraceState>& inherited) {
+  Optional<std::string> resolved =
+      resolve_otel_tracestate_value(trace_id, decision, inherited);
+  if (!resolved) {
+    return nullopt;
+  }
+
+  const bool otel_w3c_tracestate_is_unchanged =
+      inherited && *resolved == inherited->value;
+  constexpr std::size_t first_non_datadog_tracestate_position = 0;
+  const std::size_t position = otel_w3c_tracestate_is_unchanged
+                                   ? inherited->position
+                                   : first_non_datadog_tracestate_position;
+  return OtelTraceState{std::move(*resolved), position};
+}
+
 }  // anonymous namespace
 
 TraceSegment::TraceSegment(
@@ -203,7 +221,7 @@ TraceSegment::TraceSegment(
     std::size_t tags_header_max_size,
     std::vector<std::pair<std::string, std::string>> trace_tags,
     Optional<SamplingDecision> sampling_decision,
-    Optional<std::string> otel_w3c_tracestate,
+    Optional<OtelTraceState> otel_w3c_tracestate,
     Optional<std::string> additional_w3c_tracestate,
     Optional<std::string> additional_datadog_w3c_tracestate,
     std::unique_ptr<SpanData> local_root,
@@ -272,13 +290,14 @@ Optional<W3CLinkContext> TraceSegment::w3c_link_context(
     }
   }
 
+  const Optional<OtelTraceState> resolved_otel_w3c_tracestate =
+      resolve_otel_tracestate(span.trace_id, sampling_decision,
+                              otel_w3c_tracestate_);
   return std::make_pair(
-      encode_tracestate(
-          span.span_id, sampling_decision.priority, origin_, trace_tags,
-          additional_datadog_w3c_tracestate_,
-          resolve_otel_tracestate(span.trace_id, sampling_decision,
-                                  otel_w3c_tracestate_),
-          additional_w3c_tracestate_),
+      encode_tracestate(span.span_id, sampling_decision.priority, origin_,
+                        trace_tags, additional_datadog_w3c_tracestate_,
+                        resolved_otel_w3c_tracestate,
+                        additional_w3c_tracestate_),
       sampling_decision.priority > 0 ? 1u : 0u);
 }
 
@@ -563,20 +582,23 @@ bool TraceSegment::inject(DictWriter& writer, const SpanData& span,
         telemetry::counter::increment(metrics::tracer::trace_context::injected,
                                       {"header_style:b3multi"});
         break;
-      case PropagationStyle::W3C:
+      case PropagationStyle::W3C: {
+        const Optional<OtelTraceState> resolved_otel_w3c_tracestate =
+            resolve_otel_tracestate(span.trace_id, sampling_decision,
+                                    otel_w3c_tracestate_);
         writer.set("traceparent",
                    encode_traceparent(span.trace_id, span.span_id,
                                       sampling_decision.priority));
-        writer.set("tracestate",
-                   encode_tracestate(
-                       span.span_id, sampling_decision.priority, origin_,
-                       trace_tags, additional_datadog_w3c_tracestate_,
-                       resolve_otel_tracestate(span.trace_id, sampling_decision,
-                                               otel_w3c_tracestate_),
-                       additional_w3c_tracestate_));
+        writer.set(
+            "tracestate",
+            encode_tracestate(span.span_id, sampling_decision.priority, origin_,
+                              trace_tags, additional_datadog_w3c_tracestate_,
+                              resolved_otel_w3c_tracestate,
+                              additional_w3c_tracestate_));
         telemetry::counter::increment(metrics::tracer::trace_context::injected,
                                       {"header_style:tracecontext"});
         break;
+      }
       default:
         break;
     }

--- a/src/datadog/tracer.cpp
+++ b/src/datadog/tracer.cpp
@@ -247,7 +247,8 @@ Span Tracer::create_span(const SpanConfig& config) {
       logger_, collector_, config_manager_->trace_sampler(), span_sampler_,
       defaults, config_manager_, runtime_id_, injection_styles_, hostname_,
       nullopt /* origin */, tags_header_max_size_, std::move(trace_tags),
-      nullopt /* sampling_decision */, nullopt /* additional_w3c_tracestate */,
+      nullopt /* sampling_decision */, nullopt /* otel_w3c_tracestate */,
+      nullopt /* additional_w3c_tracestate */,
       nullopt /* additional_datadog_w3c_tracestate*/, std::move(span_data),
       resource_renaming_mode_, tracing_enabled_);
   Span span{span_data_ptr, segment,
@@ -483,6 +484,7 @@ Expected<Span> Tracer::extract_span(const DictReader& reader,
           injection_styles_, hostname_, std::move(merged_context.origin),
           tags_header_max_size_, std::move(merged_context.trace_tags),
           std::move(sampling_decision),
+          std::move(merged_context.otel_w3c_tracestate),
           std::move(merged_context.additional_w3c_tracestate),
           std::move(merged_context.additional_datadog_w3c_tracestate),
           std::move(span_data), resource_renaming_mode_, tracing_enabled_);

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <utility>
 
 #include "hex.h"
@@ -36,6 +37,107 @@ auto verboten(int lowest_ascii, int highest_ascii,
 constexpr bool is_hexdiglc(const char c) {
   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
          (c >= 'A' && c <= 'F');
+}
+
+constexpr bool is_lowercase_hexdig(const char c) {
+  return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+}
+
+bool is_valid_otel_hex(StringView value, std::size_t minimum_size,
+                       std::size_t maximum_size) {
+  return value.size() >= minimum_size && value.size() <= maximum_size &&
+         std::all_of(value.begin(), value.end(), is_lowercase_hexdig);
+}
+
+Optional<std::uint64_t> parse_otel_random_value(StringView value) {
+  if (!is_valid_otel_hex(value, 14, 14)) {
+    return nullopt;
+  }
+
+  const auto parsed = parse_uint64(value, 16);
+  if (parsed.if_error()) {
+    return nullopt;
+  }
+  return *parsed;
+}
+
+Optional<std::uint64_t> parse_otel_threshold(StringView value) {
+  if (!is_valid_otel_hex(value, 1, 14)) {
+    return nullopt;
+  }
+
+  const auto parsed = parse_uint64(value, 16);
+  if (parsed.if_error()) {
+    return nullopt;
+  }
+  return *parsed;
+}
+
+template <class Function>
+void for_each_otel_item(StringView raw, Function&& function) {
+  std::size_t begin = 0;
+  while (begin <= raw.size()) {
+    const auto end = raw.find(';', begin);
+    const auto item = raw.substr(begin, end - begin);
+    const auto separator = item.find(':');
+    const auto key = item.substr(0, separator);
+    const auto value = separator == StringView::npos
+                           ? StringView{}
+                           : item.substr(separator + 1);
+    function(item, key, value);
+    if (end == StringView::npos) {
+      return;
+    }
+    begin = end + 1;
+  }
+}
+
+template <class Function>
+void for_each_tracestate_member(StringView raw, Function&& function) {
+  std::size_t begin = 0;
+  while (begin < raw.size()) {
+    const auto end = raw.find(',', begin);
+    const auto member = trim(raw.substr(begin, end - begin));
+    const auto separator = member.find('=');
+    const auto key = member.substr(0, separator);
+    const auto value = separator == StringView::npos
+                           ? StringView{}
+                           : member.substr(separator + 1);
+    function(member, key, value);
+    if (end == StringView::npos) {
+      return;
+    }
+    begin = end + 1;
+  }
+}
+
+bool append_otel_item(std::string& result, StringView item) {
+  if (item.empty()) {
+    return true;
+  }
+
+  const std::size_t separator_size = result.empty() ? 0 : 1;
+  if (result.size() + separator_size + item.size() > 256) {
+    return false;
+  }
+
+  if (separator_size) {
+    result += ';';
+  }
+  append(result, item);
+  return true;
+}
+
+std::string format_otel_hex(std::uint64_t value) {
+  return hex_padded(value).substr(2);
+}
+
+std::string format_otel_threshold(std::uint64_t threshold) {
+  auto result = format_otel_hex(threshold);
+  while (result.size() > 1 && result.back() == '0') {
+    result.pop_back();
+  }
+  return result;
 }
 
 // Populate the specified `result` with data extracted from the "traceparent"
@@ -295,22 +397,47 @@ void extract_tracestate(
     if (!tracestate.empty()) {
       result.additional_w3c_tracestate = std::string{tracestate};
     }
+  } else {
+    auto& [datadog_value, other_entries] = *maybe_parsed;
+    if (!other_entries.empty()) {
+      result.additional_w3c_tracestate = std::move(other_entries);
+    }
+
+    // If the "dd" vendor entry's value exceeds 512 bytes, drop it and record a
+    // propagation error tag.
+    if (datadog_value.size() > 512) {
+      span_tags[tags::internal::propagation_error] = "extract_max_size";
+    } else {
+      parse_datadog_tracestate(result, datadog_value);
+    }
+  }
+
+  if (!result.additional_w3c_tracestate) {
     return;
   }
 
-  auto& [datadog_value, other_entries] = *maybe_parsed;
-  if (!other_entries.empty()) {
-    result.additional_w3c_tracestate = std::move(other_entries);
-  }
+  std::string remaining;
+  for_each_tracestate_member(
+      *result.additional_w3c_tracestate,
+      [&](StringView item, StringView key, StringView value) {
+        if (key == "ot") {
+          if (!result.otel_w3c_tracestate) {
+            result.otel_w3c_tracestate = std::string(value);
+          }
+          return;
+        }
 
-  // If the "dd" vendor entry's value exceeds 512 bytes, drop it and record a
-  // propagation error tag.
-  if (datadog_value.size() > 512) {
-    span_tags[tags::internal::propagation_error] = "extract_max_size";
-    return;
-  }
+        if (!remaining.empty()) {
+          remaining += ',';
+        }
+        append(remaining, item);
+      });
 
-  parse_datadog_tracestate(result, datadog_value);
+  if (remaining.empty()) {
+    result.additional_w3c_tracestate = nullopt;
+  } else {
+    result.additional_w3c_tracestate = std::move(remaining);
+  }
 }
 
 }  // namespace
@@ -424,19 +551,95 @@ std::string encode_datadog_tracestate(
   return result;
 }
 
+Optional<std::string> sanitize_otel_tracestate(StringView raw) {
+  std::string result;
+  for_each_otel_item(raw,
+                     [&](StringView item, StringView key, StringView value) {
+                       if ((key == "rv" && !parse_otel_random_value(value)) ||
+                           (key == "th" && !parse_otel_threshold(value))) {
+                         return;
+                       }
+                       append_otel_item(result, item);
+                     });
+  if (result.empty()) {
+    return nullopt;
+  }
+  return result;
+}
+
+Optional<std::uint64_t> extract_otel_random_value(StringView raw) {
+  Optional<std::uint64_t> result;
+  for_each_otel_item(raw, [&](StringView, StringView key, StringView value) {
+    if (!result && key == "rv") {
+      result = parse_otel_random_value(value);
+    }
+  });
+  return result;
+}
+
+Optional<std::string> rewrite_otel_tracestate(
+    StringView raw, Optional<std::uint64_t> random_value,
+    Optional<std::uint64_t> threshold) {
+  std::string result;
+  if (random_value) {
+    const std::string item = "rv:" + format_otel_hex(*random_value);
+    append_otel_item(result, item);
+  }
+  if (threshold) {
+    const std::string item = "th:" + format_otel_threshold(*threshold);
+    append_otel_item(result, item);
+  }
+
+  for_each_otel_item(raw, [&](StringView item, StringView key, StringView) {
+    if (key != "rv" && key != "th") {
+      append_otel_item(result, item);
+    }
+  });
+
+  if (result.empty()) {
+    return nullopt;
+  }
+  return result;
+}
+
+void append_tracestate_entries(std::string& result, StringView entries,
+                               std::size_t& member_count) {
+  std::size_t begin = 0;
+  while (member_count < 32 && begin < entries.size()) {
+    const auto end = entries.find(',', begin);
+    const auto entry = trim(entries.substr(begin, end - begin));
+    if (!entry.empty()) {
+      result += ',';
+      append(result, entry);
+      ++member_count;
+    }
+    if (end == StringView::npos) {
+      return;
+    }
+    begin = end + 1;
+  }
+}
+
 std::string encode_tracestate(
     uint64_t span_id, int sampling_priority,
     const Optional<std::string>& origin,
     const std::vector<std::pair<std::string, std::string>>& trace_tags,
     const Optional<std::string>& additional_datadog_w3c_tracestate,
+    const Optional<std::string>& otel_w3c_tracestate,
     const Optional<std::string>& additional_w3c_tracestate) {
   std::string result =
       encode_datadog_tracestate(span_id, sampling_priority, origin, trace_tags,
                                 additional_datadog_w3c_tracestate);
 
+  std::size_t member_count = 1;
+  if (otel_w3c_tracestate) {
+    result += ",ot=";
+    result += *otel_w3c_tracestate;
+    ++member_count;
+  }
+
   if (additional_w3c_tracestate) {
-    result += ',';
-    result += *additional_w3c_tracestate;
+    append_tracestate_entries(result, *additional_w3c_tracestate, member_count);
   }
 
   return result;

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -60,7 +60,7 @@ Optional<std::uint64_t> parse_otel_random_value(StringView value) {
     return nullopt;
   }
 
-  const auto parsed = parse_uint64(value, 16);
+  const Expected<std::uint64_t> parsed = parse_uint64(value, 16);
   if (parsed.if_error()) {
     return nullopt;
   }
@@ -73,7 +73,7 @@ Optional<std::uint64_t> parse_otel_threshold(StringView value) {
     return nullopt;
   }
 
-  const auto parsed = parse_uint64(value, 16);
+  const Expected<std::uint64_t> parsed = parse_uint64(value, 16);
   if (parsed.if_error()) {
     return nullopt;
   }
@@ -84,13 +84,13 @@ template <class Function>
 void for_each_otel_item(StringView raw, Function&& function) {
   std::size_t begin = 0;
   while (begin <= raw.size()) {
-    const auto end = raw.find(';', begin);
-    const auto item = raw.substr(begin, end - begin);
-    const auto separator = item.find(':');
-    const auto key = item.substr(0, separator);
-    const auto value = separator == StringView::npos
-                           ? StringView{}
-                           : item.substr(separator + 1);
+    const std::size_t end = raw.find(';', begin);
+    const StringView item = raw.substr(begin, end - begin);
+    const std::size_t separator = item.find(':');
+    const StringView key = item.substr(0, separator);
+    const StringView value =
+        separator == StringView::npos ? StringView{}
+                                       : item.substr(separator + 1);
     function(item, key, value);
     if (end == StringView::npos) {
       return;
@@ -122,7 +122,7 @@ std::string format_otel_hex(std::uint64_t value) {
 }
 
 std::string format_otel_threshold(std::uint64_t threshold) {
-  auto result = format_otel_hex(threshold);
+  std::string result = format_otel_hex(threshold);
   while (result.size() > 1 && result.back() == '0') {
     result.pop_back();
   }
@@ -326,13 +326,14 @@ void parse_w3c_tracestate(
   std::string other_w3c_tracestate;
   std::size_t begin = 0;
   while (begin < w3c_tracestate.size()) {
-    const auto end = w3c_tracestate.find(',', begin);
-    const auto member = trim(w3c_tracestate.substr(begin, end - begin));
-    const auto separator = member.find('=');
-    const auto key = member.substr(0, separator);
-    const auto member_value = separator == StringView::npos
-                                  ? StringView{}
-                                  : member.substr(separator + 1);
+    const std::size_t end = w3c_tracestate.find(',', begin);
+    const StringView member =
+        trim(w3c_tracestate.substr(begin, end - begin));
+    const std::size_t separator = member.find('=');
+    const StringView key = member.substr(0, separator);
+    const StringView member_value =
+        separator == StringView::npos ? StringView{}
+                                       : member.substr(separator + 1);
     if (key == "dd") {
       // If the "dd" vendor entry's value exceeds the maximum size, drop it
       // and record a propagation error tag.
@@ -388,9 +389,9 @@ Expected<ExtractedData> extract_w3c(
   }
 
   result.datadog_w3c_parent_id = "0000000000000000";
-  const auto maybe_tracestate = headers.lookup("tracestate");
+  const Optional<StringView> maybe_tracestate = headers.lookup("tracestate");
   if (maybe_tracestate && !maybe_tracestate->empty()) {
-    const auto tracestate = trim(*maybe_tracestate);
+    const StringView tracestate = trim(*maybe_tracestate);
     result.tracestate_full = tracestate;
     parse_w3c_tracestate(result, tracestate, span_tags);
   }
@@ -531,8 +532,8 @@ void append_tracestate_entries(std::string& result, StringView entries,
                                std::size_t& member_count) {
   std::size_t begin = 0;
   while (member_count < max_w3c_tracestate_members && begin < entries.size()) {
-    const auto end = entries.find(',', begin);
-    const auto entry = trim(entries.substr(begin, end - begin));
+    const std::size_t end = entries.find(',', begin);
+    const StringView entry = trim(entries.substr(begin, end - begin));
     if (!entry.empty()) {
       result += ',';
       append(result, entry);

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -42,6 +42,12 @@ constexpr bool is_lowercase_hexdig(const char c) {
   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
 }
 
+constexpr std::size_t otel_sampling_value_size = 14;
+constexpr std::size_t min_otel_threshold_size = 1;
+constexpr std::size_t max_w3c_tracestate_member_value_size = 256;
+constexpr std::size_t max_datadog_tracestate_value_size = 512;
+constexpr std::size_t max_w3c_tracestate_members = 32;
+
 bool is_valid_otel_hex(StringView value, std::size_t minimum_size,
                        std::size_t maximum_size) {
   return value.size() >= minimum_size && value.size() <= maximum_size &&
@@ -49,7 +55,8 @@ bool is_valid_otel_hex(StringView value, std::size_t minimum_size,
 }
 
 Optional<std::uint64_t> parse_otel_random_value(StringView value) {
-  if (!is_valid_otel_hex(value, 14, 14)) {
+  if (!is_valid_otel_hex(value, otel_sampling_value_size,
+                         otel_sampling_value_size)) {
     return nullopt;
   }
 
@@ -61,7 +68,8 @@ Optional<std::uint64_t> parse_otel_random_value(StringView value) {
 }
 
 Optional<std::uint64_t> parse_otel_threshold(StringView value) {
-  if (!is_valid_otel_hex(value, 1, 14)) {
+  if (!is_valid_otel_hex(value, min_otel_threshold_size,
+                         otel_sampling_value_size)) {
     return nullopt;
   }
 
@@ -97,7 +105,8 @@ bool append_otel_item(std::string& result, StringView item) {
   }
 
   const std::size_t separator_size = result.empty() ? 0 : 1;
-  if (result.size() + separator_size + item.size() > 256) {
+  if (result.size() + separator_size + item.size() >
+      max_w3c_tracestate_member_value_size) {
     return false;
   }
 
@@ -325,9 +334,9 @@ void parse_w3c_tracestate(
                                   ? StringView{}
                                   : member.substr(separator + 1);
     if (key == "dd") {
-      // If the "dd" vendor entry's value exceeds 512 bytes, drop it and
-      // record a propagation error tag.
-      if (member_value.size() > 512) {
+      // If the "dd" vendor entry's value exceeds the maximum size, drop it
+      // and record a propagation error tag.
+      if (member_value.size() > max_datadog_tracestate_value_size) {
         span_tags[tags::internal::propagation_error] = "extract_max_size";
       } else {
         parse_datadog_trace_state(result, member_value);
@@ -455,12 +464,11 @@ std::string encode_datadog_tracestate(
     result += *additional_datadog_w3c_tracestate;
   }
 
-  const std::size_t max_size = 256;
-  while (result.size() > max_size) {
+  while (result.size() > max_w3c_tracestate_member_value_size) {
     const auto last_semicolon_index = result.rfind(';');
     // This assumption is safe, because `result` always begins with
-    // "dd=s:<int>", and that's fewer than `max_size` characters for any
-    // `<int>`.
+    // "dd=s:<int>", and that's fewer than
+    // `max_w3c_tracestate_member_value_size` characters for any `<int>`.
     assert(last_semicolon_index != std::string::npos);
     result.resize(last_semicolon_index);
   }
@@ -522,7 +530,7 @@ Optional<std::string> rewrite_otel_tracestate(
 void append_tracestate_entries(std::string& result, StringView entries,
                                std::size_t& member_count) {
   std::size_t begin = 0;
-  while (member_count < 32 && begin < entries.size()) {
+  while (member_count < max_w3c_tracestate_members && begin < entries.size()) {
     const auto end = entries.find(',', begin);
     const auto entry = trim(entries.substr(begin, end - begin));
     if (!entry.empty()) {

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -33,7 +33,7 @@ auto verboten(int lowest_ascii, int highest_ascii,
   };
 }
 
-constexpr bool is_hexdiglc(const char c) {
+constexpr bool is_hexdig(const char c) {
   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
          (c >= 'A' && c <= 'F');
 }
@@ -155,7 +155,7 @@ Optional<std::string> extract_traceparent(ExtractedData& result,
 
           beg = i + 1;
           internal_state = state::trace_id;
-        } else if (!is_hexdiglc(traceparent[i])) {
+        } else if (!is_hexdig(traceparent[i])) {
           return "invalid_version";
         }
       } break;

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -48,42 +48,35 @@ constexpr std::size_t max_w3c_tracestate_member_value_size = 256;
 constexpr std::size_t max_datadog_tracestate_value_size = 512;
 constexpr std::size_t max_w3c_tracestate_members = 32;
 
-bool is_valid_otel_hex(StringView value, std::size_t minimum_size,
-                       std::size_t maximum_size) {
-  return value.size() >= minimum_size && value.size() <= maximum_size &&
-         std::all_of(value.begin(), value.end(), is_lowercase_hexdig);
+Optional<std::uint64_t> parse_otel_value(StringView value,
+                                         std::size_t minimum_size,
+                                         std::size_t maximum_size) {
+  if (value.size() < minimum_size || value.size() > maximum_size ||
+      !std::all_of(value.begin(), value.end(), is_lowercase_hexdig)) {
+    return nullopt;
+  }
+
+  const Expected<std::uint64_t> parsed = parse_uint64(value, 16);
+  if (parsed.if_error()) {
+    return nullopt;
+  }
+  return *parsed;
 }
 
 Optional<std::uint64_t> parse_otel_random_value(StringView value) {
-  if (!is_valid_otel_hex(value, otel_sampling_value_size,
-                         otel_sampling_value_size)) {
-    return nullopt;
-  }
-
-  const Expected<std::uint64_t> parsed = parse_uint64(value, 16);
-  if (parsed.if_error()) {
-    return nullopt;
-  }
-  return *parsed;
+  return parse_otel_value(value, otel_sampling_value_size,
+                          otel_sampling_value_size);
 }
 
 Optional<std::uint64_t> parse_otel_threshold(StringView value) {
-  if (!is_valid_otel_hex(value, min_otel_threshold_size,
-                         otel_sampling_value_size)) {
-    return nullopt;
-  }
-
-  const Expected<std::uint64_t> parsed = parse_uint64(value, 16);
-  if (parsed.if_error()) {
-    return nullopt;
-  }
-  return *parsed;
+  return parse_otel_value(value, min_otel_threshold_size,
+                          otel_sampling_value_size);
 }
 
 template <class Function>
 void for_each_otel_item(StringView raw, Function&& function) {
   std::size_t begin = 0;
-  while (begin <= raw.size()) {
+  while (begin < raw.size()) {
     const std::size_t end = raw.find(';', begin);
     const StringView item = raw.substr(begin, end - begin);
     const std::size_t separator = item.find(':');
@@ -93,6 +86,20 @@ void for_each_otel_item(StringView raw, Function&& function) {
                                  : item.substr(separator + 1);
     function(item, key, value);
     if (end == StringView::npos) {
+      return;
+    }
+    begin = end + 1;
+  }
+}
+
+template <class Function>
+void for_each_w3c_tracestate_member(StringView tracestate,
+                                    Function&& function) {
+  std::size_t begin = 0;
+  while (begin < tracestate.size()) {
+    const std::size_t end = tracestate.find(',', begin);
+    const StringView member = trim(tracestate.substr(begin, end - begin));
+    if (!function(member) || end == StringView::npos) {
       return;
     }
     begin = end + 1;
@@ -349,18 +356,11 @@ void parse_w3c_tracestate(
     ExtractedData& result, StringView w3c_tracestate,
     std::unordered_map<std::string, std::string>& span_tags) {
   std::string other_w3c_tracestate;
-  std::size_t begin = 0;
-  while (begin < w3c_tracestate.size()) {
-    const std::size_t end = w3c_tracestate.find(',', begin);
-    const StringView member = trim(w3c_tracestate.substr(begin, end - begin));
+  for_each_w3c_tracestate_member(w3c_tracestate, [&](StringView member) {
     parse_w3c_tracestate_member(result, member, span_tags,
                                 other_w3c_tracestate);
-
-    if (end == StringView::npos) {
-      break;
-    }
-    begin = end + 1;
-  }
+    return true;
+  });
 
   if (!other_w3c_tracestate.empty()) {
     result.additional_w3c_tracestate = std::move(other_w3c_tracestate);
@@ -535,20 +535,14 @@ Optional<std::string> rewrite_otel_tracestate(
 
 void append_tracestate_entries(std::string& result, StringView entries,
                                std::size_t& member_count) {
-  std::size_t begin = 0;
-  while (member_count < max_w3c_tracestate_members && begin < entries.size()) {
-    const std::size_t end = entries.find(',', begin);
-    const StringView entry = trim(entries.substr(begin, end - begin));
+  for_each_w3c_tracestate_member(entries, [&](StringView entry) {
     if (!entry.empty()) {
       result += ',';
       append(result, entry);
       ++member_count;
     }
-    if (end == StringView::npos) {
-      return;
-    }
-    begin = end + 1;
-  }
+    return member_count < max_w3c_tracestate_members;
+  });
 }
 
 std::string encode_tracestate(

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -42,8 +42,9 @@ constexpr bool is_lowercase_hexdig(const char c) {
   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
 }
 
-constexpr std::size_t otel_sampling_value_size = 14;
+constexpr std::size_t otel_random_value_size = 14;
 constexpr std::size_t min_otel_threshold_size = 1;
+constexpr std::size_t max_otel_threshold_size = otel_random_value_size;
 constexpr std::size_t max_w3c_tracestate_member_value_size = 256;
 constexpr std::size_t max_datadog_tracestate_value_size = 512;
 constexpr std::size_t max_w3c_tracestate_members = 32;
@@ -64,13 +65,13 @@ Optional<std::uint64_t> parse_otel_value(StringView value,
 }
 
 Optional<std::uint64_t> parse_otel_random_value(StringView value) {
-  return parse_otel_value(value, otel_sampling_value_size,
-                          otel_sampling_value_size);
+  return parse_otel_value(value, otel_random_value_size,
+                          otel_random_value_size);
 }
 
 Optional<std::uint64_t> parse_otel_threshold(StringView value) {
   return parse_otel_value(value, min_otel_threshold_size,
-                          otel_sampling_value_size);
+                          max_otel_threshold_size);
 }
 
 template <class Function>

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -106,22 +106,21 @@ void for_each_w3c_tracestate_member(StringView tracestate,
   }
 }
 
-bool append_otel_item(std::string& result, StringView item) {
+void append_otel_item(std::string& result, StringView item) {
   if (item.empty()) {
-    return true;
+    return;
   }
 
   const std::size_t separator_size = result.empty() ? 0 : 1;
   if (result.size() + separator_size + item.size() >
       max_w3c_tracestate_member_value_size) {
-    return false;
+    return;
   }
 
   if (separator_size) {
     result += ';';
   }
   append(result, item);
-  return true;
 }
 
 std::string format_otel_hex(std::uint64_t value) {

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -91,25 +91,6 @@ void for_each_otel_item(StringView raw, Function&& function) {
   }
 }
 
-template <class Function>
-void for_each_tracestate_member(StringView raw, Function&& function) {
-  std::size_t begin = 0;
-  while (begin < raw.size()) {
-    const auto end = raw.find(',', begin);
-    const auto member = trim(raw.substr(begin, end - begin));
-    const auto separator = member.find('=');
-    const auto key = member.substr(0, separator);
-    const auto value = separator == StringView::npos
-                           ? StringView{}
-                           : member.substr(separator + 1);
-    function(member, key, value);
-    if (end == StringView::npos) {
-      return;
-    }
-    begin = end + 1;
-  }
-}
-
 bool append_otel_item(std::string& result, StringView item) {
   if (item.empty()) {
     return true;
@@ -225,86 +206,25 @@ handle_trace_flag:
   return nullopt;
 }
 
-// `struct PartiallyParsedTracestat` contains the separated Datadog-specific and
-// non-Datadog-specific portions of tracestate.
-struct PartiallyParsedTracestate {
-  StringView datadog_value;
-  std::string other_entries;
-};
-
-// Return the separate Datadog-specific and non-Datadog-specific portions of the
-// specified `tracestate`. If `tracestate` does not have a Datadog-specific
-// portion, return `nullopt`.
-Optional<PartiallyParsedTracestate> parse_tracestate(StringView tracestate) {
-  const std::size_t begin = 0;
-  const std::size_t end = tracestate.size();
-  std::size_t pair_begin = begin;
-  while (pair_begin < end) {
-    const std::size_t pair_end = tracestate.find(',', pair_begin);
-    // Note that since this `pair` is `strip`ped, `pair_begin` is not
-    // necessarily equal to `pair.begin()` (similarly for the ends).
-    const auto pair =
-        trim(tracestate.substr(pair_begin, pair_end - pair_begin));
-    if (pair.empty()) {
-      pair_begin = (pair_end == StringView::npos) ? end : pair_end + 1;
-      continue;
-    }
-
-    const auto kv_separator = pair.find('=');
-    if (kv_separator == StringView::npos) {
-      // This is an invalid entry because it contains a non-whitespace character
-      // but not a "=".
-      // Let's move on to the next entry.
-      pair_begin = (pair_end == StringView::npos) ? end : pair_end + 1;
-      continue;
-    }
-
-    const auto key = pair.substr(0, kv_separator);
-    if (key != "dd") {
-      // On to the next.
-      pair_begin = (pair_end == StringView::npos) ? end : pair_end + 1;
-      continue;
-    }
-
-    PartiallyParsedTracestate result;
-    result.datadog_value = pair.substr(kv_separator + 1);
-    // `result->other_entries` is whatever was before the "dd" entry and
-    // whatever is after the "dd" entry, but without an extra comma in the
-    // middle.
-    if (pair_begin != 0) {
-      // There's a prefix
-      append(result.other_entries, tracestate.substr(0, pair_begin - 1));
-      if (pair_end != StringView::npos && pair_end + 1 < end) {
-        // and a suffix
-        append(result.other_entries, tracestate.substr(pair_end));
-      }
-    } else if (pair_end != StringView::npos && pair_end + 1 < end) {
-      // There's just a suffix
-      append(result.other_entries, tracestate.substr(pair_end + 1));
-    }
-
-    return result;
-  }
-
-  return nullopt;
-}
 // Fill the specified `result` with information parsed from the specified
-// `datadog_value`. `datadog_value` is the value of the "dd" entry in the
-// "tracestate" header.
+// `datadog_trace_state`. `datadog_trace_state` is the value of the "dd" entry
+// in the W3C "tracestate" header.
 //
-// `parse_datadog_tracestate` populates the following `ExtractedData` fields:
+// `parse_datadog_trace_state` populates the following `ExtractedData` fields:
 //
 // - `origin`
 // - `trace_tags`
 // - `sampling_priority`
 // - `datadog_w3c_parent_id`
 // - `additional_datadog_w3c_tracestate`
-void parse_datadog_tracestate(ExtractedData& result, StringView datadog_value) {
-  const std::size_t end = datadog_value.size();
+void parse_datadog_trace_state(ExtractedData& result,
+                               StringView datadog_trace_state) {
+  const std::size_t end = datadog_trace_state.size();
   std::size_t pair_begin = 0;
   while (pair_begin < end) {
-    const std::size_t pair_end = datadog_value.find(';', pair_begin);
-    const auto pair = datadog_value.substr(pair_begin, pair_end - pair_begin);
+    const std::size_t pair_end = datadog_trace_state.find(';', pair_begin);
+    const auto pair =
+        datadog_trace_state.substr(pair_begin, pair_end - pair_begin);
     pair_begin = (pair_end == StringView::npos) ? end : pair_end + 1;
     if (pair.empty()) {
       continue;
@@ -373,69 +293,62 @@ void parse_datadog_tracestate(ExtractedData& result, StringView datadog_value) {
   }
 }
 
-// Fill the specified `result` with information parsed from the "tracestate"
-// element of the specified `headers`, if present.
+// Fill the specified `result` with information parsed from the specified
+// `ot_tracestate`. `ot_tracestate` is the value of the "ot" entry in the W3C
+// "tracestate" header.
 //
-// `extract_tracestate` populates the `additional_w3c_tracestate` field of
-// `ExtractedData`, in addition to those populated by
-// `parse_datadog_tracestate`.
-void extract_tracestate(
-    ExtractedData& result, const DictReader& headers,
+// `parse_ot_tracestate` populates `otel_w3c_tracestate` if it has not already
+// been set.
+void parse_ot_tracestate(ExtractedData& result, StringView ot_tracestate) {
+  if (!result.otel_w3c_tracestate) {
+    result.otel_w3c_tracestate = std::string(ot_tracestate);
+  }
+}
+
+// Fill the specified `result` with information parsed from the specified W3C
+// `tracestate`.
+//
+// `parse_w3c_tracestate` populates `additional_w3c_tracestate`, in addition to
+// the fields populated by `parse_datadog_trace_state` and
+// `parse_ot_tracestate`.
+void parse_w3c_tracestate(
+    ExtractedData& result, StringView w3c_tracestate,
     std::unordered_map<std::string, std::string>& span_tags) {
-  const auto maybe_tracestate = headers.lookup("tracestate");
-  if (!maybe_tracestate || maybe_tracestate->empty()) {
-    return;
-  }
-
-  const auto tracestate = trim(*maybe_tracestate);
-  result.tracestate_full = tracestate;
-
-  auto maybe_parsed = parse_tracestate(tracestate);
-  if (!maybe_parsed) {
-    // No "dd" entry in `tracestate`, so there's nothing to extract.
-    if (!tracestate.empty()) {
-      result.additional_w3c_tracestate = std::string{tracestate};
-    }
-  } else {
-    auto& [datadog_value, other_entries] = *maybe_parsed;
-    if (!other_entries.empty()) {
-      result.additional_w3c_tracestate = std::move(other_entries);
-    }
-
-    // If the "dd" vendor entry's value exceeds 512 bytes, drop it and record a
-    // propagation error tag.
-    if (datadog_value.size() > 512) {
-      span_tags[tags::internal::propagation_error] = "extract_max_size";
+  std::string other_w3c_tracestate;
+  std::size_t begin = 0;
+  while (begin < w3c_tracestate.size()) {
+    const auto end = w3c_tracestate.find(',', begin);
+    const auto member = trim(w3c_tracestate.substr(begin, end - begin));
+    const auto separator = member.find('=');
+    const auto key = member.substr(0, separator);
+    const auto member_value = separator == StringView::npos
+                                  ? StringView{}
+                                  : member.substr(separator + 1);
+    if (key == "dd") {
+      // If the "dd" vendor entry's value exceeds 512 bytes, drop it and
+      // record a propagation error tag.
+      if (member_value.size() > 512) {
+        span_tags[tags::internal::propagation_error] = "extract_max_size";
+      } else {
+        parse_datadog_trace_state(result, member_value);
+      }
+    } else if (key == "ot") {
+      parse_ot_tracestate(result, member_value);
     } else {
-      parse_datadog_tracestate(result, datadog_value);
+      if (!other_w3c_tracestate.empty()) {
+        other_w3c_tracestate += ',';
+      }
+      append(other_w3c_tracestate, member);
     }
+
+    if (end == StringView::npos) {
+      break;
+    }
+    begin = end + 1;
   }
 
-  if (!result.additional_w3c_tracestate) {
-    return;
-  }
-
-  std::string remaining;
-  for_each_tracestate_member(
-      *result.additional_w3c_tracestate,
-      [&](StringView item, StringView key, StringView value) {
-        if (key == "ot") {
-          if (!result.otel_w3c_tracestate) {
-            result.otel_w3c_tracestate = std::string(value);
-          }
-          return;
-        }
-
-        if (!remaining.empty()) {
-          remaining += ',';
-        }
-        append(remaining, item);
-      });
-
-  if (remaining.empty()) {
-    result.additional_w3c_tracestate = nullopt;
-  } else {
-    result.additional_w3c_tracestate = std::move(remaining);
+  if (!other_w3c_tracestate.empty()) {
+    result.additional_w3c_tracestate = std::move(other_w3c_tracestate);
   }
 }
 
@@ -466,7 +379,12 @@ Expected<ExtractedData> extract_w3c(
   }
 
   result.datadog_w3c_parent_id = "0000000000000000";
-  extract_tracestate(result, headers, span_tags);
+  const auto maybe_tracestate = headers.lookup("tracestate");
+  if (maybe_tracestate && !maybe_tracestate->empty()) {
+    const auto tracestate = trim(*maybe_tracestate);
+    result.tracestate_full = tracestate;
+    parse_w3c_tracestate(result, tracestate, span_tags);
+  }
 
   return result;
 }

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
-#include <cstdint>
 #include <utility>
 
 #include "hex.h"

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -314,16 +314,19 @@ void parse_datadog_trace_state(ExtractedData& result,
 // "tracestate" header.
 //
 // `parse_ot_tracestate` preserves the first OpenTelemetry state in a header.
-void parse_ot_tracestate(ExtractedData& result, StringView ot_tracestate) {
+void parse_ot_tracestate(ExtractedData& result, StringView ot_tracestate,
+                         std::size_t position) {
   if (!result.otel_w3c_tracestate) {
-    result.otel_w3c_tracestate = std::string(ot_tracestate);
+    result.otel_w3c_tracestate =
+        OtelTraceState{std::string(ot_tracestate), position};
   }
 }
 
 void parse_w3c_tracestate_member(
     ExtractedData& result, StringView member,
     std::unordered_map<std::string, std::string>& span_tags,
-    std::string& other_w3c_tracestate) {
+    std::string& other_w3c_tracestate,
+    std::size_t& other_w3c_tracestate_member_count) {
   const std::size_t separator = member.find('=');
   const StringView key = member.substr(0, separator);
   const StringView member_value = separator == StringView::npos
@@ -339,13 +342,17 @@ void parse_w3c_tracestate_member(
     if (member_value.size() > max_w3c_tracestate_member_value_size) {
       span_tags[tags::internal::propagation_error] = "extract_max_size";
     } else {
-      parse_ot_tracestate(result, member_value);
+      parse_ot_tracestate(result, member_value,
+                          other_w3c_tracestate_member_count);
     }
   } else {
     if (!other_w3c_tracestate.empty()) {
       other_w3c_tracestate += ',';
     }
-    append(other_w3c_tracestate, member);
+    if (!member.empty()) {
+      append(other_w3c_tracestate, member);
+      ++other_w3c_tracestate_member_count;
+    }
   }
 }
 
@@ -359,9 +366,10 @@ void parse_w3c_tracestate(
     ExtractedData& result, StringView w3c_tracestate,
     std::unordered_map<std::string, std::string>& span_tags) {
   std::string other_w3c_tracestate;
+  std::size_t other_w3c_tracestate_member_count = 0;
   for_each_w3c_tracestate_member(w3c_tracestate, [&](StringView member) {
-    parse_w3c_tracestate_member(result, member, span_tags,
-                                other_w3c_tracestate);
+    parse_w3c_tracestate_member(result, member, span_tags, other_w3c_tracestate,
+                                other_w3c_tracestate_member_count);
     return true;
   });
 
@@ -536,16 +544,41 @@ Optional<std::string> rewrite_otel_tracestate(
   return result;
 }
 
-void append_tracestate_entries(std::string& result, StringView entries,
-                               std::size_t& member_count) {
+// Append other vendors and the `ot` member in their specified order.
+void append_tracestate_entries(
+    std::string& result, StringView entries, std::size_t& member_count,
+    const Optional<OtelTraceState>& otel_w3c_tracestate) {
+  std::size_t other_w3c_tracestate_position = 0;
+  const auto append_otel_tracestate = [&]() {
+    result += ",ot=";
+    result += otel_w3c_tracestate->value;
+    ++member_count;
+  };
+
   for_each_w3c_tracestate_member(entries, [&](StringView entry) {
-    if (!entry.empty()) {
-      result += ',';
-      append(result, entry);
-      ++member_count;
+    if (entry.empty()) {
+      return true;
     }
+    if (otel_w3c_tracestate &&
+        otel_w3c_tracestate->position == other_w3c_tracestate_position) {
+      append_otel_tracestate();
+      if (member_count >= max_w3c_tracestate_members) {
+        return false;
+      }
+    }
+
+    result += ',';
+    append(result, entry);
+    ++member_count;
+    ++other_w3c_tracestate_position;
     return member_count < max_w3c_tracestate_members;
   });
+
+  if (otel_w3c_tracestate &&
+      otel_w3c_tracestate->position == other_w3c_tracestate_position &&
+      member_count < max_w3c_tracestate_members) {
+    append_otel_tracestate();
+  }
 }
 
 std::string encode_tracestate(
@@ -553,21 +586,19 @@ std::string encode_tracestate(
     const Optional<std::string>& origin,
     const std::vector<std::pair<std::string, std::string>>& trace_tags,
     const Optional<std::string>& additional_datadog_w3c_tracestate,
-    const Optional<std::string>& otel_w3c_tracestate,
+    const Optional<OtelTraceState>& otel_w3c_tracestate,
     const Optional<std::string>& additional_w3c_tracestate) {
   std::string result =
       encode_datadog_tracestate(span_id, sampling_priority, origin, trace_tags,
                                 additional_datadog_w3c_tracestate);
 
   std::size_t member_count = 1;
-  if (otel_w3c_tracestate) {
-    result += ",ot=";
-    result += *otel_w3c_tracestate;
-    ++member_count;
-  }
-
-  if (additional_w3c_tracestate) {
-    append_tracestate_entries(result, *additional_w3c_tracestate, member_count);
+  if (additional_w3c_tracestate || otel_w3c_tracestate) {
+    const StringView entries = additional_w3c_tracestate
+                                   ? StringView(*additional_w3c_tracestate)
+                                   : StringView{};
+    append_tracestate_entries(result, entries, member_count,
+                              otel_w3c_tracestate);
   }
 
   return result;

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -313,8 +313,7 @@ void parse_datadog_trace_state(ExtractedData& result,
 // `ot_tracestate`. `ot_tracestate` is the value of the "ot" entry in the W3C
 // "tracestate" header.
 //
-// `parse_ot_tracestate` populates `otel_w3c_tracestate` if it has not already
-// been set.
+// `parse_ot_tracestate` preserves the first OpenTelemetry state in a header.
 void parse_ot_tracestate(ExtractedData& result, StringView ot_tracestate) {
   if (!result.otel_w3c_tracestate) {
     result.otel_w3c_tracestate = std::string(ot_tracestate);

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -337,7 +337,11 @@ void parse_w3c_tracestate_member(
       parse_datadog_trace_state(result, member_value);
     }
   } else if (key == "ot") {
-    parse_ot_tracestate(result, member_value);
+    if (member_value.size() > max_w3c_tracestate_member_value_size) {
+      span_tags[tags::internal::propagation_error] = "extract_max_size";
+    } else {
+      parse_ot_tracestate(result, member_value);
+    }
   } else {
     if (!other_w3c_tracestate.empty()) {
       other_w3c_tracestate += ',';

--- a/src/datadog/w3c_propagation.cpp
+++ b/src/datadog/w3c_propagation.cpp
@@ -88,9 +88,9 @@ void for_each_otel_item(StringView raw, Function&& function) {
     const StringView item = raw.substr(begin, end - begin);
     const std::size_t separator = item.find(':');
     const StringView key = item.substr(0, separator);
-    const StringView value =
-        separator == StringView::npos ? StringView{}
-                                       : item.substr(separator + 1);
+    const StringView value = separator == StringView::npos
+                                 ? StringView{}
+                                 : item.substr(separator + 1);
     function(item, key, value);
     if (end == StringView::npos) {
       return;
@@ -314,6 +314,31 @@ void parse_ot_tracestate(ExtractedData& result, StringView ot_tracestate) {
   }
 }
 
+void parse_w3c_tracestate_member(
+    ExtractedData& result, StringView member,
+    std::unordered_map<std::string, std::string>& span_tags,
+    std::string& other_w3c_tracestate) {
+  const std::size_t separator = member.find('=');
+  const StringView key = member.substr(0, separator);
+  const StringView member_value = separator == StringView::npos
+                                      ? StringView{}
+                                      : member.substr(separator + 1);
+  if (key == "dd") {
+    if (member_value.size() > max_datadog_tracestate_value_size) {
+      span_tags[tags::internal::propagation_error] = "extract_max_size";
+    } else {
+      parse_datadog_trace_state(result, member_value);
+    }
+  } else if (key == "ot") {
+    parse_ot_tracestate(result, member_value);
+  } else {
+    if (!other_w3c_tracestate.empty()) {
+      other_w3c_tracestate += ',';
+    }
+    append(other_w3c_tracestate, member);
+  }
+}
+
 // Fill the specified `result` with information parsed from the specified W3C
 // `tracestate`.
 //
@@ -327,29 +352,9 @@ void parse_w3c_tracestate(
   std::size_t begin = 0;
   while (begin < w3c_tracestate.size()) {
     const std::size_t end = w3c_tracestate.find(',', begin);
-    const StringView member =
-        trim(w3c_tracestate.substr(begin, end - begin));
-    const std::size_t separator = member.find('=');
-    const StringView key = member.substr(0, separator);
-    const StringView member_value =
-        separator == StringView::npos ? StringView{}
-                                       : member.substr(separator + 1);
-    if (key == "dd") {
-      // If the "dd" vendor entry's value exceeds the maximum size, drop it
-      // and record a propagation error tag.
-      if (member_value.size() > max_datadog_tracestate_value_size) {
-        span_tags[tags::internal::propagation_error] = "extract_max_size";
-      } else {
-        parse_datadog_trace_state(result, member_value);
-      }
-    } else if (key == "ot") {
-      parse_ot_tracestate(result, member_value);
-    } else {
-      if (!other_w3c_tracestate.empty()) {
-        other_w3c_tracestate += ',';
-      }
-      append(other_w3c_tracestate, member);
-    }
+    const StringView member = trim(w3c_tracestate.substr(begin, end - begin));
+    parse_w3c_tracestate_member(result, member, span_tags,
+                                other_w3c_tracestate);
 
     if (end == StringView::npos) {
       break;

--- a/src/datadog/w3c_propagation.h
+++ b/src/datadog/w3c_propagation.h
@@ -7,6 +7,7 @@
 #include <datadog/dict_reader.h>
 #include <datadog/expected.h>
 #include <datadog/optional.h>
+#include <datadog/string_view.h>
 #include <datadog/trace_id.h>
 
 #include <cstdint>
@@ -37,12 +38,21 @@ Expected<ExtractedData> extract_w3c(
 std::string encode_traceparent(TraceID trace_id, std::uint64_t span_id,
                                int sampling_priority);
 
+Optional<std::string> sanitize_otel_tracestate(StringView raw);
+
+Optional<std::uint64_t> extract_otel_random_value(StringView raw);
+
+Optional<std::string> rewrite_otel_tracestate(
+    StringView raw, Optional<std::uint64_t> random_value,
+    Optional<std::uint64_t> threshold);
+
 // Return a value for the "tracestate" header containing the specified fields.
 std::string encode_tracestate(
     uint64_t span_id, int sampling_priority,
     const Optional<std::string>& origin,
     const std::vector<std::pair<std::string, std::string>>& trace_tags,
     const Optional<std::string>& additional_datadog_w3c_tracestate,
+    const Optional<std::string>& otel_w3c_tracestate,
     const Optional<std::string>& additional_w3c_tracestate);
 
 }  // namespace tracing

--- a/src/datadog/w3c_propagation.h
+++ b/src/datadog/w3c_propagation.h
@@ -7,6 +7,7 @@
 #include <datadog/dict_reader.h>
 #include <datadog/expected.h>
 #include <datadog/optional.h>
+#include <datadog/otel_tracestate.h>
 #include <datadog/string_view.h>
 #include <datadog/trace_id.h>
 
@@ -52,7 +53,7 @@ std::string encode_tracestate(
     const Optional<std::string>& origin,
     const std::vector<std::pair<std::string, std::string>>& trace_tags,
     const Optional<std::string>& additional_datadog_w3c_tracestate,
-    const Optional<std::string>& otel_w3c_tracestate,
+    const Optional<OtelTraceState>& otel_w3c_tracestate,
     const Optional<std::string>& additional_w3c_tracestate);
 
 }  // namespace tracing

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -933,6 +933,15 @@ TEST_SPAN("injecting W3C tracestate header") {
        },
        // The "s:0" comes from the sampling decision in `traceparent_drop`.
        "dd=s:0;p:$parent_id,foo=bar,boing=boing"},
+
+      {__LINE__,
+       "unmodified OpenTelemetry member preserves vendor order",
+       {
+           {"traceparent", traceparent_drop},
+           {"tracestate", "foo=bar,ot=future:value,boing=boing"},
+       },
+       // The "s:0" comes from the sampling decision in `traceparent_drop`.
+       "dd=s:0;p:$parent_id,foo=bar,ot=future:value,boing=boing"},
   }));
 
   CAPTURE(test_case.name);

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -4,6 +4,7 @@
 
 #include <datadog/clock.h>
 #include <datadog/hex.h>
+#include <datadog/id_generator.h>
 #include <datadog/injection_options.h>
 #include <datadog/null_collector.h>
 #include <datadog/optional.h>
@@ -792,7 +793,8 @@ TEST_SPAN("injecting W3C tracestate header") {
            {"x-datadog-origin", "France"},
        },
        // The "s:-1" and "t.ksr:0" comes from the 0% sample rate.
-       "dd=s:-1;p:$parent_id;o:France;t.ksr:0"},
+       "dd=s:-1;p:$parent_id;o:France;t.ksr:0,ot=rv:f0948a54d43b8e;th:"
+       "ffffffffffffff"},
 
       {__LINE__,
        "trace tags",
@@ -802,7 +804,8 @@ TEST_SPAN("injecting W3C tracestate header") {
            {"x-datadog-tags", "_dd.p.foo=x,_dd.p.bar=y,ignored=wrong_prefix"},
        },
        // The "s:-1" and "t.ksr:0"  comes from the 0% sample rate.
-       "dd=s:-1;p:$parent_id;t.foo:x;t.bar:y;t.ksr:0"},
+       "dd=s:-1;p:$parent_id;t.foo:x;t.bar:y;t.ksr:0,ot=rv:f0948a54d43b8e;"
+       "th:ffffffffffffff"},
 
       {__LINE__,
        "extra fields",
@@ -832,7 +835,7 @@ TEST_SPAN("injecting W3C tracestate header") {
           },
           // The "s:-1" comes from the 0% sample rate.
           "dd=s:-1;p:$parent_id;o:France_ is a country~nation_ so is "
-          "______.;t.ksr:0",
+          "______.;t.ksr:0,ot=rv:f0948a54d43b8e;th:ffffffffffffff",
       },
 
       {__LINE__,
@@ -843,7 +846,8 @@ TEST_SPAN("injecting W3C tracestate header") {
            {"x-datadog-tags", "_dd.p.a;d台北x =foo,_dd.p.ok=bar"},
        },
        // The "s:-1" comes from the 0% sample rate.
-       "dd=s:-1;p:$parent_id;t.a_d______x_:foo;t.ok:bar;t.ksr:0"},
+       "dd=s:-1;p:$parent_id;t.a_d______x_:foo;t.ok:bar;t.ksr:0,ot=rv:"
+       "f0948a54d43b8e;th:ffffffffffffff"},
 
       {__LINE__,
        "replace invalid characters in trace tag value",
@@ -854,7 +858,7 @@ TEST_SPAN("injecting W3C tracestate header") {
        },
        // The "s:-1" comes from the 0% sample rate.
        "dd=s:-1;p:$parent_id;t.wacky:hello fr_d_ how are "
-       "_________?;t.ksr:0"},
+       "_________?;t.ksr:0,ot=rv:f0948a54d43b8e;th:ffffffffffffff"},
 
       {__LINE__,
        "replace equal signs with tildes in trace tag value",
@@ -864,7 +868,8 @@ TEST_SPAN("injecting W3C tracestate header") {
            {"x-datadog-tags", "_dd.p.base64_thingy=d2Fra2EhIHdhaw=="},
        },
        // The "s:-1" comes from the 0% sample rate.
-       "dd=s:-1;p:$parent_id;t.base64_thingy:d2Fra2EhIHdhaw~~;t.ksr:0"},
+       "dd=s:-1;p:$parent_id;t.base64_thingy:d2Fra2EhIHdhaw~~;t.ksr:0,ot="
+       "rv:f0948a54d43b8e;th:ffffffffffffff"},
 
       {__LINE__,
        "oversized origin truncates it and subsequent fields",
@@ -883,7 +888,7 @@ TEST_SPAN("injecting W3C tracestate header") {
            {"x-datadog-tags", "_dd.p.foo=bar,_dd.p.honk=honk"},
        },
        // The "s:-1" comes from the 0% sample rate.
-       "dd=s:-1;p:$parent_id"},
+       "dd=s:-1;p:$parent_id,ot=rv:f0948a54d43b8e;th:ffffffffffffff"},
 
       {__LINE__,
        "oversized trace tag truncates it and subsequent fields",
@@ -901,7 +906,8 @@ TEST_SPAN("injecting W3C tracestate header") {
             "ooooooooooooooooooong,_dd.p.lost=forever"},
        },
        // The "s:-1" comes from the 0% sample rate.
-       "dd=s:-1;p:$parent_id;t.foo:bar"},
+       "dd=s:-1;p:$parent_id;t.foo:bar,ot=rv:f0948a54d43b8e;"
+       "th:ffffffffffffff"},
 
       {__LINE__,
        "oversized extra field truncates itself and subsequent fields",
@@ -953,6 +959,127 @@ TEST_SPAN("injecting W3C tracestate header") {
   REQUIRE(found->second == test_case.expected_tracestate);
 
   REQUIRE(logger->error_count() == 0);
+}
+
+TEST_SPAN("OpenTelemetry consistent probability sampling") {
+  class Generator : public IDGenerator {
+    const TraceID trace_id_;
+
+   public:
+    explicit Generator(TraceID trace_id) : trace_id_(trace_id) {}
+    TraceID trace_id(const TimePoint&) const override { return trace_id_; }
+    std::uint64_t span_id() const override { return trace_id_.low; }
+  };
+
+  SECTION("local probability decisions emit a consistent rv and th") {
+    struct TestCase {
+      double rate;
+      std::uint64_t trace_id;
+      bool sampled;
+      std::string expected_ot;
+    };
+
+    const auto test_case = GENERATE(values<TestCase>({
+        {0.01, 1, false, "rv:f0948a54d43b8e;th:fd70a3d70a3d7"},
+        {0.1, 1, true, "rv:f0948a54d43b8e;th:e6666666666668"},
+        {0.2, 1, true, "rv:f0948a54d43b8e;th:ccccccccccccd"},
+        {0.5, 1, true, "rv:f0948a54d43b8e;th:8"},
+        {0.99, 1, true, "rv:f0948a54d43b8e;th:028f5c28f5c29"},
+        {0.1, UINT64_C(0x03A93EE8B1999F00), true,
+         "rv:e6666666666668;th:e6666666666668"},
+        {0.05, UINT64_C(5401449561355763072), false,
+         "rv:f333333333332f;th:f333333333333"},
+    }));
+
+    CAPTURE(test_case.rate);
+    CAPTURE(test_case.trace_id);
+    CAPTURE(test_case.expected_ot);
+
+    TracerConfig config;
+    config.service = "testsvc";
+    config.collector = std::make_shared<NullCollector>();
+    config.logger = std::make_shared<NullLogger>();
+    config.telemetry.enabled = false;
+    config.injection_styles = {PropagationStyle::W3C};
+    config.trace_sampler.sample_rate = test_case.rate;
+    config.trace_sampler.max_per_second = 100;
+
+    const auto finalized = finalize_config(config);
+    REQUIRE(finalized);
+    Tracer tracer{*finalized,
+                  std::make_shared<Generator>(TraceID(test_case.trace_id))};
+
+    auto span = tracer.create_span();
+    MockDictWriter writer;
+    span.inject(writer);
+
+    const auto tracestate = writer.items.find("tracestate");
+    REQUIRE(tracestate != writer.items.end());
+    REQUIRE(tracestate->second.find("dd=") == 0);
+    REQUIRE(tracestate->second.find("ot=" + test_case.expected_ot) !=
+            std::string::npos);
+    const auto& traceparent = writer.items.at("traceparent");
+    REQUIRE(traceparent.substr(traceparent.size() - 3) ==
+            (test_case.sampled ? "-01" : "-00"));
+  }
+
+  SECTION("non-probability decisions retain inherited rv but erase th") {
+    TracerConfig config;
+    config.service = "testsvc";
+    config.collector = std::make_shared<NullCollector>();
+    config.logger = std::make_shared<NullLogger>();
+    config.telemetry.enabled = false;
+    config.extraction_styles = {PropagationStyle::W3C};
+    config.injection_styles = {PropagationStyle::W3C};
+
+    const auto finalized = finalize_config(config);
+    REQUIRE(finalized);
+    Tracer tracer{*finalized};
+
+    const std::unordered_map<std::string, std::string> input_headers{
+        {"traceparent",
+         "00-00000000000000000000000000000001-0000000000000001-00"},
+        {"tracestate", "ot=rv:1234567890abcd;th:e6666666666668"},
+    };
+    MockDictReader reader{input_headers};
+    auto span = tracer.extract_span(reader);
+    REQUIRE(span);
+    span->trace_segment().override_sampling_priority(
+        int(SamplingPriority::USER_KEEP));
+
+    MockDictWriter writer;
+    span->inject(writer);
+    REQUIRE(writer.items.at("tracestate").find("ot=rv:1234567890abcd") !=
+            std::string::npos);
+    REQUIRE(writer.items.at("tracestate").find("th:") == std::string::npos);
+  }
+
+  SECTION("rate-limiter demotion clears locally generated sampling values") {
+    TracerConfig config;
+    config.service = "testsvc";
+    config.collector = std::make_shared<NullCollector>();
+    config.logger = std::make_shared<NullLogger>();
+    config.telemetry.enabled = false;
+    config.injection_styles = {PropagationStyle::W3C};
+    config.trace_sampler.sample_rate = 1.0;
+    config.trace_sampler.max_per_second = 0.1;
+
+    const auto finalized = finalize_config(config);
+    REQUIRE(finalized);
+    Tracer tracer{*finalized, std::make_shared<Generator>(TraceID(1))};
+
+    {
+      auto span = tracer.create_span();
+      MockDictWriter writer;
+      span.inject(writer);
+      REQUIRE(writer.items.at("tracestate").find("ot=") != std::string::npos);
+    }
+
+    auto span = tracer.create_span();
+    MockDictWriter writer;
+    span.inject(writer);
+    REQUIRE(writer.items.at("tracestate").find("ot=") == std::string::npos);
+  }
 }
 
 TEST_SPAN("128-bit trace ID injection") {

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -1003,12 +1003,12 @@ TEST_SPAN("OpenTelemetry consistent probability sampling") {
     config.trace_sampler.sample_rate = test_case.rate;
     config.trace_sampler.max_per_second = 100;
 
-    const auto finalized = finalize_config(config);
+    const Expected<FinalizedTracerConfig> finalized = finalize_config(config);
     REQUIRE(finalized);
     Tracer tracer{*finalized,
                   std::make_shared<Generator>(TraceID(test_case.trace_id))};
 
-    auto span = tracer.create_span();
+    Span span = tracer.create_span();
     MockDictWriter writer;
     span.inject(writer);
 
@@ -1017,7 +1017,7 @@ TEST_SPAN("OpenTelemetry consistent probability sampling") {
     REQUIRE(tracestate->second.find("dd=") == 0);
     REQUIRE(tracestate->second.find("ot=" + test_case.expected_ot) !=
             std::string::npos);
-    const auto& traceparent = writer.items.at("traceparent");
+    const std::string& traceparent = writer.items.at("traceparent");
     REQUIRE(traceparent.substr(traceparent.size() - 3) ==
             (test_case.sampled ? "-01" : "-00"));
   }
@@ -1031,7 +1031,7 @@ TEST_SPAN("OpenTelemetry consistent probability sampling") {
     config.extraction_styles = {PropagationStyle::W3C};
     config.injection_styles = {PropagationStyle::W3C};
 
-    const auto finalized = finalize_config(config);
+    const Expected<FinalizedTracerConfig> finalized = finalize_config(config);
     REQUIRE(finalized);
     Tracer tracer{*finalized};
 
@@ -1041,7 +1041,7 @@ TEST_SPAN("OpenTelemetry consistent probability sampling") {
         {"tracestate", "ot=rv:1234567890abcd;th:e6666666666668"},
     };
     MockDictReader reader{input_headers};
-    auto span = tracer.extract_span(reader);
+    Expected<Span> span = tracer.extract_span(reader);
     REQUIRE(span);
     span->trace_segment().override_sampling_priority(
         int(SamplingPriority::USER_KEEP));
@@ -1063,18 +1063,18 @@ TEST_SPAN("OpenTelemetry consistent probability sampling") {
     config.trace_sampler.sample_rate = 1.0;
     config.trace_sampler.max_per_second = 0.1;
 
-    const auto finalized = finalize_config(config);
+    const Expected<FinalizedTracerConfig> finalized = finalize_config(config);
     REQUIRE(finalized);
     Tracer tracer{*finalized, std::make_shared<Generator>(TraceID(1))};
 
     {
-      auto span = tracer.create_span();
+      Span span = tracer.create_span();
       MockDictWriter writer;
       span.inject(writer);
       REQUIRE(writer.items.at("tracestate").find("ot=") != std::string::npos);
     }
 
-    auto span = tracer.create_span();
+    Span span = tracer.create_span();
     MockDictWriter writer;
     span.inject(writer);
     REQUIRE(writer.items.at("tracestate").find("ot=") == std::string::npos);

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -4,7 +4,6 @@
 
 #include <datadog/clock.h>
 #include <datadog/hex.h>
-#include <datadog/id_generator.h>
 #include <datadog/injection_options.h>
 #include <datadog/null_collector.h>
 #include <datadog/optional.h>

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -2081,9 +2081,12 @@ TEST_TRACER("heterogeneous extraction") {
      {{"x-datadog-trace-id", "48"}, {"x-datadog-parent-id", "64"},
       {"x-datadog-origin", "Kansas"}, {"x-datadog-sampling-priority", "2"},
       {"traceparent", "00-00000000000000000000000000000030-0000000000000040-01"},
-      {"tracestate", "competitor=stuff,dd=o:Nebraska;s:1;ah:choo"}}, // origin is different
+      {"tracestate", "competitor=stuff,dd=o:Nebraska;s:1;ah:choo,"
+                     "ot=rv:1234567890abcd;th:e6666666666668;future:value"}}, // origin is different
      {{"traceparent", "00-00000000000000000000000000000030-000000000000002a-01"},
-      {"tracestate", "dd=s:2;p:000000000000002a;o:Kansas;ah:choo,competitor=stuff"}}},
+      {"tracestate", "dd=s:2;p:000000000000002a;o:Kansas;ah:choo,"
+                     "ot=rv:1234567890abcd;th:e6666666666668;future:value,"
+                     "competitor=stuff"}}},
 
     {__LINE__, "ignore interlopers",
      {PropagationStyle::DATADOG, PropagationStyle::B3, PropagationStyle::W3C},
@@ -2104,7 +2107,8 @@ TEST_TRACER("heterogeneous extraction") {
      {{"x-datadog-trace-id", "48"}, {"x-datadog-parent-id", "64"},
       {"x-datadog-origin", "Kansas"}, {"x-datadog-sampling-priority", "2"},
       {"traceparent", "00-00000000000000000000000000000031-0000000000000040-01"},
-      {"tracestate", "competitor=stuff,dd=o:Nebraska;s:1;ah:choo"}},
+      {"tracestate", "competitor=stuff,dd=o:Nebraska;s:1;ah:choo,"
+                     "ot=rv:1234567890abcd;th:e6666666666668;future:value"}},
      {{"traceparent", "00-00000000000000000000000000000030-000000000000002a-01"},
       {"tracestate", "dd=s:2;p:000000000000002a;o:Kansas"}}},
 

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -1729,7 +1729,7 @@ TEST_TRACER("restart extraction link uses metadata from the selected context") {
 
 TEST_TRACER("OpenTelemetry tracestate sampling values") {
   SECTION("malformed sampling values are removed") {
-    const auto normalized =
+    const Optional<std::string> normalized =
         sanitize_otel_tracestate("rv:1234567890abcd;th:ABC;future:value");
     REQUIRE(normalized);
     REQUIRE(*normalized == "rv:1234567890abcd;future:value");
@@ -1738,13 +1738,13 @@ TEST_TRACER("OpenTelemetry tracestate sampling values") {
   }
 
   SECTION("sampling values are replaced without altering other values") {
-    const auto rewritten = rewrite_otel_tracestate("rv:bad;future:value;th:bad",
-                                                   UINT64_C(0xf0948a54d43b8e),
-                                                   UINT64_C(0xe6666666666668));
+    const Optional<std::string> rewritten = rewrite_otel_tracestate(
+        "rv:bad;future:value;th:bad", UINT64_C(0xf0948a54d43b8e),
+        UINT64_C(0xe6666666666668));
     REQUIRE(rewritten);
     REQUIRE(*rewritten == "rv:f0948a54d43b8e;th:e6666666666668;future:value");
 
-    const auto no_threshold =
+    const Optional<std::string> no_threshold =
         rewrite_otel_tracestate("rv:1234567890abcd;th:e6666666666668",
                                 UINT64_C(0x1234567890abcd), nullopt);
     REQUIRE(no_threshold);
@@ -1763,7 +1763,8 @@ TEST_TRACER("OpenTelemetry tracestate sampling values") {
     std::unordered_map<std::string, std::string> span_tags;
     MockLogger logger;
 
-    const auto extracted = extract_w3c(reader, span_tags, logger);
+    const Expected<ExtractedData> extracted =
+        extract_w3c(reader, span_tags, logger);
     REQUIRE(extracted);
     REQUIRE(extracted->otel_w3c_tracestate ==
             "rv:1234567890abcd;th:e6666666666668;future:value");

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -1730,11 +1730,11 @@ TEST_TRACER("restart extraction link uses metadata from the selected context") {
 TEST_TRACER("OpenTelemetry tracestate sampling values") {
   SECTION("malformed sampling values are removed") {
     const auto normalized =
-        sanitize_otel_tracestate("rv:1234567890abcd;th:not-hex;future:value");
+        sanitize_otel_tracestate("rv:1234567890abcd;th:ABC;future:value");
     REQUIRE(normalized);
     REQUIRE(*normalized == "rv:1234567890abcd;future:value");
 
-    REQUIRE(!sanitize_otel_tracestate("rv:not-hex;th:also-not-hex"));
+    REQUIRE(!sanitize_otel_tracestate("rv:1234567890ABCD;th:A"));
   }
 
   SECTION("sampling values are replaced without altering other values") {

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -1727,6 +1727,50 @@ TEST_TRACER("restart extraction link uses metadata from the selected context") {
   REQUIRE(link.context.flags == Optional<std::uint32_t>(1u));
 }
 
+TEST_TRACER("OpenTelemetry tracestate sampling values") {
+  SECTION("malformed sampling values are removed") {
+    const auto normalized =
+        sanitize_otel_tracestate("rv:1234567890abcd;th:not-hex;future:value");
+    REQUIRE(normalized);
+    REQUIRE(*normalized == "rv:1234567890abcd;future:value");
+
+    REQUIRE(!sanitize_otel_tracestate("rv:not-hex;th:also-not-hex"));
+  }
+
+  SECTION("sampling values are replaced without altering other values") {
+    const auto rewritten = rewrite_otel_tracestate("rv:bad;future:value;th:bad",
+                                                   UINT64_C(0xf0948a54d43b8e),
+                                                   UINT64_C(0xe6666666666668));
+    REQUIRE(rewritten);
+    REQUIRE(*rewritten == "rv:f0948a54d43b8e;th:e6666666666668;future:value");
+
+    const auto no_threshold =
+        rewrite_otel_tracestate("rv:1234567890abcd;th:e6666666666668",
+                                UINT64_C(0x1234567890abcd), nullopt);
+    REQUIRE(no_threshold);
+    REQUIRE(*no_threshold == "rv:1234567890abcd");
+  }
+
+  SECTION("the OpenTelemetry member is separated from other vendors") {
+    const std::unordered_map<std::string, std::string> headers{
+        {"traceparent",
+         "00-00000000000000000000000000000001-0000000000000001-01"},
+        {"tracestate",
+         "dd=s:2,ot=rv:1234567890abcd;th:e6666666666668;future:value,"
+         "congo=t61rcWkgMzE"},
+    };
+    MockDictReader reader{headers};
+    std::unordered_map<std::string, std::string> span_tags;
+    MockLogger logger;
+
+    const auto extracted = extract_w3c(reader, span_tags, logger);
+    REQUIRE(extracted);
+    REQUIRE(extracted->otel_w3c_tracestate ==
+            "rv:1234567890abcd;th:e6666666666668;future:value");
+    REQUIRE(extracted->additional_w3c_tracestate == "congo=t61rcWkgMzE");
+  }
+}
+
 TEST_TRACER("baggage usage") {
   TracerConfig config;
   config.logger = std::make_shared<NullLogger>();

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -1797,6 +1797,22 @@ TEST_TRACER("OpenTelemetry tracestate sampling values") {
             "rv:1234567890abcd;th:e6666666666668;future:value");
     REQUIRE(extracted->additional_w3c_tracestate == "congo=t61rcWkgMzE");
   }
+
+  SECTION("the first OpenTelemetry member is retained") {
+    const std::unordered_map<std::string, std::string> headers{
+        {"traceparent",
+         "00-00000000000000000000000000000001-0000000000000001-01"},
+        {"tracestate", "ot=first,ot=second"},
+    };
+    MockDictReader reader{headers};
+    std::unordered_map<std::string, std::string> span_tags;
+    MockLogger logger;
+
+    const Expected<ExtractedData> extracted =
+        extract_w3c(reader, span_tags, logger);
+    REQUIRE(extracted);
+    REQUIRE(extracted->otel_w3c_tracestate == "first");
+  }
 }
 
 TEST_TRACER("baggage usage") {

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -1793,7 +1793,8 @@ TEST_TRACER("OpenTelemetry tracestate sampling values") {
     const Expected<ExtractedData> extracted =
         extract_w3c(reader, span_tags, logger);
     REQUIRE(extracted);
-    REQUIRE(extracted->otel_w3c_tracestate ==
+    REQUIRE(extracted->otel_w3c_tracestate);
+    REQUIRE(extracted->otel_w3c_tracestate->value ==
             "rv:1234567890abcd;th:e6666666666668;future:value");
     REQUIRE(extracted->additional_w3c_tracestate == "congo=t61rcWkgMzE");
   }
@@ -1811,7 +1812,8 @@ TEST_TRACER("OpenTelemetry tracestate sampling values") {
     const Expected<ExtractedData> extracted =
         extract_w3c(reader, span_tags, logger);
     REQUIRE(extracted);
-    REQUIRE(extracted->otel_w3c_tracestate == "first");
+    REQUIRE(extracted->otel_w3c_tracestate);
+    REQUIRE(extracted->otel_w3c_tracestate->value == "first");
   }
 }
 
@@ -2129,8 +2131,8 @@ TEST_TRACER("heterogeneous extraction") {
                      "ot=rv:1234567890abcd;th:e6666666666668;future:value"}}, // origin is different
      {{"traceparent", "00-00000000000000000000000000000030-000000000000002a-01"},
       {"tracestate", "dd=s:2;p:000000000000002a;o:Kansas;ah:choo,"
-                     "ot=rv:1234567890abcd;th:e6666666666668;future:value,"
-                     "competitor=stuff"}}},
+                     "competitor=stuff,ot=rv:1234567890abcd;th:e6666666666668;"
+                     "future:value"}}},
 
     {__LINE__, "ignore interlopers",
      {PropagationStyle::DATADOG, PropagationStyle::B3, PropagationStyle::W3C},

--- a/test/test_tracer.cpp
+++ b/test/test_tracer.cpp
@@ -1291,6 +1291,33 @@ TEST_TRACER("span extraction") {
             "extract_max_size");
   }
 
+  SECTION(
+      "'extract_max_size' propagation error if tracestate \"ot\" vendor "
+      "value is oversized on extract") {
+    constexpr std::size_t max_w3c_tracestate_member_value_size = 256;
+    const std::string ot_value(max_w3c_tracestate_member_value_size + 1, 'a');
+    std::unordered_map<std::string, std::string> span_tags;
+    MockLogger logger;
+    CAPTURE(logger.entries);
+    CAPTURE(span_tags);
+
+    std::unordered_map<std::string, std::string> headers{
+        {"traceparent",
+         "00-00000000000000000000000000000001-0000000000000001-00"},
+        {"tracestate", "dd=s:1,ot=" + ot_value + ",vendorx=keepme"}};
+    MockDictReader reader{headers};
+
+    const auto extracted = extract_w3c(reader, span_tags, logger);
+    REQUIRE(extracted);
+    REQUIRE(extracted->otel_w3c_tracestate == nullopt);
+    REQUIRE(extracted->additional_w3c_tracestate == "vendorx=keepme");
+
+    REQUIRE(logger.entries.empty());
+    REQUIRE(span_tags.count(tags::internal::propagation_error) == 1);
+    REQUIRE(span_tags.at(tags::internal::propagation_error) ==
+            "extract_max_size");
+  }
+
   SECTION("W3C Phase 3 support - Preferring tracecontext") {
     // Tests behavior from system-test
     // test_headers_tracecontext.py::test_tracestate_w3c_p_extract_datadog_w3c


### PR DESCRIPTION
## Summary

Adds W3C `tracestate` support for OpenTelemetry `ot` sampling state.

- Parses `ot` separately from Datadog and other vendor state.
- Retains valid inherited state, drops malformed `rv` and `th` values, and writes sampling values for eligible local probability decisions.
- Carries W3C state only when it belongs to the selected matching trace.

## Testing

- `cmake --build .build -j`
- `./.build/test/tests`