### PR TITLE
Replace long-lived DD_CI_VIS_API_KEY by short-lived credentials via dd-sts-action

### DIFF
--- a/.github/actions/dd-sts-credentials/action.yml
+++ b/.github/actions/dd-sts-credentials/action.yml
@@ -1,0 +1,15 @@
+name: "Get Datadog credentials"
+description: "Exchange the workflow's OIDC token for a short-lived Datadog API key via dd-sts"
+
+outputs:
+  api_key:
+    description: "Datadog API key"
+    value: ${{ steps.dd-sts-action.outputs.api_key }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: dd-sts-action
+      uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2 # v1.0.5
+      with:
+        policy: public-datadog-dd-trace-cpp

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -53,9 +53,9 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write
     env:
       BUILD_DIR: .build
-      HAS_DD_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY != '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Configure
@@ -66,10 +66,15 @@ jobs:
         run: cd ${BUILD_DIR} && test/tests -r junit -o report.xml
         env:
           ASAN_OPTIONS: alloc_dealloc_mismatch=0
+      - name: Get Datadog credentials
+        uses: ./.github/actions/dd-sts-credentials
+        id: dd-sts-credentials
+        if: success() || failure()
+        continue-on-error: true
       - name: Upload test report to Datadog
-        if: (success() || failure()) && env.HAS_DD_API_KEY == 'true'
+        if: (success() || failure()) && steps.dd-sts-credentials.outcome == 'success'
         env:
-          DD_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY }}
+          DD_API_KEY: ${{ steps.dd-sts-credentials.outputs.api_key }}
         run: |
           curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-${{ matrix.arch }}" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
           datadog-ci junit upload --service dd-trace-cpp --tags test.source.file:test/*.cpp .build/report.xml
@@ -138,8 +143,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    env:
-      HAS_DD_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY != '' }}
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Dependency Manager (scoop)
@@ -158,10 +162,15 @@ jobs:
         run: |
           & 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\Tools\\Launch-VsDevShell.ps1' -arch ${{ matrix.arch }}
           .\build\test\tests.exe -r junit -o report.xml
+      - name: Get Datadog credentials
+        uses: ./.github/actions/dd-sts-credentials
+        id: dd-sts-credentials
+        if: success() || failure()
+        continue-on-error: true
       - name: Upload test report to Datadog
-        if: (success() || failure()) && env.HAS_DD_API_KEY == 'true'
+        if: (success() || failure()) && steps.dd-sts-credentials.outcome == 'success'
         env:
-          DD_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY }}
+          DD_API_KEY: ${{ steps.dd-sts-credentials.outputs.api_key }}
         run: |
           Invoke-WebRequest -Uri "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_win-x64" -OutFile "datadog-ci.exe"
           ./datadog-ci.exe junit upload --service dd-trace-cpp --tags test.source.file:test/*.cpp report.xml
@@ -176,17 +185,21 @@ jobs:
     permissions:
       contents: read
       packages: read
-    env:
-      HAS_DD_API_KEY: ${{ secrets.DD_CI_VIS_API_KEY != '' }}
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: bin/test --coverage --verbose
+      - name: Get Datadog credentials
+        uses: ./.github/actions/dd-sts-credentials
+        id: dd-sts-credentials
+        if: success()
+        continue-on-error: true
       - name: Upload code coverage report to Datadog
-        if: success() && env.HAS_DD_API_KEY == 'true'
+        if: success() && steps.dd-sts-credentials.outcome == 'success'
         # See https://github.com/DataDog/coverage-upload-github-action/releases
         uses: DataDog/coverage-upload-github-action@d9548b1c3c4ab639d5d3ab29a1508af188975f77 # v1.0.5
         with:
-          api_key: ${{ secrets.DD_CI_VIS_API_KEY }}
+          api_key: ${{ steps.dd-sts-credentials.outputs.api_key }}
           files: .coverage/filtered.info
           format: lcov
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,7 @@ See [docs/development.md](docs/development.md) for build, test, and formatting i
 ## Architecture
 
 See [docs/design.md](docs/design.md) for the library's architecture and design rationale.
+
+## Agent-Only Instructions
+
+Write short comments, with simple words and short sentences.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-Follow [AGENTS.md](AGENTS.md).
+AGENTS.md


### PR DESCRIPTION
# Description

Migrate the long-lived `DD_CI_VIS_API_KEY` secret to short-lived credentials from `dd-sts`.

This is done with a new local composite action, `.github/actions/dd-sts-credentials`, which uses `DataDog/dd-sts-action`.

# Additional Notes

By the way, small amendment in agents intsructions.

Jira ticket: [IDMPL-808 [C++ Tracer] [CI] Remove DD_CI_VIS_API_KEY secret](https://datadoghq.atlassian.net/browse/IDMPL-808)