### PR TITLE
Fix C99 extensions compilation error with Clang

### DIFF
--- a/src/datadog/otel_process_ctx.cpp
+++ b/src/datadog/otel_process_ctx.cpp
@@ -14,15 +14,17 @@
   #define _GNU_SOURCE
 #endif
 
-#if defined(__GNUC__) && defined(__cplusplus) && __cplusplus < 202002L
+#if defined(__GNUC__) && defined(__cplusplus)
   // This file uses C99 compound literals with designated initializers
-  // throughout. They are standard in C (since C99) and in C++ (since C++20),
-  // but trigger -Wpedantic (older GCC) or -Wc++20-extensions (newer GCC) when
-  // compiled as C++17 or older. Silencing -Wpragmas first lets GCC versions
-  // that don't know -Wc++20-extensions accept the pragma silently.
+  // throughout. Designated initializers are standard in C++20; compound
+  // literals themselves never are. This triggers -Wpedantic (older GCC) or
+  // -Wc++20-extensions (newer GCC) under C++17 or older, and -Wc99-extensions
+  // (Clang) regardless of dialect. Silencing -Wpragmas first lets GCC
+  // versions that don't know -Wc++20-extensions accept the pragma silently.
   #pragma GCC diagnostic ignored "-Wpragmas"
   #pragma GCC diagnostic ignored "-Wpedantic"
   #pragma GCC diagnostic ignored "-Wc++20-extensions"
+  #pragma GCC diagnostic ignored "-Wc99-extensions"
 #endif
 
 // Note: Things here are needed for NOOP. Things that are only for non-NOOP get added further below.


### PR DESCRIPTION
# Description

Extend the existing diagnostic-suppression block in `otel_process_ctx.cpp` to also ignore `-Wc99-extensions`, and drop the `__cplusplus < 202002L` restriction so it applies regardless of dialect.

# Motivation

When trying to integrate dd-trace-cpp v2.2.0 in nginx-datadog, we hit the [following compilation error](https://mosaic.us1.ddbuild.io/change-request/14070253949740083178?owner=datadog&repository=nginx-datadog&taskId=gitlab&taskExecutionId=1968635320):

```
otel_process_ctx.cpp:153:21: error: compound literals are a C99-specific feature [-Werror,-Wc99-extensions]
  153 |   if (!data) return (otel_process_ctx_result) {.success = false, .error_message = "otel_process_ctx_data is NULL (" __FILE__ ":" ADD_QUOTES(__LINE__) ")"};
```

# Additional Notes

Jira ticket: [IDMPL-814 [C++ Tracer] C99 compound literals compilation error](https://datadoghq.atlassian.net/browse/IDMPL-814)