### PR TITLE
CI: fix Datadog credentials OIDC exchange broken by `environment: dev`

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -65,11 +65,9 @@ jobs:
         env:
           ASAN_OPTIONS: alloc_dealloc_mismatch=0
       - name: Get Datadog credentials
+        if: (success() || failure()) && github.event_name != 'pull_request'
         uses: ./.github/actions/dd-sts-credentials
         id: dd-sts-credentials
-        if: success() || failure()
-        # This fails on PRs.
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
       - name: Upload test report to Datadog
         if: (success() || failure()) && steps.dd-sts-credentials.outcome == 'success'
         env:
@@ -160,11 +158,9 @@ jobs:
           & 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\Tools\\Launch-VsDevShell.ps1' -arch ${{ matrix.arch }}
           .\build\test\tests.exe -r junit -o report.xml
       - name: Get Datadog credentials
+        if: (success() || failure()) && github.event_name != 'pull_request'
         uses: ./.github/actions/dd-sts-credentials
         id: dd-sts-credentials
-        if: success() || failure()
-        # This fails on PRs.
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
       - name: Upload test report to Datadog
         if: (success() || failure()) && steps.dd-sts-credentials.outcome == 'success'
         env:
@@ -186,14 +182,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: bin/test --coverage --verbose
       - name: Get Datadog credentials
+        if: success() && github.event_name != 'pull_request'
         uses: ./.github/actions/dd-sts-credentials
         id: dd-sts-credentials
-        if: success()
-        # This fails on PRs.
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
       - name: Upload code coverage report to Datadog
         if: success() && steps.dd-sts-credentials.outcome == 'success'
-        # See https://github.com/DataDog/coverage-upload-github-action/releases
         uses: DataDog/coverage-upload-github-action@d9548b1c3c4ab639d5d3ab29a1508af188975f77 # v1.0.5
         with:
           api_key: ${{ steps.dd-sts-credentials.outputs.api_key }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -48,8 +48,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: datadog/docker-library:dd-trace-cpp-ci-23768e9-${{matrix.docker-arch}}
-    environment:
-      name: dev
     permissions:
       contents: read
       packages: read
@@ -138,8 +136,6 @@ jobs:
     defaults:
       run:
         shell: powershell
-    environment:
-      name: dev
     permissions:
       contents: read
       packages: read
@@ -180,8 +176,6 @@ jobs:
     runs-on: ubuntu-22.04-arm
     container:
       image: datadog/docker-library:dd-trace-cpp-ci-23768e9-arm64
-    environment:
-      name: dev
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -68,7 +68,8 @@ jobs:
         uses: ./.github/actions/dd-sts-credentials
         id: dd-sts-credentials
         if: success() || failure()
-        continue-on-error: true
+        # This fails on PRs.
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
       - name: Upload test report to Datadog
         if: (success() || failure()) && steps.dd-sts-credentials.outcome == 'success'
         env:
@@ -162,7 +163,8 @@ jobs:
         uses: ./.github/actions/dd-sts-credentials
         id: dd-sts-credentials
         if: success() || failure()
-        continue-on-error: true
+        # This fails on PRs.
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
       - name: Upload test report to Datadog
         if: (success() || failure()) && steps.dd-sts-credentials.outcome == 'success'
         env:
@@ -187,7 +189,8 @@ jobs:
         uses: ./.github/actions/dd-sts-credentials
         id: dd-sts-credentials
         if: success()
-        continue-on-error: true
+        # This fails on PRs.
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
       - name: Upload code coverage report to Datadog
         if: success() && steps.dd-sts-credentials.outcome == 'success'
         # See https://github.com/DataDog/coverage-upload-github-action/releases

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -65,11 +65,11 @@ jobs:
         env:
           ASAN_OPTIONS: alloc_dealloc_mismatch=0
       - name: Get Datadog credentials
-        if: (success() || failure()) && github.event_name != 'pull_request'
+        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
         uses: ./.github/actions/dd-sts-credentials
         id: dd-sts-credentials
       - name: Upload test report to Datadog
-        if: (success() || failure()) && steps.dd-sts-credentials.outcome == 'success'
+        if: ${{ !cancelled() && steps.dd-sts-credentials.outcome == 'success' }}
         env:
           DD_API_KEY: ${{ steps.dd-sts-credentials.outputs.api_key }}
         run: |
@@ -158,11 +158,11 @@ jobs:
           & 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\Tools\\Launch-VsDevShell.ps1' -arch ${{ matrix.arch }}
           .\build\test\tests.exe -r junit -o report.xml
       - name: Get Datadog credentials
-        if: (success() || failure()) && github.event_name != 'pull_request'
+        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
         uses: ./.github/actions/dd-sts-credentials
         id: dd-sts-credentials
       - name: Upload test report to Datadog
-        if: (success() || failure()) && steps.dd-sts-credentials.outcome == 'success'
+        if: ${{ !cancelled() && steps.dd-sts-credentials.outcome == 'success' }}
         env:
           DD_API_KEY: ${{ steps.dd-sts-credentials.outputs.api_key }}
         run: |


### PR DESCRIPTION
# Description

For the CI, remove `environment: name: dev` in CMake builds, because it made the OIDC exchanges (to get credentials) fail, and it was actually useless.

# Motivation

`dd-sts-action` OIDC exchange has been failing with `HTTP 401` since #357. [Example](https://github.com/DataDog/dd-trace-cpp/actions/runs/32686092924/job/97311474011#step:7:23):

```
Get Datadog credentials
Run DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
Successfully retrieved GitHub OIDC token.
Exchanging OIDC token for Datadog credentials at 'https://webhooks.build.datadoghq.com/sts/datadog/exchange?policy=public-datadog-dd-trace-cpp'...
Error: Failed to exchange OIDC token for Datadog credentials: HTTP error! status: 401, 
```

# Additional Notes

These failures were silent because we know that such 'get credentials' steps fail on PRs. Thus, we narrow the `continue-on-error` for these steps to PRs.

[Validation](https://github.com/DataDog/dd-trace-cpp/actions/runs/32734665649/job/97457671864):
```
Run DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
  Requesting GitHub OIDC token with audience 'dd-sts'...
  Response from https://run-actions-2-azure-eastus.actions.githubusercontent.com/190//idtoken/4c38ac50-79eb-4088-be77-7bf328820afc/bc9f2347-f972-5c9d-b8a3-f71d61fb657a?api-version=2.0&audience=dd-sts: HTTP 200 (301ms)
  Successfully retrieved GitHub OIDC token.
  Exchanging OIDC token for Datadog credentials at 'https://webhooks.build.datadoghq.com/sts/datadog/exchange?policy=public-datadog-dd-trace-cpp'...
  Response from https://webhooks.build.datadoghq.com/sts/datadog/exchange?policy=public-datadog-dd-trace-cpp: HTTP 200 (329ms)
  Received credentials
  dd-sts-action completed successfully.
```

Jira ticket: [IDMPL-821 https://datadoghq.atlassian.net/browse/IDMPL-821](https://datadoghq.atlassian.net/browse/IDMPL-821)