### PR TITLE
fix(telemetry): nest product errors in app-started payload

### DIFF
--- a/src/datadog/telemetry/telemetry_impl.cpp
+++ b/src/datadog/telemetry/telemetry_impl.cpp
@@ -617,27 +617,24 @@ std::string Telemetry::app_started_payload() {
     /// is no need to declare it.
     if (product.name == Product::Name::tracing) continue;
 
-    auto p = nlohmann::json{
-        {to_string(product.name),
-         nlohmann::json{
-             {"version", product.version},
-             {"enabled", product.enabled},
-         }},
+    auto product_details = nlohmann::json{
+        {"version", product.version},
+        {"enabled", product.enabled},
     };
 
     if (product.error_code || product.error_message) {
-      auto p_error = nlohmann::json{};
+      auto product_error = nlohmann::json{};
       if (product.error_code) {
-        p_error.emplace("code", *product.error_code);
+        product_error.emplace("code", *product.error_code);
       }
       if (product.error_message) {
-        p_error.emplace("message", *product.error_message);
+        product_error.emplace("message", *product.error_message);
       }
 
-      p.emplace("error", std::move(p_error));
+      product_details.emplace("error", std::move(product_error));
     }
 
-    product_json.emplace(std::move(p));
+    product_json.emplace(to_string(product.name), std::move(product_details));
   }
 
   auto app_started_msg = nlohmann::json{

--- a/test/telemetry/test_telemetry.cpp
+++ b/test/telemetry/test_telemetry.cpp
@@ -330,7 +330,7 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry lifecycle") {
       }
     }
 
-    SECTION("With AppSec product state") {
+    SECTION("Product error is nested under the product name") {
       client->clear();
 
       Configuration cfg;
@@ -346,8 +346,11 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry lifecycle") {
                             client, scheduler, *url);
 
       const auto message_batch = nlohmann::json::parse(client->request_body);
-      const auto& appsec =
-          message_batch["payload"][0]["payload"]["products"]["appsec"];
+      const auto& appsec = message_batch.at("payload")
+                               .at(0)
+                               .at("payload")
+                               .at("products")
+                               .at("appsec");
 
       CHECK(appsec ==
             nlohmann::json{

--- a/test/telemetry/test_telemetry.cpp
+++ b/test/telemetry/test_telemetry.cpp
@@ -329,6 +329,33 @@ TELEMETRY_IMPLEMENTATION_TEST("Tracer telemetry lifecycle") {
         }
       }
     }
+
+    SECTION("With AppSec product state") {
+      client->clear();
+
+      Configuration cfg;
+      cfg.products.emplace_back(Product{Product::Name::appsec,
+                                        false,
+                                        "1.2.3",
+                                        12,
+                                        "Error initializing WAF",
+                                        {}});
+
+      auto telemetry =
+          Telemetry::create(*finalize_config(cfg), tracer_signature, logger,
+                            client, scheduler, *url);
+
+      const auto message_batch = nlohmann::json::parse(client->request_body);
+      const auto& appsec =
+          message_batch["payload"][0]["payload"]["products"]["appsec"];
+
+      CHECK(appsec ==
+            nlohmann::json{
+                {"version", "1.2.3"},
+                {"enabled", false},
+                {"error",
+                 {{"code", 12}, {"message", "Error initializing WAF"}}}});
+    }
   }
 
   SECTION("dtor send app-closing message") {


### PR DESCRIPTION
## What does this PR do?

Serializes telemetry product details directly under `products.<product>` and keeps optional startup errors inside that product object.

The existing object-level `emplace` throws when an integration registers a product, preventing `app-started` telemetry from being sent. This unblocks integrations such as `nginx-datadog` from reporting their authoritative AppSec startup state.

## Validation

- `cmake --build build -j4`
- `./build/test/tests` (199852 assertions in 134 test cases)
- exercised from a local NGINX worker with AppSec enabled and disabled