### PR TITLE
fix(tracing): avoid unresolved round symbol

### DIFF
--- a/src/datadog/trace_segment.cpp
+++ b/src/datadog/trace_segment.cpp
@@ -14,7 +14,6 @@
 #include <array>
 #include <cassert>
 #include <charconv>
-#include <cmath>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -173,9 +172,10 @@ Optional<std::string> resolve_otel_tracestate_value(
   }
 
   constexpr std::uint64_t max_value = UINT64_C(1) << 56;
-  std::uint64_t threshold = static_cast<std::uint64_t>(
-      std::round((1.0 - decision.configured_rate->value()) *
-                 static_cast<double>(max_value)));
+  const double threshold_value = (1.0 - decision.configured_rate->value()) *
+                                 static_cast<double>(max_value);
+  // The value is non-negative. Adding 0.5 before truncation rounds it.
+  std::uint64_t threshold = static_cast<std::uint64_t>(threshold_value + 0.5);
   threshold = std::min(threshold, max_value - 1);
 
   std::uint64_t random_value = (~knuth_hash(trace_id.low)) >> 8;

--- a/test/test_span.cpp
+++ b/test/test_span.cpp
@@ -988,11 +988,13 @@ TEST_SPAN("OpenTelemetry consistent probability sampling") {
     };
 
     const auto test_case = GENERATE(values<TestCase>({
+        {0.0, 1, false, "rv:f0948a54d43b8e;th:ffffffffffffff"},
         {0.01, 1, false, "rv:f0948a54d43b8e;th:fd70a3d70a3d7"},
         {0.1, 1, true, "rv:f0948a54d43b8e;th:e6666666666668"},
         {0.2, 1, true, "rv:f0948a54d43b8e;th:ccccccccccccd"},
         {0.5, 1, true, "rv:f0948a54d43b8e;th:8"},
         {0.99, 1, true, "rv:f0948a54d43b8e;th:028f5c28f5c29"},
+        {1.0, 1, true, "rv:f0948a54d43b8e;th:0"},
         {0.1, UINT64_C(0x03A93EE8B1999F00), true,
          "rv:e6666666666668;th:e6666666666668"},
         {0.05, UINT64_C(5401449561355763072), false,


### PR DESCRIPTION
## Summary

- replace `std::round` in OpenTelemetry sampling threshold calculation with equivalent non-negative arithmetic
- preserve threshold behavior at the `0` and `1` sampling-rate boundaries
- prevent libc-free downstream modules from retaining an unresolved `round` symbol

## Root cause

`nginx-datadog` removes its musl libc dependency after linking. The `std::round` call introduced by #354 remained undefined in the module, causing nginx to fail at startup with `undefined symbol: round`.

## Validation

- focused OpenTelemetry sampling test: 52 assertions passed
- full unit suite: 199,862 assertions in 134 test cases passed
- clang-format 14 dry-run passed
- `trace_segment.cpp.o` has no undefined `round` symbol